### PR TITLE
Do not save tmp topologies

### DIFF
--- a/geotrek/common/mixins.py
+++ b/geotrek/common/mixins.py
@@ -50,9 +50,17 @@ class TimeStampedModelMixin(models.Model):
     lastmod_verbose_name = _("Modification")
 
 
+class NoDeleteQuerySet(models.QuerySet):
+    def existing(self):
+        return self.filter(deleted=False)
+
+
 class NoDeleteManager(DefaultManager):
     # Use this manager when walking through FK/M2M relationships
     use_for_related_fields = True
+
+    def get_queryset(self):
+        return NoDeleteQuerySet(self.model, using=self._db)
 
     # Filter out deleted objects
     def existing(self):

--- a/geotrek/core/sql/post_20_topologies.sql
+++ b/geotrek/core/sql/post_20_topologies.sql
@@ -8,7 +8,6 @@ ALTER TABLE core_topology ALTER COLUMN geom_need_update SET DEFAULT FALSE;
 
 ALTER TABLE core_topology DROP CONSTRAINT IF EXISTS e_t_evenement_geom_not_empty;
 ALTER TABLE core_topology DROP CONSTRAINT IF EXISTS core_topology_geom_not_empty;
-ALTER TABLE core_topology ADD CONSTRAINT core_topology_geom_not_empty CHECK (deleted OR (geom IS NOT NULL));
 
 
 -------------------------------------------------------------------------------

--- a/geotrek/core/tests/test_path_split.py
+++ b/geotrek/core/tests/test_path_split.py
@@ -1118,6 +1118,7 @@ class SplitPathPointTopologyTest(TestCase):
         poi = Point(1, 3, srid=settings.SRID)
         poi.transform(settings.API_SRID)
         topology = Topology.deserialize({'lat': poi.y, 'lng': poi.x})
+        topology.save()
         aggr = topology.aggregations.all()[0]
         position = topology.geom.coords
 
@@ -1153,6 +1154,7 @@ class SplitPathPointTopologyTest(TestCase):
         poi = Point(7, 3, srid=settings.SRID)
         poi.transform(settings.API_SRID)
         topology = Topology.deserialize({'lat': poi.y, 'lng': poi.x})
+        topology.save()
         aggr = topology.aggregations.all()[0]
         position = topology.geom.coords
 

--- a/geotrek/core/tests/test_topology.py
+++ b/geotrek/core/tests/test_topology.py
@@ -97,7 +97,8 @@ class TopologyTest(TestCase):
         self.assertEqual(Path.include_invisible.count(), 2)
 
         # create topo on visible path
-        topology = Topology._topologypoint(0, 0, None).reload()
+        topology = Topology._topologypoint(0, 0, None)
+        topology.save()
 
         # because FK and M2M are used with default manager only, others tests are in SQL
         conn = connections[DEFAULT_DB_ALIAS]
@@ -120,7 +121,8 @@ class TopologyTest(TestCase):
         self.assertNotIn(path_unvisible.pk, [ele['id_path'] for ele in datas], "{}".format(datas))
 
         # new topo on invible path
-        topology = Topology._topologypoint(0, 3, None).reload()
+        topology = Topology._topologypoint(0, 3, None)
+        topology.save()
 
         cur.execute(
             """
@@ -240,13 +242,6 @@ class TopologyMutateTest(TestCase):
         topology1.mutate(topology2)
         self.assertEqual(topology1.offset, 14.5)
         self.assertEqual(len(topology1.paths.all()), 1)
-        # topology2 does not exist anymore
-        self.assertEqual(len(Topology.objects.filter(pk=topology2.pk)), 0)
-        # Without deletion
-        topology3 = TopologyFactory.create()
-        topology1.mutate(topology3, delete=False)
-        # topology3 still exists
-        self.assertEqual(len(Topology.objects.filter(pk=topology3.pk)), 1)
 
     def test_mutate_intersection(self):
         # Mutate a Point topology at an intersection, and make sure its aggregations
@@ -367,6 +362,7 @@ class TopologyPointTest(TestCase):
         poi = Point(10, 10, srid=settings.SRID)
         poi.transform(settings.API_SRID)
         poitopo = Topology.deserialize({'lat': poi.y, 'lng': poi.x})
+        poitopo.save()
         self.assertAlmostEqual(0.5, poitopo.aggregations.all()[0].start_position, places=6)
         self.assertAlmostEqual(10, poitopo.offset, places=6)
 
@@ -384,6 +380,7 @@ class TopologyPointTest(TestCase):
         poi = Point(0, 2.5, srid=settings.SRID)
         poi.transform(settings.API_SRID)
         poitopo = Topology.deserialize({'lat': poi.y, 'lng': poi.x})
+        poitopo.save()
         self.assertAlmostEqual(0.5, poitopo.aggregations.all()[0].start_position, places=6)
         self.assertAlmostEqual(0, poitopo.offset, places=6)
         self.assertAlmostEqual(0, poitopo.geom.x, places=6)
@@ -427,6 +424,7 @@ class TopologyPointTest(TestCase):
         self.assertEqual(1, len(Path.objects.all()))
 
         father = Topology.deserialize({'lat': -1, 'lng': -1})
+        father.save()
 
         poi = Point(500, 600, srid=settings.SRID)
         poi.transform(settings.API_SRID)

--- a/geotrek/core/widgets.py
+++ b/geotrek/core/widgets.py
@@ -10,8 +10,6 @@
 """
 import json
 
-from django.template import loader
-from django.conf import settings
 from mapentity.widgets import MapWidget
 
 from .models import Topology
@@ -81,22 +79,3 @@ class PointLineTopologyWidget(PointTopologyWidget, LineTopologyWidget):
     """ A widget allowing to point a position with a marker or a list of paths.
     """
     pass
-
-
-class TopologyReadonlyWidget(BaseTopologyWidget):
-    template_name = "mapentity/mapgeometry_fragment.html"
-
-    def render(self, name, value, attrs=None, renderer=None):
-        """
-        Completely bypass widget rendering, and just render a geometry.
-        """
-        topology = value
-        if isinstance(topology, (str, int)):
-            topology = self.deserialize(topology)
-        if topology:
-            geom = topology.geom
-            geom.transform(settings.API_SRID)
-        else:  # if form invalid
-            geom = None
-        context = {'object': geom, 'mapname': name}
-        return loader.render_to_string(self.template_name, context)

--- a/geotrek/maintenance/forms.py
+++ b/geotrek/maintenance/forms.py
@@ -11,7 +11,6 @@ from crispy_forms.layout import Fieldset, Layout, Div, HTML
 from geotrek.common.forms import CommonForm
 from geotrek.core.fields import TopologyField
 from geotrek.core.models import Topology
-from geotrek.core.widgets import TopologyReadonlyWidget
 
 from .models import Intervention, Project
 
@@ -142,8 +141,7 @@ class InterventionForm(CommonForm):
                     url=self.instance.target.get_detail_url()
             )
             # Topology is readonly
-            self.fields['topology'].required = False
-            self.fields['topology'].widget = TopologyReadonlyWidget()
+            del self.fields['topology']
 
         # Length is not editable in AltimetryMixin
         self.fields['length'].initial = self.instance.length
@@ -155,7 +153,7 @@ class InterventionForm(CommonForm):
         target = self.instance.target
         if not target.pk:
             target.save()
-        topology = self.cleaned_data.pop('topology')
+        topology = self.cleaned_data.get('topology')
         if topology and topology.pk != target.pk:
             target.mutate(topology)
         intervention = super().save(*args, **kwargs, commit=False)

--- a/geotrek/maintenance/tests/test_views.py
+++ b/geotrek/maintenance/tests/test_views.py
@@ -249,13 +249,11 @@ class InterventionViewsTest(CommonTest):
             infra = InfrastructureFactory.create()
         else:
             infra = InfrastructureFactory.create(geom='SRID=2154;POINT (700000 6600000)')
-        infrastr = "%s" % infra
 
         response = self.client.get('%s?target_id=%s&target_type=%s' % (Intervention.get_add_url(),
                                                                        infra.pk,
                                                                        ContentType.objects.get_for_model(Infrastructure).pk))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, infrastr)
         # Should be able to save form successfully
         data = self.get_good_data()
         response = self.client.post('%s?target_id=%s&target_type=%s' % (Intervention.get_add_url(),
@@ -271,13 +269,11 @@ class InterventionViewsTest(CommonTest):
             infra = InfrastructureFactory.create()
         else:
             infra = InfrastructureFactory.create(geom='SRID=2154;POINT (700000 6600000)')
-        infrastr = "%s" % infra
 
         response = self.client.get('%s?target_id=%s&target_type=%s' % (Intervention.get_add_url(),
                                                                        infra.pk,
                                                                        ContentType.objects.get_for_model(Infrastructure).pk))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, infrastr)
         data = self.get_good_data()
 
         # If form invalid, it should not fail
@@ -294,12 +290,10 @@ class InterventionViewsTest(CommonTest):
             infra = InfrastructureFactory.create()
         else:
             infra = InfrastructureFactory.create(geom='SRID=2154;POINT (700000 6600000)')
-        infrastr = "%s" % infra
 
         intervention = InterventionFactory.create(target=infra)
         response = self.client.get(intervention.get_update_url())
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, infrastr)
         # Should be able to save form successfully
         form = response.context['form']
         data = form.initial

--- a/geotrek/maintenance/tests/test_views.py
+++ b/geotrek/maintenance/tests/test_views.py
@@ -555,7 +555,8 @@ class ExportTest(TranslationResetMixin, TestCase):
         lng, lat = tuple(Point(1, 1, srid=settings.SRID).transform(settings.API_SRID, clone=True))
 
         closest_path = PathFactory(geom=LineString(Point(0, 0), Point(1, 0), srid=settings.SRID))
-        topo_point = Topology._topologypoint(lng, lat, None).reload()
+        topo_point = Topology._topologypoint(lng, lat, None)
+        topo_point.save()
 
         self.assertEqual(topo_point.paths.get(), closest_path)
 

--- a/geotrek/settings/env_tests.py
+++ b/geotrek/settings/env_tests.py
@@ -4,6 +4,8 @@
 
 TEST = True
 
+ALLOWED_HOSTS = ['localhost']
+
 CELERY_ALWAYS_EAGER = True
 
 TEST_EXCLUDE = ('django',)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ django-geojson==3.1.0
 django-js-asset==1.2.2
 git+https://github.com/chibisov/drf-extensions.git@19efac2ede0eef82aac4785d47a405454fb48225#egg=drf-extensions
 git+https://github.com/GeotrekCE/django-leaflet.git@0.19+geotrek8#egg=django-leaflet
+django-modelcluster==5.1
 django-modeltranslation==0.15.2
 django-mptt==0.11.0
 django-multiselectfield==0.1.12

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ class BuildCommand(distutils.command.build.build):
                 copy(path, os.path.join(curdir, self.build_lib, subdir, path))
             os.chdir(curdir)
 
+
 setup(
     name='geotrek',
     version=open(os.path.join(here, 'VERSION')).read().strip(),
@@ -50,6 +51,7 @@ setup(
         'django-weasyprint',
         'djangorestframework',
         'djangorestframework-gis',
+        'django-modelcluster',
         'easy-thumbnails',
         'lxml',
         'paperclip',


### PR DESCRIPTION
Now Topology.deserialize() (and thus TopologyField) does not create temporary topologies in database anymore. You are responsible to save the topology after deserialization if need be. This prevent dangling topologies in database that decrease performances.