### PR TITLE
Draft : Add ST is empty altimetry

### DIFF
--- a/geotrek/altimetry/sql/post_10_utilities.sql
+++ b/geotrek/altimetry/sql/post_10_utilities.sql
@@ -236,6 +236,9 @@ BEGIN
         RETURN result;
     END IF;
 
+    IF ST_IsEmpty(geom) THEN
+        RETURN result;
+    END IF;
     -- Ensure parameter is a point or a line
     IF ST_GeometryType(geom) NOT IN ('ST_Point', 'ST_LineString') THEN
         SELECT ST_Force3DZ(geom), 0.0, 0, 0, 0, 0 INTO result;


### PR DESCRIPTION
Problem with upperbound limit ...

It happens to have Linestring Empty during altimetry.