### PR TITLE
Change base settings watermark

### DIFF
--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -646,9 +646,11 @@ LINE_CODE_FORMAT = u"{signagecode}-{bladenumber}-{linenumber}"
 SHOW_EXTREMITIES = False
 
 THUMBNAIL_COPYRIGHT_FORMAT = u""
+
 # If you want copyright added to your pictures, change THUMBNAIL_COPYRIGHT_FORMAT to this :
-#THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
+# THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
 # You can also add legend
+
 THUMBNAIL_COPYRIGHT_SIZE = 15
 
 REST_FRAMEWORK = {

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -645,7 +645,10 @@ BLADE_CODE_FORMAT = u"{signagecode}-{bladenumber}"
 LINE_CODE_FORMAT = u"{signagecode}-{bladenumber}-{linenumber}"
 SHOW_EXTREMITIES = False
 
-THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"  # You can add legend
+THUMBNAIL_COPYRIGHT_FORMAT = u""
+# If you want copyright added to your pictures, change THUMBNAIL_COPYRIGHT_FORMAT to this :
+#THUMBNAIL_COPYRIGHT_FORMAT = u"{title} {author}"
+# You can also add legend
 THUMBNAIL_COPYRIGHT_SIZE = 15
 
 REST_FRAMEWORK = {

--- a/geotrek/tourism/tests/test_views.py
+++ b/geotrek/tourism/tests/test_views.py
@@ -166,6 +166,7 @@ class BasicJSONAPITest(TranslationResetMixin):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(

--- a/geotrek/tourism/tests/test_views.py
+++ b/geotrek/tourism/tests/test_views.py
@@ -167,6 +167,7 @@ class BasicJSONAPITest(TranslationResetMixin):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(

--- a/geotrek/tourism/tests/test_views.py
+++ b/geotrek/tourism/tests/test_views.py
@@ -120,10 +120,10 @@ class TouristicContentFormTest(TrekkingManagerTest):
         self.assertContains(response, 'value="%s" selected' % self.category.pk)
 
 
-@override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
 class BasicJSONAPITest(TranslationResetMixin):
     factory = None
 
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def setUp(self):
         super(BasicJSONAPITest, self).setUp()
         self._build_object()

--- a/geotrek/tourism/tests/test_views.py
+++ b/geotrek/tourism/tests/test_views.py
@@ -120,6 +120,7 @@ class TouristicContentFormTest(TrekkingManagerTest):
         self.assertContains(response, 'value="%s" selected' % self.category.pk)
 
 
+@override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
 class BasicJSONAPITest(TranslationResetMixin):
     factory = None
 
@@ -166,7 +167,6 @@ class BasicJSONAPITest(TranslationResetMixin):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
-    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -532,6 +532,7 @@ class TrekCustomPublicViewTests(TrekkingManagerTest):
 
 
 class TrekJSONSetUp(TrekkingManagerTest):
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def setUp(self):
         self.login()
 
@@ -631,7 +632,6 @@ class TrekPracticeTest(TrekJSONSetUp):
             u'category_id': self.touristic_content.prefixed_category_id})
 
 
-@override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
 class TrekJSONDetailTest(TrekJSONSetUp):
     """ Since we migrated some code to Django REST Framework, we should test
     the migration extensively. Geotrek-rando mainly relies on this view.

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -631,6 +631,7 @@ class TrekPracticeTest(TrekJSONSetUp):
             u'category_id': self.touristic_content.prefixed_category_id})
 
 
+@override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
 class TrekJSONDetailTest(TrekJSONSetUp):
     """ Since we migrated some code to Django REST Framework, we should test
     the migration extensively. Geotrek-rando mainly relies on this view.
@@ -660,7 +661,6 @@ class TrekJSONDetailTest(TrekJSONSetUp):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
-    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -661,6 +661,7 @@ class TrekJSONDetailTest(TrekJSONSetUp):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -660,6 +660,7 @@ class TrekJSONDetailTest(TrekJSONSetUp):
         self.assertDictEqual(self.result['published_status'][0],
                              {u'lang': u'en', u'status': True, u'language': u'English'})
 
+    @override_settings(THUMBNAIL_COPYRIGHT_FORMAT="{title} {author}")
     def test_pictures(self):
         self.assertDictEqual(self.result['pictures'][0],
                              {u'url': '{url}.800x800_q85_size_watermark-{size}_text-{text}.png'.format(


### PR DESCRIPTION
Change default copyright, to keep previous Geotrek-admin behaviour, i.e. watermark is added in Geotrek-rando and not in Geotrek-admin.

THUMBNAIL_COPYRIGHT_FORMAT = u""

(new PR from branch in main repo)