### PR TITLE
Fix missing pictogram in mobile api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ CHANGELOG
 
 - Add itinerancy mobile
 
+**Bug fixes**
+
+- Fix missing pictograms for mobile app
+
 
 2.27.11 (2019-07-17)
 --------------------

--- a/geotrek/api/management/commands/sync_mobile.py
+++ b/geotrek/api/management/commands/sync_mobile.py
@@ -160,7 +160,7 @@ class Command(BaseCommand):
     def sync_pictograms(self, model, directory='', zipfile=None, size=None):
         for obj in model.objects.all():
             if not obj.pictogram:
-                return
+                continue
             file_name, file_extension = os.path.splitext(obj.pictogram.name)
             if file_extension == '.svg':
                 name = os.path.join(settings.MEDIA_URL.strip('/'), '%s.png' % file_name)


### PR DESCRIPTION
There was a `return` in loop `sync_pictogram` function in `sync_mobile` command, I changed this to `continue`.