### PR TITLE
Upgrade to psycopg2 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,7 @@ coverage==4.5.3
 cryptography==2.8
 cssselect2==0.2.2
 defusedxml==0.6.0
-# Django==1.11.28
-Django==2.0.*
+Django==2.0.13
 django-appconf==1.0.3
 django-appypod==2.0.4
 django-celery-results==1.0.1
@@ -67,7 +66,7 @@ openapi-codec==1.3.2
 paperclip==2.2.4
 Pillow==6.2.0
 pkg-resources==0.0.0
-psycopg2==2.7.7
+psycopg2==2.8.4
 public==2019.4.13
 pycodestyle==2.5.0
 pycparser==2.19


### PR DESCRIPTION
Django 1.11 was not compatible with psycopg2 > 2.7