### PR TITLE
Add filter comfort and stake

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ CHANGELOG
 * Fix creation of Youtube/Soundcloud attachments
 * Fix cancellation when editing geometries
 * Show which structure choices are related to
+* Add confort and stake filters to path list
 
 
 2.20.1 (2018-07-16)

--- a/geotrek/core/filters.py
+++ b/geotrek/core/filters.py
@@ -82,7 +82,7 @@ class PathFilterSet(StructureRelatedFilterSet):
     class Meta(StructureRelatedFilterSet.Meta):
         model = Path
         fields = StructureRelatedFilterSet.Meta.fields + \
-            ['valid', 'length', 'networks', 'usages']
+            ['valid', 'length', 'networks', 'usages', 'comfort', 'stake']
 
 
 class TrailFilterSet(StructureRelatedFilterSet):


### PR DESCRIPTION
Add the filter of confort and stake in Path filters (on the left). We keep in the right filters of topologies (treks, intervention ...).

Asked on this issue : #1668
