### PR TITLE
Doc Swagger command

### DIFF
--- a/docs/advanced-configuration.rst
+++ b/docs/advanced-configuration.rst
@@ -231,7 +231,7 @@ https://launchpad.net/~ubuntugis/+archive/ubuntu/ppa
 Swagger
 -------
 
-In order to enable swagger module to auto-document API `/api/v2/`, in the custom settings file,
+In order to enable swagger module to auto-document API ``/api/v2/``, in the custom settings file,
 add the following code:
 
 .. code-block :: python
@@ -239,7 +239,7 @@ add the following code:
     # Enable API v2 documentation
     INSTALLED_APPS += ('drf_yasg', )
 
-Then run ``sudo geotrek restart``.
+Then run ``sudo dpkg-reconfigure -u geotrek-admin``.
 
 
 WYSIWYG editor configuration


### PR DESCRIPTION
Depuis la version 2.46.0, le Swagger permettant d'auto-documenter l'API V2 n'est plus activé par défaut. 
Il faut l'activer en ajoutant le module Swagger : https://geotrek.readthedocs.io/en/master/advanced-configuration.html#swagger

Après avoir ajouter la ligne indiquée dans le fichier de configuration, la documentation mentionne de lancer la commande ``sudo geotrek restart``.
Cette commande n'existe pas à priori mais est plutôt ``sudo service geotrek restart`` et ne suffit pas. Après son exécution le Swagger n'était pas accessible.
J'ai du lancer la commande ``sudo dpkg-reconfigure -u geotrek-admin`` pour que le Swagger soit accessible.