### PR TITLE
More consistent env_* Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,23 +58,15 @@ clean: clean_harmless
 
 env_test: install clean_harmless
 	$(BUILDOUT) -c conf/buildout-tests.cfg $(BUILDOUT_ARGS)
-	make all_compilemessages
 
 env_dev: install clean_harmless
 	$(BUILDOUT) -c conf/buildout-dev.cfg $(BUILDOUT_ARGS)
-	make all_compilemessages
-	bin/django syncdb --noinput --migrate
-	bin/django sync_translation_fields --noinput
-	bin/django update_translation_fields
-	bin/django update_permissions
 
 env_prod: install clean_harmless
 	$(BUILDOUT) -c conf/buildout-prod.cfg $(BUILDOUT_ARGS)
-	make all_compilemessages
 
 env_standalone: install clean_harmless
 	$(BUILDOUT) -c conf/buildout-prod-standalone.cfg $(BUILDOUT_ARGS)
-	make all_compilemessages
 
 
 
@@ -106,14 +98,15 @@ update:
 	bin/django sync_translation_fields --noinput
 	bin/django update_translation_fields
 	bin/django update_permissions
+	make all_compilemessages
 
 deploy: update
 	bin/supervisorctl restart all
 
-all_makemessages: install
+all_makemessages:
 	for dir in `find geotrek/ -type d -name locale`; do pushd `dirname $$dir` > /dev/null; $(ROOT_DIR)/bin/django-admin makemessages --no-location --all; popd > /dev/null; done
 
-all_compilemessages: install
+all_compilemessages:
 	for dir in `find geotrek/ -type d -name locale`; do pushd `dirname $$dir` > /dev/null; $(ROOT_DIR)/bin/django-admin compilemessages; popd > /dev/null; done
 	for dir in `find lib/src/ -type d -name locale`; do pushd `dirname $$dir` > /dev/null; $(ROOT_DIR)/bin/django-admin compilemessages; popd > /dev/null; done
 

--- a/conf/buildout-prod.cfg
+++ b/conf/buildout-prod.cfg
@@ -28,8 +28,7 @@ eggs +=
     python-memcached
 
 [mkdirs]
-paths += ${django:staticroot}
-         ${django:deployroot}/var/nginxcache/
+paths += ${django:deployroot}/var/nginxcache/
          ${django:deployroot}/var/log/
          ${django:deployroot}/var/tmp/
          ${django:deployroot}/etc/init

--- a/conf/buildout.cfg
+++ b/conf/buildout.cfg
@@ -51,7 +51,8 @@ uploadroot = ${django:mediaroot}/${django:uploaddir}
 
 [mkdirs]
 recipe = z3c.recipe.mkdir
-paths = ${django:mediaroot}
+paths = ${django:staticroot}
+        ${django:mediaroot}
         ${django:tmproot}
         ${django:cacheroot}
         ${django:uploadroot}

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -47,11 +47,11 @@ Start local instance :
 
 ::
 
-    make env_dev serve
+    make env_dev update serve
 
 .. note::
 
-    Running ``env_dev`` is recommended after a pull of new source code,
+    Running ``env_dev`` and ``update`` is recommended after a pull of new source code,
     but is not mandatory : ``make serve`` is enough most of the time.
 
 
@@ -59,14 +59,14 @@ Run unit tests :
 
 ::
 
-    make env_test tests
+    make env_test update tests
 
 
 Run unit tests in verbose mode, and without migrations :
 
 ::
 
-    make env_dev tests
+    make env_dev update tests
 
 
 For Capture server, run an instance of screamshotter in a separate terminal :
@@ -186,7 +186,7 @@ Then run:
 
 ::
 
-    make env_dev
+    make env_dev update
     cd lib/src/mapentity/
     git submodule init
     git submodule update

--- a/install.sh
+++ b/install.sh
@@ -444,6 +444,12 @@ function geotrek_setup {
         exit_error 3 "Could not setup python environment !"
     fi
 
+    if $dev ; then
+        echo_step "Initializing data..."
+        make update
+        echo_progress
+    fi
+
     if $tests ; then
         # XXX: Why Django tests require the main database :( ?
         bin/django syncdb --noinput


### PR DESCRIPTION
Now env_\* targets just run buildout. So you have to explicitely call update
target after env_dev one. Moreover all_compilemessages is added to update
target so it is run by salt install.
