### PR TITLE
WIP: Change default copyright format to ""

### DIFF
--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -646,9 +646,11 @@ LINE_CODE_FORMAT = u"{signagecode}-{bladenumber}-{linenumber}"
 SHOW_EXTREMITIES = False
 
 THUMBNAIL_COPYRIGHT_FORMAT = u""
+
 # If you want copyright added to your pictures, change THUMBNAIL_COPYRIGHT_FORMAT to this :
-#THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
+# THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
 # You can also add legend
+
 THUMBNAIL_COPYRIGHT_SIZE = 15
 
 REST_FRAMEWORK = {

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -645,7 +645,10 @@ BLADE_CODE_FORMAT = u"{signagecode}-{bladenumber}"
 LINE_CODE_FORMAT = u"{signagecode}-{bladenumber}-{linenumber}"
 SHOW_EXTREMITIES = False
 
-THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"  # You can add legend
+THUMBNAIL_COPYRIGHT_FORMAT = u""
+# If you want copyright added to your pictures, change THUMBNAIL_COPYRIGHT_FORMAT to this :
+#THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
+# You can also add legend
 THUMBNAIL_COPYRIGHT_SIZE = 15
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Change default copyright, to keep previous Geotrek-admin behaviour, i.e. watermark is added in Geotrek-rando and not in Geotrek-admin.

THUMBNAIL_COPYRIGHT_FORMAT = u""