### PR TITLE
Use upstream appy (now supports Python 3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amqp==2.5.2
-appy-python-3==2020.11.24
+appy==1.0.7
 beautifulsoup4==4.9.0
 billiard==3.6.3.0
 cairocffi==0.9.0
@@ -16,7 +16,7 @@ cssselect2==0.2.2
 defusedxml==0.6.0
 Django==3.1.*
 django-appconf==1.0.3
-django-appypod==2.0.6
+django-appypod==2.0.7
 django-celery-results==1.0.1
 django-colorfield==0.3.0
 django-compressor==2.4

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'BeautifulSoup4',
         'gpxpy',
         'django-appypod',
-        'appy-python-3',
         'django-compressor',
         'django-crispy-forms',
         'django-embed-video',


### PR DESCRIPTION
Le code de appy dont dépend django-appypod est sur https://forge.pallavi.be/projects/appy-python-3, ça ne change pas. Par contre, il n'était pas releasé sur Pypi donc on avait fait une release nous même sur https://pypi.org/project/appy-python-3/. Désormais, Appy compatible python 3 est releasé par le mainteneur sur https://pypi.org/project/appy/

Pour bien faire il faudrait supprimer https://pypi.org/project/appy-python-3/. En principe les installations packagées (Ubuntu ou Docker) devraient continuer à fonctionner. Par contre, ça va casser les vieux ./install.sh mais je ne sais pas si il en reste.