### PR TITLE
Improve logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,10 @@ jobs:
         pip3 wheel --wheel-dir=~/.wheel_dir -r requirements.txt
         pip3 install --find-links=~/.wheel_dir -r requirements.txt
 
+    - name: Create test log directory
+      run: |
+        mkdir -p ./var/log
+
     - name: Check migrations
       run: |
         python3 ./manage.py makemigrations --check

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,9 @@ COPY VERSION VERSION
 COPY .coveragerc .coveragerc
 COPY docker/* /usr/local/bin/
 
+ENTRYPOINT ["/bin/sh", "-e", "/usr/local/bin/entrypoint.sh"]
+EXPOSE 8000
+
 RUN ENV=dev CONVERSION_HOST=localhost CAPTURE_HOST=localhost CUSTOM_SETTINGS_FILE= SECRET_KEY=tmp /opt/venv/bin/python ./manage.py compilemessages
 
-EXPOSE 8000
-ENTRYPOINT ["/bin/sh", "-e", "/usr/local/bin/entrypoint.sh"]
 CMD ["gunicorn", "geotrek.wsgi:application", "--bind=0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV CAPTURE_HOST="screamshotter"
 ENV CUSTOM_SETTINGS_FILE="/opt/geotrek-admin/var/conf/custom.py"
 
 WORKDIR /opt/geotrek-admin
+RUN mkdir -p /opt/geotrek-admin/var/log
 
 # Install postgis because raster2pgsl is required by manage.py loaddem
 RUN apt-get update -qq && apt-get install -y -qq  \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Minor improvements**
 
 - Disable debug log in debian package post installation script.
+- Improve and fix error logging, now errors and warnings are logged to var/geotrek.log and console.
 
 
 2.86.0 (2022-09-05)

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -838,7 +838,7 @@ with open(env_settings_file, 'r') as f:
 custom_settings_file = os.getenv('CUSTOM_SETTINGS_FILE')
 if custom_settings_file and 'tests' not in ENV:
     with open(custom_settings_file, 'r') as f:
-        print("Read custom configuration from {}".format(env_settings_file))
+        print("Read custom configuration from {}".format(custom_settings_file))
         exec(f.read())
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = MODELTRANSLATION_LANGUAGES[0]

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -696,7 +696,7 @@ CAPTURE_AUTOLOGIN_TOKEN = os.getenv('CAPTURE_AUTOLOGIN_TOKEN', None)
 # more details on how to customize your logging configuration.
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    'disable_existing_loggers': False,
     'filters': {
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'
@@ -708,49 +708,29 @@ LOGGING = {
         },
     },
     'handlers': {
+        'console': {
+            'level': 'ERROR',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
+        'log_file': {
+            'level': 'WARNING',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'formatter': 'simple',
+            'filename': os.path.join(VAR_DIR, 'log', 'geotrek.log'),
+            'when': 'midnight',
+            'backupCount': 30,
+        },
         'mail_admins': {
             'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'logging.NullHandler'
-        },
-        'console': {
-            'level': 'WARNING',
-            'class': 'logging.StreamHandler',
-            'formatter': 'simple'
+            'class': 'django.utils.log.AdminEmailHandler',
         },
     },
     'loggers': {
-        'django.db.backends': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'django.request': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'django': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'geotrek': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
-            'propagate': False,
-        },
-        'mapentity': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
-            'propagate': False,
-        },
         '': {
-            'handlers': ['console', 'mail_admins'],
-            'level': 'INFO',
-            'propagate': False,
+            'handlers': ['console'],
         },
-    }
+    },
 }
 
 BLADE_ENABLED = True

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -831,12 +831,14 @@ ENV = os.getenv('ENV', 'prod')
 assert ENV in ('prod', 'dev', 'tests', 'tests_nds')
 env_settings_file = os.path.join(os.path.dirname(__file__), 'env_{}.py'.format(ENV))
 with open(env_settings_file, 'r') as f:
+    print("Read env configuration from {}".format(env_settings_file))
     exec(f.read())
 
 # Override with custom settings
 custom_settings_file = os.getenv('CUSTOM_SETTINGS_FILE')
 if custom_settings_file and 'tests' not in ENV:
     with open(custom_settings_file, 'r') as f:
+        print("Read custom configuration from {}".format(env_settings_file))
         exec(f.read())
 
 MODELTRANSLATION_DEFAULT_LANGUAGE = MODELTRANSLATION_LANGUAGES[0]

--- a/geotrek/settings/env_dev.py
+++ b/geotrek/settings/env_dev.py
@@ -38,5 +38,4 @@ SYNC_RANDO_OPTIONS = {
     'url': 'http://geotrek.local:8000'  # Mandatory for dev mode. Must point to the same domain than SERVER_NAME in .env
 }
 
-LOGGING['loggers']['geotrek']['level'] = 'DEBUG'
 LOGGING['loggers']['']['level'] = 'DEBUG'

--- a/geotrek/settings/env_dev.py
+++ b/geotrek/settings/env_dev.py
@@ -9,7 +9,7 @@ import os
 # We change 'var/extra_locale' to 'geotrek/locale'
 
 if 'makemessages' in sys.argv:
-    LOCALE_PATHS = (os.path.join(PROJECT_DIR, 'locale'),)  # NoQA: F821
+    LOCALE_PATHS = (os.path.join(PROJECT_DIR, 'locale'),)
 
 DEBUG = True
 
@@ -23,22 +23,20 @@ INSTALLED_APPS = (
     'django_extensions',
     'debug_toolbar',
     'drf_yasg',
-) + INSTALLED_APPS  # NoQA: F821
+) + INSTALLED_APPS
 
 INTERNAL_IPS = type(str('c'), (), {'__contains__': lambda *a: True})()
 
 ALLOWED_HOSTS = ['*']
 
-MIDDLEWARE += (  # NoQA: F821
+MIDDLEWARE += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
-#
-# Use some default tiles
-# ..........................
 
-LOGGING['loggers']['geotrek']['level'] = 'DEBUG'  # NoQA: F821
-LOGGING['loggers']['']['level'] = 'DEBUG'  # NoQA: F821
 
 SYNC_RANDO_OPTIONS = {
     'url': 'http://geotrek.local:8000'  # Mandatory for dev mode. Must point to the same domain than SERVER_NAME in .env
 }
+
+LOGGING['loggers']['geotrek']['level'] = 'DEBUG'
+LOGGING['loggers']['']['level'] = 'DEBUG'

--- a/geotrek/settings/env_prod.py
+++ b/geotrek/settings/env_prod.py
@@ -12,10 +12,4 @@ CACHES['default']['BACKEND'] = 'django.core.cache.backends.memcached.MemcachedCa
 CACHES['default']['LOCATION'] = '{}:{}'.format(os.getenv('MEMCACHED_HOST', 'memcached'),
                                                os.getenv('MEMCACHED_PORT', '11211'))
 
-LOGGING['handlers']['mail_admins']['class'] = 'django.utils.log.AdminEmailHandler'
-LOGGING['handlers']['logfile'] = {'class': 'logging.FileHandler',
-                                  'formatter': 'simple',
-                                  'filename': os.path.join(VAR_DIR, 'log', 'geotrek.log')}
-
-LOGGING['loggers']['geotrek']['handlers'].append('logfile')
-LOGGING['loggers']['mapentity']['handlers'].append('logfile')
+LOGGING['loggers']['']['handlers'] = ('mail_admins', 'console', 'log_file')

--- a/geotrek/settings/env_tests.py
+++ b/geotrek/settings/env_tests.py
@@ -10,6 +10,8 @@ CELERY_ALWAYS_EAGER = True
 
 # TEST_EXCLUDE = ('django',)
 
+ALLOWED_HOSTS = ['localhost']
+
 INSTALLED_APPS += (
     'geotrek.diving',
     'geotrek.sensitivity',
@@ -17,7 +19,8 @@ INSTALLED_APPS += (
     'drf_yasg',
 )
 
-LOGGING['handlers']['console']['level'] = 'CRITICAL'
+LOGGING['loggers']['']['handlers'] = ('log_file', )
+LOGGING['handlers']['log_file']['level'] = 'INFO'
 
 LANGUAGE_CODE = 'en'
 MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'


### PR DESCRIPTION
L'idée c'est :
- ajout d'une rotation de var/log/geotrek/log quotidienne sur 30 jours,
- en prod : ERROR par mail et sur la console (logs docker ou systemd), WARNING dans les var/log/geotrek.log,
- en dev : INFO sur la console
- en test : INFO dans les logs, rien sur la console pour ne pas pourrir la sortie des tests

Je ne suis pas certain que ça soit parfait. N'hésitez pas à critiquer (et à proposer ;)