### PR TITLE
Add better handling of get requests in parsers

### DIFF
--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -1,11 +1,11 @@
 import os
 import re
 import requests
+import logging
 from requests.auth import HTTPBasicAuth
 import xlrd
 import xml.etree.ElementTree as ET
 from functools import reduce
-from urllib.request import urlopen
 from collections import Iterable
 from time import sleep
 
@@ -32,6 +32,8 @@ from geotrek.common.models import FileType, Attachment
 if 'modeltranslation' in settings.INSTALLED_APPS:
     from modeltranslation.fields import TranslationField
     from modeltranslation.translator import translator, NotRegistered
+
+logger = logging.getLogger(__name__)
 
 
 class ImportError(Exception):
@@ -70,8 +72,6 @@ class Parser(object):
     non_fields = {}
     natural_keys = {}
     field_options = {}
-    sleep_time = 60
-    number_of_try = 3
 
     def __init__(self, progress_cb=None, user=None, encoding='utf8'):
         self.warnings = {}
@@ -461,20 +461,22 @@ class Parser(object):
                 self.add_warning(str(e))
         self.end()
 
-    def get_or_retry(self, url, params=None, authent=None):
-        try_get = self.number_of_try
+    def request_or_retry(self, url, verb='get', params=None, authent=None):
+        try_get = settings.PARSER_NUMBER_OF_TRIES
         assert try_get > 0
         while try_get:
-            response = requests.get(url, params=params, auth=authent)
-            if response.status_code == 503:
-                sleep(self.sleep_time)
+            action = getattr(requests, verb)
+            response = action(url, params=params, auth=authent)
+            if response.status_code in settings.PARSER_RETRY_HTTP_STATUS:
+                logger.info("Failed to fetch url {}. Retrying ...".format(url))
+                sleep(settings.PARSER_RETRY_SLEEP_TIME)
                 try_get -= 1
             elif response.status_code == 200:
                 return response
             else:
                 break
-        raise GlobalImportError(_("Failed to download {url}. HTTP status code {status_code}").format(url=response.url,
-                                                                                                     status_code=response.status_code))
+        logger.warning("Failed to fetch {} after {} times. Status code : {}.".format(url, settings.PARSER_NUMBER_OF_TRIES, response.status_code))
+        raise GlobalImportError(_("Failed to download {url}. HTTP status code {status_code}").format(url=response.url, status_code=response.status_code))
 
 
 class ShapeParser(Parser):
@@ -580,7 +582,10 @@ class AttachmentParserMixin(object):
             return size != attachment.attachment_file.size
 
         if parsed_url.scheme == 'http' or parsed_url.scheme == 'https':
-            response = requests.head(url, allow_redirects=True)
+            try:
+                response = self.request_or_retry(url, verb='head', params={'allow_redirects': True})
+            except requests.exceptions.RequestException as e:
+                raise ValueImportError('Failed to load attachment: {exc}'.format(exc=e))
             size = response.headers.get('content-length')
             return size is not None and int(size) != attachment.attachment_file.size
 
@@ -590,15 +595,14 @@ class AttachmentParserMixin(object):
         parsed_url = urlparse(url)
         if parsed_url.scheme == 'ftp':
             try:
-                response = urlopen(url)
-            except Exception:
-                self.add_warning(_("Failed to download '{url}'").format(url=url))
-                return None
+                response = self.request_or_retry(url)
+            except requests.exceptions.RequestException as e:
+                raise ValueImportError('Failed to load attachment: {exc}'.format(exc=e))
             return response.read()
         else:
             if self.download_attachments:
                 try:
-                    response = requests.get(url)
+                    response = self.request_or_retry(url)
                 except requests.exceptions.RequestException as e:
                     raise ValueImportError('Failed to load attachment: {exc}'.format(exc=e))
                 if response.status_code != requests.codes.ok:
@@ -684,7 +688,7 @@ class TourInSoftParser(AttachmentParserMixin, Parser):
                 '$top': 1000,
                 '$skip': skip,
             }
-            response = self.get_or_retry(self.url, params)
+            response = self.request_or_retry(self.url, params=params)
             self.root = response.json()
             self.nb = self.get_nb()
             for row in self.items:
@@ -787,7 +791,7 @@ class TourismSystemParser(AttachmentParserMixin, Parser):
                 'size': size,
                 'start': skip,
             }
-            response = self.get_or_retry(self.url, params, HTTPBasicAuth(self.login, self.password))
+            response = self.request_or_retry(self.url, params=params, authent=HTTPBasicAuth(self.login, self.password))
             self.root = response.json()
             self.nb = int(self.root['metadata']['total'])
             for row in self.items:
@@ -819,7 +823,7 @@ class OpenSystemParser(Parser):
             'Pass': self.password,
             'Action': 'concentrateur_liaisons',
         }
-        response = self.get_or_retry(self.url, params)
+        response = self.request_or_retry(self.url, params=params)
         self.root = ET.fromstring(response.content).find('Resultat').find('Objets')
         self.nb = len(self.root)
         for row in self.root:

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -151,6 +151,7 @@ class AttachmentParserTests(TestCase):
     def test_attachment_not_updated(self, mocked_head, mocked_get):
         mocked_get.return_value.status_code = 200
         mocked_get.return_value.content = ''
+        mocked_head.return_value.status_code = 200
         mocked_head.return_value.headers = {'content-length': 0}
         filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
         call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -3,6 +3,9 @@ import os
 from shutil import rmtree
 from tempfile import mkdtemp
 from io import StringIO
+from requests import Response
+from requests.exceptions import RequestException
+import urllib
 
 from django.test import TestCase
 from django.conf import settings
@@ -14,7 +17,7 @@ from django.template.exceptions import TemplateDoesNotExist
 from geotrek.authent.factories import StructureFactory
 from geotrek.trekking.models import Trek
 from geotrek.common.models import Organism, FileType, Attachment
-from geotrek.common.parsers import ExcelParser, AttachmentParserMixin, TourInSoftParser, ValueImportError
+from geotrek.common.parsers import ExcelParser, AttachmentParserMixin, TourInSoftParser, ValueImportError, TourismSystemParser, OpenSystemParser
 
 
 class OrganismParser(ExcelParser):
@@ -159,6 +162,45 @@ class AttachmentParserTests(TestCase):
         self.assertEqual(mocked_get.call_count, 1)
         self.assertEqual(Attachment.objects.count(), 1)
 
+    @override_settings(PARSER_RETRY_SLEEP_TIME=1)
+    @mock.patch('requests.get')
+    @mock.patch('requests.head')
+    def test_attachment_request_fail(self, mocked_head, mocked_get):
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.content = ''
+        mocked_head.return_value.status_code = 503
+        filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+        call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)
+        with self.assertRaises(CommandError):
+            call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)
+        self.assertEqual(mocked_get.call_count, 1)
+        self.assertEqual(mocked_head.call_count, 3)
+        self.assertEqual(Attachment.objects.count(), 1)
+
+    @mock.patch('requests.get')
+    @mock.patch('requests.head')
+    def test_attachment_request_except(self, mocked_head, mocked_get):
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.content = ''
+        mocked_head.side_effect = RequestException()
+        filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+        call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)
+        call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)
+        self.assertEqual(mocked_get.call_count, 1)
+        self.assertEqual(mocked_head.call_count, 1)
+        self.assertEqual(Attachment.objects.count(), 1)
+
+    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.urlparse')
+    def test_attachment_download_fail(self, mocked_urlparse, mocked_get):
+        filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+        mocked_get.side_effect = RequestException()
+        mocked_urlparse.return_value = urllib.parse.urlparse('ftp://test.url.com/organism.xls')
+
+        call_command('import', 'geotrek.common.tests.test_parsers.AttachmentParser', filename, verbosity=0)
+
+        self.assertEqual(mocked_get.call_count, 1)
+
 
 class TourInSoftParserTests(TestCase):
 
@@ -188,3 +230,58 @@ class TourInSoftParserTests(TestCase):
             parser.filter_website('', 'Mél|chateau.senonches@gmail.Com#Instagram|#chateaudesenonches')
         with self.assertRaises(ValueImportError):
             parser.filter_contact('', ('Mél|chateau.senonches@gmail.Com#Instagram|#chateaudesenonches', ''))
+
+
+class TourismSystemParserTest(TestCase):
+    @mock.patch('geotrek.common.parsers.HTTPBasicAuth')
+    @mock.patch('requests.get')
+    def test_attachment(self, mocked_get, mocked_auth):
+        class TestTourismSystemParser(TourismSystemParser):
+            def __init__(self):
+                self.model = Trek
+                self.filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+                self.filetype = FileType.objects.create(type="Photographie")
+                self.login = "test"
+                self.password = "test"
+                super(TourismSystemParser, self).__init__()
+
+        def side_effect():
+            response = Response()
+            response.status_code = 200
+            response._content = bytes('{\"metadata\": {\"total\": 1}, \"data\": [] }', 'utf-8')
+            response.encoding = 'utf-8'
+            return response
+
+        mocked_auth.return_value = None
+        mocked_get.return_value = side_effect()
+        parser = TestTourismSystemParser()
+        parser.parse()
+        self.assertEqual(mocked_get.call_count, 1)
+        self.assertEqual(mocked_auth.call_count, 1)
+
+
+class OpenSystemParserTest(TestCase):
+    @mock.patch('requests.get')
+    def test_attachment(self, mocked_get):
+        class TestOpenSystemParser(OpenSystemParser):
+            def __init__(self):
+                self.model = Trek
+                self.filename = os.path.join(os.path.dirname(__file__), 'data', 'organism.xls')
+                self.filetype = FileType.objects.create(type="Photographie")
+                self.login = "test"
+                self.password = "test"
+                super(OpenSystemParser, self).__init__()
+
+        def side_effect():
+            response = Response()
+            response.status_code = 200
+            response._content = bytes(
+                "<?xml version=\"1.0\"?><Data><Resultat><Objets>[]</Objets></Resultat></Data>",
+                'utf-8'
+            )
+            return response
+
+        mocked_get.return_value = side_effect()
+        parser = TestOpenSystemParser()
+        parser.parse()
+        self.assertEqual(mocked_get.call_count, 1)

--- a/geotrek/sensitivity/parsers.py
+++ b/geotrek/sensitivity/parsers.py
@@ -46,7 +46,7 @@ class BiodivParser(Parser):
         return kwargs
 
     def next_row(self):
-        response = self.get_or_retry('https://biodiv-sports.fr/api/v2/sportpractice/')
+        response = self.request_or_retry('https://biodiv-sports.fr/api/v2/sportpractice/')
         for practice in response.json()['results']:
             defaults = {'name_' + lang: practice['name'][lang] for lang in practice['name'].keys() if lang in settings.MODELTRANSLATION_LANGUAGES}
             SportPractice.objects.get_or_create(id=practice['id'], defaults=defaults)
@@ -57,7 +57,7 @@ class BiodivParser(Parser):
         url += '&in_bbox={}'.format(','.join([str(coord) for coord in bbox.extent]))
         if self.practices:
             url += '&practices={}'.format(','.join([str(practice) for practice in self.practices]))
-        response = self.get_or_retry(url)
+        response = self.request_or_retry(url)
 
         self.root = response.json()
         self.nb = int(self.root['count'])

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -720,3 +720,8 @@ PRIMARY_COLOR = "#7b8c12"
 ONLY_EXTERNAL_PUBLIC_PDF = False
 
 SEND_REPORT_ACK = True
+
+# Parser parameters for retries and error codes
+PARSER_RETRY_SLEEP_TIME = 60  # time of sleep between requests
+PARSER_NUMBER_OF_TRIES = 3  # number of requests to try before abandon
+PARSER_RETRY_HTTP_STATUS = [503]

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -103,7 +103,7 @@ class ApidaeParser(AttachmentParserMixin, Parser):
                 'first': self.skip,
                 'responseFields': self.responseFields
             }
-            response = self.get_or_retry(self.url, {'query': json.dumps(params)})
+            response = self.request_or_retry(self.url, params={'query': json.dumps(params)})
             self.root = response.json()
             self.nb = int(self.root['numFound'])
             for row in self.items:
@@ -519,7 +519,7 @@ class EspritParcParser(AttachmentParserMixin, Parser):
         return self.root['responseData']
 
     def next_row(self):
-        response = self.get_or_retry(self.url)
+        response = self.request_or_retry(self.url)
         self.root = response.json()
         self.nb = int(self.root['numFound'])
 

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -5,7 +5,7 @@ import requests
 from unittest import mock
 import os
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -104,7 +104,7 @@ class ParserTests(TranslationResetMixin, TestCase):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
 
     @mock.patch('requests.get')
-    @mock.patch('geotrek.common.parsers.Parser.sleep_time', 0)
+    @override_settings(PARSER_SLEEP_TIME=0)
     @mock.patch('geotrek.common.parsers.AttachmentParserMixin.download_attachments', False)
     def test_create_content_espritparc_retry(self, mocked):
         def mocked_json():
@@ -132,7 +132,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(TouristicContent.objects.count(), 1)
 
     @mock.patch('requests.get')
-    @mock.patch('geotrek.common.parsers.Parser.sleep_time', 0)
+    @override_settings(PARSER_SLEEP_TIME=0)
     def test_create_content_espritparc_retry_fail(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeContent.json')


### PR DESCRIPTION
In AttachmentParserMixin add call to get_or_retry in order to be able to
tests url multipl times. AttachmentParserMixin now inherit from Parser
class.