### PR TITLE
Avoid a db connection when requesting time from database

### DIFF
--- a/geotrek/common/utils/__init__.py
+++ b/geotrek/common/utils/__init__.py
@@ -44,9 +44,9 @@ class reify(object):
 
 
 def dbnow():
-    cursor = connection.cursor()
-    cursor.execute("SELECT statement_timestamp() AT TIME ZONE 'UTC';")
-    row = cursor.fetchone()
+    with connection._nodb_cursor() as cursor:
+        cursor.execute("SELECT statement_timestamp() AT TIME ZONE 'UTC';")
+        row = cursor.fetchone()
     return row[0].replace(tzinfo=utc)
 
 


### PR DESCRIPTION
Typically when running tests, this was querying the non-test database,
which might exist or not.