### PR TITLE
Import parsers from file and get rid of symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ COPY .coveragerc .coveragerc
 COPY docker/* /usr/local/bin/
 
 RUN cd geotrek; ENV=dev CUSTOM_SETTINGS_FILE= SECRET_KEY=tmp ../env/bin/python ../manage.py compilemessages; cd ..
-RUN ln -sf /app/src/var/conf/parsers.py /app/src/bulkimport/parsers.py
 
 EXPOSE 8000
 ENTRYPOINT ["/bin/sh", "-e", "/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,9 +22,8 @@ if [ ! -f /app/src/var/conf/parsers.py ]; then
     touch /app/src/var/conf/parsers.py
 fi
 
-# When a volume is mounted to /app/src, bulkimport/parsers.py and venv are hidden
+# When a volume is mounted to /app/src and venv are hidden
 if [ "$ENV" = "dev" ]; then
-    ln -sf /app/src/var/conf/parsers.py /app/src/bulkimport/parsers.py
     if [ ! -d env ]; then
         python3 -m venv env
         env/bin/pip install --no-cache-dir -r requirements.txt

--- a/geotrek/common/management/commands/import.py
+++ b/geotrek/common/management/commands/import.py
@@ -9,24 +9,37 @@ class Command(BaseCommand):
     leave_locale_alone = True
 
     def add_arguments(self, parser):
-        parser.add_argument('parser')
+        parser.add_argument('parser', help='Parser class')
         parser.add_argument('shapefile', nargs="?")
         parser.add_argument('-l', dest='limit', type=int, help='Limit number of lines to import')
         parser.add_argument('--encoding', '-e', default='utf8')
+        parser.add_argument('--file', '-f', help="File path")
 
     def handle(self, *args, **options):
         verbosity = options['verbosity']
         limit = options['limit']
         encoding = options['encoding']
 
-        # Validate arguments
-
-        try:
+        if '.' in options['parser'] and options['file'] is None:
+            # Python import syntax
             module_name, class_name = options['parser'].rsplit('.', 1)
-            module = importlib.import_module(module_name)
+            module_path = module_name.replace('.', '/') + '.py'
+        else:
+            # File path + class name
+            module_path = options['file'] or 'bulkimport/parsers.py'
+            module_name = module_path.rstrip('.py').replace('/', '.')
+            class_name = options['parser']
+
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(module)
+        except FileNotFoundError:
+            raise CommandError("Failed to import parser file '{0}'".format(module_path))
+        try:
             Parser = getattr(module, class_name)
-        except (ImportError, AttributeError):
-            raise CommandError("Failed to import parser class '{0}'".format(options['parser']))
+        except AttributeError:
+            raise CommandError("Failed to import parser class '{0}'".format(class_name))
         if not Parser.filename and not Parser.url and not options['shapefile']:
             raise CommandError("File path missing")
 

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -34,7 +34,11 @@ class AttachmentParser(AttachmentParserMixin, OrganismEidParser):
 
 class ParserTests(TestCase):
     def test_bad_parser_class(self):
-        with self.assertRaisesRegexp(CommandError, "Failed to import parser class 'geotrek.common.DoesNotExist'"):
+        with self.assertRaisesRegexp(CommandError, "Failed to import parser class 'DoesNotExist'"):
+            call_command('import', 'geotrek.common.tests.test_parsers.DoesNotExist', '', verbosity=0)
+
+    def test_bad_parser_file(self):
+        with self.assertRaisesRegexp(CommandError, "Failed to import parser file 'geotrek/common.py'"):
             call_command('import', 'geotrek.common.DoesNotExist', '', verbosity=0)
 
     def test_no_filename_no_url(self):
@@ -54,6 +58,13 @@ class ParserTests(TestCase):
     def test_create(self):
         filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
         call_command('import', 'geotrek.common.tests.test_parsers.OrganismParser', filename, verbosity=0)
+        self.assertEqual(Organism.objects.count(), 1)
+        organism = Organism.objects.get()
+        self.assertEqual(organism.organism, "Comité Théodule")
+
+    def test_create_with_file_option(self):
+        filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+        call_command('import', 'OrganismParser', filename, file='geotrek/common/tests/test_parsers.py', verbosity=0)
         self.assertEqual(Organism.objects.count(), 1)
         organism = Organism.objects.get()
         self.assertEqual(organism.organism, "Comité Théodule")

--- a/geotrek/sensitivity/tests/test_parsers.py
+++ b/geotrek/sensitivity/tests/test_parsers.py
@@ -88,7 +88,7 @@ json_test_species = {
 
 
 class BiodivParserTests(TranslationResetMixin, TestCase):
-    @mock.patch('geotrek.sensitivity.parsers.requests')
+    @mock.patch('requests.get')
     def test_create(self, mocked):
         def side_effect(url):
             response = requests.Response()
@@ -98,7 +98,7 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
             else:
                 response.json = lambda: json_test_species
             return response
-        mocked.get.side_effect = side_effect
+        mocked.side_effect = side_effect
         call_command('import', 'geotrek.sensitivity.parsers.BiodivParser', verbosity=0)
         practice = SportPractice.objects.get()
         species = Species.objects.first()
@@ -123,17 +123,17 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(area_2.eid, '2')
         self.assertEqual(area_2.geom.geom_type, 'MultiPolygon')
 
-    @mock.patch('geotrek.sensitivity.parsers.requests')
+    @mock.patch('requests.get')
     def test_status_code_404(self, mocked):
         def side_effect(url):
             response = requests.Response()
             response.status_code = 404
             return response
-        mocked.get.side_effect = side_effect
+        mocked.side_effect = side_effect
         with self.assertRaisesRegexp(CommandError, "Failed to download https://biodiv-sports.fr/api/v2/sportpractice/"):
             call_command('import', 'geotrek.sensitivity.parsers.BiodivParser', verbosity=0)
 
-    @mock.patch('geotrek.sensitivity.parsers.requests')
+    @mock.patch('requests.get')
     def test_create_no_id(self, mocked):
         def side_effect(url):
             response = requests.Response()
@@ -146,7 +146,7 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
                 json_test_species_without_id['results'][1]['species_id'] = None
                 response.json = lambda: json_test_species_without_id
             return response
-        mocked.get.side_effect = side_effect
+        mocked.side_effect = side_effect
         call_command('import', 'geotrek.sensitivity.parsers.BiodivParser', verbosity=0)
         practice = SportPractice.objects.first()
         species = Species.objects.first()
@@ -159,7 +159,7 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
         self.assertQuerysetEqual(species.practices.all(), ['<SportPractice: Land>'])
         self.assertEqual(area.eid, '1')
 
-    @mock.patch('geotrek.sensitivity.parsers.requests')
+    @mock.patch('requests.get')
     def test_create_species_url(self, mocked):
         def side_effect(url):
             response = requests.Response()
@@ -169,14 +169,15 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
             else:
                 json_test_species_without_id = json_test_species.copy()
                 json_test_species_without_id['results'][0]['info_url'] = "toto.com"
+                json_test_species_without_id['results'][1]['info_url'] = "toto.com"
                 response.json = lambda: json_test_species_without_id
             return response
-        mocked.get.side_effect = side_effect
+        mocked.side_effect = side_effect
         call_command('import', 'geotrek.sensitivity.parsers.BiodivParser', verbosity=0)
         species = Species.objects.first()
         self.assertEqual(species.url, "toto.com")
 
-    @mock.patch('geotrek.sensitivity.parsers.requests')
+    @mock.patch('requests.get')
     def test_create_species_radius(self, mocked):
         def side_effect(url):
             response = requests.Response()
@@ -189,7 +190,7 @@ class BiodivParserTests(TranslationResetMixin, TestCase):
                 json_test_species_without_id['results'][1]['radius'] = 5
                 response.json = lambda: json_test_species_without_id
             return response
-        mocked.get.side_effect = side_effect
+        mocked.side_effect = side_effect
         call_command('import', 'geotrek.sensitivity.parsers.BiodivParser', verbosity=0)
         species = Species.objects.first()
         self.assertEqual(species.radius, 5)


### PR DESCRIPTION
Old syntax kept for compatibility (the module must be in python path) :

```./manage.py import bulkimport.parsers.MyParser```

New syntax (the module can be outside python path) : 

```./manage.py import --file bulkimport/parsers.py MyParser```

Or just (bulkimport/parsers.py is the default) :

```./manage.py import MyParser```

With docker yo should use :

```./manage.py import var/conf/parsers.py MyParser```
