### PR TITLE
Fix empty attachment link in admin list

### DIFF
--- a/geotrek/common/admin.py
+++ b/geotrek/common/admin.py
@@ -77,7 +77,7 @@ class MapEntityContentTypeFilter(admin.SimpleListFilter):
 class AttachmentAdmin(admin.ModelAdmin):
     date_hierarchy = 'date_update'
     search_fields = ('title', 'legend', 'author')
-    list_display = ('title', 'legend', 'author', 'content_type')
+    list_display = ('filename', 'legend', 'author', 'content_type')
     list_filter = ('filetype', MapEntityContentTypeFilter)
     readonly_fields = ('content_type', 'object_id', 'creator', 'title')
 


### PR DESCRIPTION
Quand on ne donne pas de titre, le lien dans l'admin est vide donc on ne peut pas cliquer sur ce lien sans texte.