### PR TITLE
add network alias to get screamshotter and convertit working in docke…

### DIFF
--- a/.env-dev.dist
+++ b/.env-dev.dist
@@ -1,5 +1,5 @@
 ENV=dev
-DOMAIN_NAME=geotrek.local
+SERVER_NAME=geotrek.local
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_USER=geotrek

--- a/.env-dev.dist
+++ b/.env-dev.dist
@@ -1,4 +1,5 @@
 ENV=dev
+DOMAIN_NAME=geotrek.local
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_USER=geotrek

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -54,7 +54,7 @@ services:
     networks:
       default:
         aliases:
-          - ${DOMAIN_NAME}
+          - ${SERVER_NAME:geotrek.local}
 
 volumes:
   postgres:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -51,6 +51,10 @@ services:
       - convertit
     user: ${UID:-1000}:${GID:-1000}
     command: ./manage.py runserver 0.0.0.0:8000
+    networks:
+      default:
+        aliases:
+          - ${DOMAIN_NAME}
 
 volumes:
   postgres:


### PR DESCRIPTION
Revert changes in docker-compose to keep screamshotter and convertit working in development mode

to work, you need to define DOMAIN_NAME in dev mode (see .env.dist and your .env file)

for example, geotrek.local, and set your /etc/hosts to target 127.0.0.1 

Problem is that screamshotter and convertit can't resolve localhost or 127.0.0.1 in local docker development mode, and this address came from your browser url. So browser url should be resolved by screamshotter and convertit containers in local and not public environmenent)

This problem can also happen in production if private DNS are used (resolve by using extra_hosts)

![Capture d’écran de 2020-09-15 13-53-50](https://user-images.githubusercontent.com/7448208/93211658-d4111880-f761-11ea-9e0a-be8fa0f81618.png)
