### PR TITLE
Fix API v2 zoning filter with postgis 2.4 (Ubuntu 18.04)

### DIFF
--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -154,6 +154,7 @@ class BaseApiTest(TestCase):
         trek_models.OrderedTrekChild(parent=cls.treks[0], child=cls.child2, order=3).save()
         cls.content = tourism_factory.TouristicContentFactory.create(published=True, geom='SRID=2154;POINT(0 0)')
         cls.city = zoning_factory.CityFactory(code='01000', geom='SRID=2154;MULTIPOLYGON(((-1 -1, -1 1, 1 1, 1 -1, -1 -1)))')
+        cls.city2 = zoning_factory.CityFactory(code='02000', geom='SRID=2154;MULTIPOLYGON(((199 199, 199 201, 201 201, 201 199, 199 199)))')
         cls.district = zoning_factory.DistrictFactory(id=420, geom='SRID=2154;MULTIPOLYGON(((-1 -1, -1 1, 1 1, 1 -1, -1 -1)))')
         cls.accessibility = trek_factory.AccessibilityFactory(id=4)
         cls.route = trek_factory.RouteFactory(id=680)
@@ -414,7 +415,7 @@ class APIAccessAnonymousTestCase(BaseApiTest):
         self.assertEqual(len(json_response.get('results')), 0)
 
     def test_trek_city(self):
-        response = self.get_trek_list({'cities': self.city.pk})
+        response = self.get_trek_list({'cities': '{},{}'.format(self.city.pk, self.city2.pk)})
         self.assertEqual(len(response.json()['results']), 16)
 
     def test_tour_list(self):

--- a/geotrek/api/v2/filters.py
+++ b/geotrek/api/v2/filters.py
@@ -3,7 +3,7 @@ import coreschema
 
 from coreapi.document import Field
 from django.conf import settings
-from django.contrib.gis.db.models import Collect
+from django.contrib.gis.db.models import Union
 from django.db.models.query_utils import Q
 from django.utils.translation import gettext as _
 from rest_framework.filters import BaseFilterBackend
@@ -220,11 +220,11 @@ class GeotrekTouristicContentFilter(BaseFilterBackend):
                 qs = qs.filter(Q(type2__in=types_id))
         cities = request.GET.get('cities')
         if cities:
-            cities_geom = City.objects.filter(code__in=cities.split(',')).aggregate(Collect('geom'))['geom__collect']
+            cities_geom = City.objects.filter(code__in=cities.split(',')).aggregate(Union('geom'))['geom__union']
             qs = qs.filter(geom__intersects=cities_geom) if cities_geom else qs.none()
         districts = request.GET.get('districts')
         if districts:
-            districts_geom = District.objects.filter(id__in=districts.split(',')).aggregate(Collect('geom'))['geom__collect']
+            districts_geom = District.objects.filter(id__in=districts.split(',')).aggregate(Union('geom'))['geom__union']
             qs = qs.filter(geom__intersects=districts_geom) if districts_geom else qs.none()
         structures = request.GET.get('structures')
         if structures:
@@ -322,11 +322,11 @@ class GeotrekTrekQueryParamsFilter(BaseFilterBackend):
             qs = qs.filter(ascent__lte=ascent_max)
         cities = request.GET.get('cities')
         if cities:
-            cities_geom = City.objects.filter(code__in=cities.split(',')).aggregate(Collect('geom'))['geom__collect']
+            cities_geom = City.objects.filter(code__in=cities.split(',')).aggregate(Union('geom'))['geom__union']
             qs = qs.filter(geom__intersects=cities_geom) if cities_geom else qs.none()
         districts = request.GET.get('districts')
         if districts:
-            districts_geom = District.objects.filter(id__in=districts.split(',')).aggregate(Collect('geom'))['geom__collect']
+            districts_geom = District.objects.filter(id__in=districts.split(',')).aggregate(Union('geom'))['geom__union']
             qs = qs.filter(geom__intersects=districts_geom) if districts_geom else qs.none()
         structures = request.GET.get('structures')
         if structures:


### PR DESCRIPTION
St_Intersects n'accepte les GeometryCollections qu'à partir de Postgis 2.4