### PR TITLE
Add SHOW_LABELS setting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,12 @@ CHANGELOG
 
 **Bug fixes**
 
+-
+
+**Minor changes**
+
+- SHOW_LABELS setting allow to hide status labels on map
+
 
 2.30.0 (2019-11-26)
 -------------------

--- a/geotrek/common/views.py
+++ b/geotrek/common/views.py
@@ -156,6 +156,7 @@ class JSSettings(mapentity_views.JSSettings):
         )
         dictsettings['version'] = __version__
         dictsettings['showExtremities'] = settings.SHOW_EXTREMITIES
+        dictsettings['showLabels'] = settings.SHOW_LABELS
         return dictsettings
 
 

--- a/geotrek/land/static/land/main.js
+++ b/geotrek/land/static/land/main.js
@@ -54,7 +54,7 @@ $(window).on('entity:map', function (e, data) {
                 color = colorspool[idx % colorspool.length];
             layer.setStyle({color: color});
 
-            if (window.SETTINGS.showExtremities && data.properties.name) {
+            if (window.SETTINGS.showLabels && data.properties.name) {
                 // Add label in the middle of the line
                 MapEntity.showLineLabel(layer, {
                     color: color,

--- a/geotrek/land/static/land/main.js
+++ b/geotrek/land/static/land/main.js
@@ -54,8 +54,8 @@ $(window).on('entity:map', function (e, data) {
                 color = colorspool[idx % colorspool.length];
             layer.setStyle({color: color});
 
-            // Add label in the middle of the line
-            if (data.properties.name) {
+            if (window.SETTINGS.showExtremities && data.properties.name) {
+                // Add label in the middle of the line
                 MapEntity.showLineLabel(layer, {
                     color: color,
                     text: data.properties.name,

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -682,7 +682,8 @@ PASSWORD_HASHERS = [
 BLADE_CODE_TYPE = int
 BLADE_CODE_FORMAT = "{signagecode}-{bladenumber}"
 LINE_CODE_FORMAT = "{signagecode}-{bladenumber}-{linenumber}"
-SHOW_EXTREMITIES = False
+SHOW_EXTREMITIES = False  # Show a bullet at path extremities
+SHOW_LABELS = True  # Show labels on status
 
 THUMBNAIL_COPYRIGHT_FORMAT = ""
 


### PR DESCRIPTION
Allow to show/hide status labels on map. Default is True. Hiding labels is a very big performance improvement.