### PR TITLE
Rename postgis function without underscores

### DIFF
--- a/geotrek/altimetry/sql/10_utilities.sql
+++ b/geotrek/altimetry/sql/10_utilities.sql
@@ -26,7 +26,7 @@ BEGIN
     last_ele := NULL;
     last_last_ele := NULL;
 
-    FOR current IN SELECT (ST_DumpPoints(ST_Force_3D(geom))).geom AS geom LOOP
+    FOR current IN SELECT (ST_DumpPoints(ST_Force3D(geom))).geom AS geom LOOP
 
          -- smoothing with last element
          ele := (ST_Z(current)::integer + coalesce(last_ele, ST_Z(current)::integer)) / 2;
@@ -108,7 +108,7 @@ BEGIN
     IF ST_ZMin(linegeom) < 0 OR ST_ZMax(linegeom) > 0 THEN
         -- Already 3D, do not need to drape.
         -- (Use-case is when assembling paths geometries to build topologies)
-        RETURN QUERY SELECT (ST_DumpPoints(ST_Force_3D(linegeom))).geom AS geom;
+        RETURN QUERY SELECT (ST_DumpPoints(ST_Force3D(linegeom))).geom AS geom;
 
     ELSE
         RETURN QUERY
@@ -175,13 +175,13 @@ BEGIN
     -- Skip if no DEM (speed-up tests)
     PERFORM * FROM raster_columns WHERE r_table_name = 'mnt';
     IF NOT FOUND THEN
-        SELECT ST_Force_3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
+        SELECT ST_Force3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
         RETURN result;
     END IF;
 
     -- Ensure parameter is a point or a line
     IF ST_GeometryType(geom) NOT IN ('ST_Point', 'ST_LineString') THEN
-        SELECT ST_Force_3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
+        SELECT ST_Force3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
         RETURN result;
     END IF;
 
@@ -241,13 +241,13 @@ BEGIN
     -- Skip if no DEM (speed-up tests)
     PERFORM * FROM raster_columns WHERE r_table_name = 'mnt';
     IF NOT FOUND THEN
-        SELECT ST_Force_3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
+        SELECT ST_Force3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
         RETURN result;
     END IF;
 
     -- Ensure parameter is a point or a line
     IF ST_GeometryType(geom) NOT IN ('ST_Point', 'ST_LineString') THEN
-        SELECT ST_Force_3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
+        SELECT ST_Force3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;
         RETURN result;
     END IF;
 

--- a/geotrek/core/sql/00_cleanup.sql
+++ b/geotrek/core/sql/00_cleanup.sql
@@ -1,7 +1,7 @@
 -- Cleanup public schema if installed before release 0.28
 DROP VIEW IF EXISTS public.l_v_sentier;
 DROP FUNCTION IF EXISTS public.ST_InterpolateAlong(geometry, geometry) CASCADE;
-DROP FUNCTION IF EXISTS public.ST_Smart_Line_Substring(geometry, float, float) CASCADE;
+DROP FUNCTION IF EXISTS public.ST_SmartLineSubstring(geometry, float, float) CASCADE;
 DROP FUNCTION IF EXISTS public.ft_IsBefore(geometry, geometry) CASCADE;
 DROP FUNCTION IF EXISTS public.ft_IsAfter(geometry, geometry) CASCADE;
 DROP FUNCTION IF EXISTS public.ft_Smart_MakeLine(geometry[]) CASCADE;

--- a/geotrek/core/sql/10_utilities.sql
+++ b/geotrek/core/sql/10_utilities.sql
@@ -10,7 +10,7 @@ DECLARE
     side_offset float;
     tuple record;
 BEGIN
-    linear_offset := ST_Line_Locate_Point(line, point);
+    linear_offset := ST_LineLocatePoint(line, point);
     shortest_line := ST_ShortestLine(line, point);
     crossing_dir := ST_LineCrossingDirection(line, shortest_line);
     -- /!\ In ST_LineCrossingDirection(), offset direction break the convention postive=left/negative=right
@@ -30,17 +30,17 @@ $$ LANGUAGE plpgsql;
 
 
 -------------------------------------------------------------------------------
--- A smart ST_Line_Substring that supports start > end
+-- A smart ST_LineSubstring that supports start > end
 -------------------------------------------------------------------------------
 
-CREATE OR REPLACE FUNCTION geotrek.ST_Smart_Line_Substring(geom geometry, t_start float, t_end float) RETURNS geometry AS $$
+CREATE OR REPLACE FUNCTION geotrek.ST_SmartLineSubstring(geom geometry, t_start float, t_end float) RETURNS geometry AS $$
 DECLARE
     egeom geometry;
 BEGIN
     IF t_start < t_end THEN
-        egeom := ST_Line_Substring(geom, t_start, t_end);
+        egeom := ST_LineSubstring(geom, t_start, t_end);
     ELSE
-        egeom := ST_Line_Substring(ST_Reverse(geom), 1.0-t_start, 1.0-t_end);
+        egeom := ST_LineSubstring(ST_Reverse(geom), 1.0-t_start, 1.0-t_end);
     END IF;
     RETURN egeom;
 END;

--- a/geotrek/core/sql/20_evenements.sql
+++ b/geotrek/core/sql/20_evenements.sql
@@ -105,7 +105,7 @@ BEGIN
 
         -- RAISE NOTICE '% % % %', (t_offset = 0), (egeom IS NULL), (ST_IsEmpty(egeom)), (ST_X(egeom) = 0 AND ST_Y(egeom) = 0);
         IF t_offset = 0 OR egeom IS NULL OR ST_IsEmpty(egeom) OR (ST_X(egeom) = 0 AND ST_Y(egeom) = 0) THEN
-            SELECT ST_GeometryN(ST_LocateAlong(ST_AddMeasure(ST_Force_2D(t.geom), 0, 1), et.pk_debut, e.decallage), 1)
+            SELECT ST_GeometryN(ST_LocateAlong(ST_AddMeasure(ST_Force2D(t.geom), 0, 1), et.pk_debut, e.decallage), 1)
                 INTO egeom
                 FROM e_t_evenement e, e_r_evenement_troncon et, l_t_troncon t
                 WHERE e.id = eid AND et.evenement = e.id AND et.troncon = t.id;
@@ -117,8 +117,8 @@ BEGIN
         -- NOTE: LineMerge and Line_Substring work on X and Y only. If two
         -- points in the line have the same X/Y but a different Z, these
         -- functions will see only on point. --> No problem in mountain path management.
-        FOR t_offset, t_geom, t_geom_3d IN SELECT e.decallage, ST_Smart_Line_Substring(t.geom, et.pk_debut, et.pk_fin),
-                                                               ST_Smart_Line_Substring(t.geom_3d, et.pk_debut, et.pk_fin)
+        FOR t_offset, t_geom, t_geom_3d IN SELECT e.decallage, ST_SmartLineSubstring(t.geom, et.pk_debut, et.pk_fin),
+                                                               ST_SmartLineSubstring(t.geom_3d, et.pk_debut, et.pk_fin)
                FROM e_t_evenement e, e_r_evenement_troncon et, l_t_troncon t
                WHERE e.id = eid AND et.evenement = e.id AND et.troncon = t.id
                  AND et.pk_debut != et.pk_fin
@@ -139,8 +139,8 @@ BEGIN
 
     IF t_count > 0 THEN
         SELECT * FROM ft_elevation_infos(egeom_3d, {{ALTIMETRIC_PROFILE_STEP}}) INTO elevation;
-        UPDATE e_t_evenement SET geom = ST_Force_2D(egeom),
-                                 geom_3d = ST_Force_3DZ(elevation.draped),
+        UPDATE e_t_evenement SET geom = ST_Force2D(egeom),
+                                 geom_3d = ST_Force3DZ(elevation.draped),
                                  longueur = ST_3DLength(elevation.draped),
                                  pente = elevation.slope,
                                  altitude_minimum = elevation.min_elevation,

--- a/geotrek/core/sql/50_troncons_split.sql
+++ b/geotrek/core/sql/50_troncons_split.sql
@@ -145,19 +145,19 @@ BEGIN
         IF ST_DWITHIN(ST_STARTPOINT(NEW.geom), troncon.geom, 0)
         THEN
             intersections_on_current := array_append(intersections_on_current,
-                                                 ST_Line_Locate_Point(troncon.geom,
+                                                 ST_LineLocatePoint(troncon.geom,
                                                                       ST_CLOSESTPOINT(troncon.geom, ST_STARTPOINT(NEW.geom))));
         END IF;
 
         IF ST_DWITHIN(ST_ENDPOINT(NEW.geom), troncon.geom, 0)
         THEN
             intersections_on_current := array_append(intersections_on_current,
-                                                 ST_Line_Locate_Point(troncon.geom,
+                                                 ST_LineLocatePoint(troncon.geom,
                                                                       ST_CLOSESTPOINT(troncon.geom, ST_ENDPOINT(NEW.geom))));
 
         END IF;
         RAISE NOTICE 'EEE : %', array_to_string(intersections_on_current, ', ');
-        FOR fraction IN SELECT ST_Line_Locate_Point(troncon.geom, (ST_Dump(ST_Intersection(troncon.geom, NEW.geom))).geom)
+        FOR fraction IN SELECT ST_LineLocatePoint(troncon.geom, (ST_Dump(ST_Intersection(troncon.geom, NEW.geom))).geom)
         LOOP
             intersections_on_current := array_append(intersections_on_current, fraction);
         END LOOP;
@@ -187,7 +187,7 @@ BEGIN
                 a := intersections_on_new[i];
                 b := intersections_on_new[i+1];
 
-                segment := ST_Line_Substring(newgeom, a, b);
+                segment := ST_LineSubstring(newgeom, a, b);
 
                 IF coalesce(ST_Length(segment), 0) < 1 THEN
                      intersections_on_new[i+1] := a;
@@ -260,7 +260,7 @@ BEGIN
                 a := intersections_on_current[i];
                 b := intersections_on_current[i+1];
 
-                segment := ST_Line_Substring(troncon.geom, a, b);
+                segment := ST_LineSubstring(troncon.geom, a, b);
 
                 IF coalesce(ST_Length(segment), 0) < 1 THEN
                      intersections_on_new[i+1] := a;
@@ -346,7 +346,7 @@ BEGIN
                         -- Special case : point topology at the end of path
                         IF b = 1 THEN
                             SELECT geom INTO t_geom FROM l_t_troncon WHERE id = troncon.id;
-                            fraction := ST_Line_Locate_Point(segment, ST_EndPoint(troncon.geom));
+                            fraction := ST_LineLocatePoint(segment, ST_EndPoint(troncon.geom));
                             INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin)
                                 SELECT tid_clone, evenement, pk_debut, pk_fin
                                 FROM e_r_evenement_troncon et,
@@ -363,7 +363,7 @@ BEGIN
                         END IF;
                         -- Special case : point topology exactly where NEW path intersects
                         IF a > 0 THEN
-                            fraction := ST_Line_Locate_Point(NEW.geom, ST_Line_Interpolate_Point(troncon.geom, a));
+                            fraction := ST_LineLocatePoint(NEW.geom, ST_LineInterpolatePoint(troncon.geom, a));
                             INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin, ordre)
                                 SELECT NEW.id, et.evenement, fraction, fraction, ordre
                                 FROM e_r_evenement_troncon et,

--- a/geotrek/zoning/sql/10_couches_sig.sql
+++ b/geotrek/zoning/sql/10_couches_sig.sql
@@ -118,7 +118,7 @@ BEGIN
     -- Note: Column names differ between commune, secteur and zonage, we can not use an elegant loop.
 
     -- Commune
-    FOR rec IN EXECUTE 'SELECT id, ST_Line_Locate_Point($1, COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_Line_Locate_Point($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT insee AS id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_commune WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
+    FOR rec IN EXECUTE 'SELECT id, ST_LineLocatePoint($1, COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_LineLocatePoint($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT insee AS id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_commune WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
     LOOP
         INSERT INTO e_t_evenement (date_insert, date_update, kind, decallage, longueur, geom, supprime) VALUES (now(), now(), 'CITYEDGE', 0, 0, NEW.geom, FALSE) RETURNING id INTO eid;
         INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin) VALUES (NEW.id, eid, least(rec.pk_a, rec.pk_b), greatest(rec.pk_a, rec.pk_b));
@@ -126,7 +126,7 @@ BEGIN
     END LOOP;
 
     -- Secteur
-    FOR rec IN EXECUTE 'SELECT id, ST_Line_Locate_Point($1,COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_Line_Locate_Point($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_secteur WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
+    FOR rec IN EXECUTE 'SELECT id, ST_LineLocatePoint($1,COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_LineLocatePoint($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_secteur WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
     LOOP
         INSERT INTO e_t_evenement (date_insert, date_update, kind, decallage, longueur, geom, supprime) VALUES (now(), now(), 'DISTRICTEDGE', 0, 0, NEW.geom, FALSE) RETURNING id INTO eid;
         INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin) VALUES (NEW.id, eid, least(rec.pk_a, rec.pk_b), greatest(rec.pk_a, rec.pk_b));
@@ -134,7 +134,7 @@ BEGIN
     END LOOP;
 
     -- Zonage
-    FOR rec IN EXECUTE 'SELECT id, ST_Line_Locate_Point($1, COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_Line_Locate_Point($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_zonage_reglementaire WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
+    FOR rec IN EXECUTE 'SELECT id, ST_LineLocatePoint($1, COALESCE(ST_StartPoint(geom), geom)) as pk_a, ST_LineLocatePoint($1, COALESCE(ST_EndPoint(geom), geom)) as pk_b FROM (SELECT id, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS geom FROM l_zonage_reglementaire WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
     LOOP
         INSERT INTO e_t_evenement (date_insert, date_update, kind, decallage, longueur, geom, supprime) VALUES (now(), now(), 'RESTRICTEDAREAEDGE', 0, 0, NEW.geom, FALSE) RETURNING id INTO eid;
         INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin) VALUES (NEW.id, eid, least(rec.pk_a, rec.pk_b), greatest(rec.pk_a, rec.pk_b));
@@ -183,7 +183,7 @@ BEGIN
     END IF;
 
     -- Add new evenement
-    FOR rec IN EXECUTE 'SELECT id, egeom AS geom, ST_Line_Locate_Point(tgeom, ST_StartPoint(egeom)) AS pk_a, ST_Line_Locate_Point(tgeom, ST_EndPoint(egeom)) AS pk_b FROM (SELECT id, geom AS tgeom, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS egeom FROM l_t_troncon WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
+    FOR rec IN EXECUTE 'SELECT id, egeom AS geom, ST_LineLocatePoint(tgeom, ST_StartPoint(egeom)) AS pk_a, ST_LineLocatePoint(tgeom, ST_EndPoint(egeom)) AS pk_b FROM (SELECT id, geom AS tgeom, (ST_Dump(ST_Multi(ST_Intersection(geom, $1)))).geom AS egeom FROM l_t_troncon WHERE ST_Intersects(geom, $1)) AS sub' USING NEW.geom
     LOOP
         INSERT INTO e_t_evenement (date_insert, date_update, kind, decallage, longueur, geom, supprime) VALUES (now(), now(), kind_name, 0, 0, rec.geom, FALSE) RETURNING id INTO eid;
         INSERT INTO e_r_evenement_troncon (troncon, evenement, pk_debut, pk_fin) VALUES (rec.id, eid, least(rec.pk_a, rec.pk_b), greatest(rec.pk_a, rec.pk_b));


### PR DESCRIPTION
Names with underscore are deprecated and triggers a lot of warnings in the log, at least on recent postgis versions.

WARNING ! This PR will not work with Ubuntu Precise 12.04 used in our travis tests