### PR TITLE
Fix projection of departure_geom attribute in API v2

### DIFF
--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -420,7 +420,10 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return get_translation_or_dict('departure', self, obj)
 
         def get_departure_geom(self, obj):
-            return obj.geom_3d[0][0] if isinstance(obj.geom_3d, MultiLineString) else obj.geom_3d[0]
+            geom = obj.geom3d_transformed
+            if isinstance(geom, MultiLineString):
+                geom = geom[0]
+            return geom[0][:2]
 
         def get_arrival(self, obj):
             return get_translation_or_dict('arrival', self, obj)


### PR DESCRIPTION
L'API doit causer en projection SPI_SRID (4326). De plus avoir l'altitude du point de départ est inutile. L'intérêt de l'attribut departure_geom est de pouvoir positionner le point de départ sur la carte (en 2D).