### PR TITLE
Fix mocking of requests in EspritParcParser tests

### DIFF
--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -512,7 +512,7 @@ class EspritParcParser(AttachmentParserMixin, Parser):
         for subval in val or []:
             if 'url' in subval:
                 result.append((subval['url'],
-                               subval.get('legend', None),
+                               subval.get('legende', None),
                                subval.get('credits', None)))
         return result
 

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -87,6 +87,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Type B")
         with self.assertRaises(CommandError):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
+        self.assertTrue(mocked.called)
 
     @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_espritparc_failed(self, mocked):
@@ -102,6 +103,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType2Factory(label="Agriculture biologique", category=category)
         with self.assertRaises(CommandError):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
+        self.assertTrue(mocked.called)
+
 
     @mock.patch('geotrek.common.parsers.requests.get')
     @override_settings(PARSER_RETRY_SLEEP_TIME=0)
@@ -129,6 +132,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Type A")
         TouristicContentType1Factory(label="Type B")
         call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser')
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
 
     @mock.patch('geotrek.common.parsers.requests.get')
@@ -153,6 +157,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Type B")
         with self.assertRaisesRegex(CommandError, "Failed to download %s. HTTP status code 503" % EauViveParser.url):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser')
+            self.assertTrue(mocked.called)
 
     @mock.patch('geotrek.common.parsers.requests.get')
     @mock.patch('geotrek.common.parsers.requests.head')
@@ -177,6 +182,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType2Factory(label="Agriculture biologique", category=category)
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.tests.test_parsers.EspritParc', filename, verbosity=2, stdout=output)
+        self.assertTrue(mocked_get.called)
+        self.assertTrue(mocked_head.called)
         self.assertIn("Type 1 'Miel' does not exist for category 'Miels et produits de la ruche'. Please add it,",
                       output.getvalue())
 
@@ -204,6 +211,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Cire", category=category)
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.tests.test_parsers.EspritParc', filename, verbosity=2, stdout=output)
+        self.assertTrue(mocked_get.called)
+        self.assertTrue(mocked_head.called)
         self.assertIn("Type 2 'Bienvenue à la ferme' does not exist for category 'Miels et produits de la ruche'. Please add it",
                       output.getvalue())
 
@@ -221,6 +230,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Type A")
         TouristicContentType1Factory(label="Type B")
         call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=0)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
         content = TouristicContent.objects.get()
         self.assertEqual(content.eid, "479743")
@@ -262,6 +272,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType1Factory(label="Type A")
         TouristicContentType1Factory(label="Type B")
         call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=0)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
 
     @mock.patch('geotrek.common.parsers.requests.get')
@@ -276,6 +287,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         FileType.objects.create(type="Photographie")
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.parsers.TouristicEventApidaeParser', verbosity=2, stdout=output)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicEvent.objects.count(), 0)
 
     @mock.patch('geotrek.common.parsers.requests.get')
@@ -291,6 +303,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(TouristicEvent.objects.count(), 0)
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.parsers.TouristicEventApidaeParser', verbosity=2, stdout=output)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicEvent.objects.count(), 1)
         event = TouristicEvent.objects.get()
         self.assertEqual(event.eid, "323154")
@@ -336,6 +349,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.tests.test_parsers.ApidaeConstantFieldEventParser', verbosity=2,
                      stdout=output)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicEvent.objects.count(), 1)
         event = TouristicEvent.objects.get()
         self.assertEqual(str(event.type), "Constant Event")
@@ -361,6 +375,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         output = io.StringIO()
         call_command('import', 'geotrek.tourism.tests.test_parsers.ApidaeConstantFieldContentParser', verbosity=2,
                      stdout=output)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
         content = TouristicContent.objects.get()
         self.assertEqual(str(content.category), "Constant Content")
@@ -396,6 +411,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         TouristicContentType2Factory(label="Bienvenue à la ferme", category=category)
         TouristicContentType2Factory(label="Agriculture biologique", category=category)
         call_command('import', 'geotrek.tourism.tests.test_parsers.EspritParc', filename, verbosity=0)
+        self.assertTrue(mocked_get.called)
+        self.assertTrue(mocked_head.called)
         self.assertEqual(TouristicContent.objects.count(), 24)
         content = TouristicContent.objects.all()
         eid = [
@@ -430,6 +447,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         source = RecordSourceFactory(name="CDT 28")
         portal = TargetPortalFactory(name="Itinérance")
         call_command('import', 'geotrek.tourism.tests.test_parsers.HOT28', verbosity=0)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
         content = TouristicContent.objects.get()
         self.assertEqual(content.eid, "HOTCEN0280010001")
@@ -467,6 +485,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         source = RecordSourceFactory(name="CDT 28")
         portal = TargetPortalFactory(name="Itinérance")
         call_command('import', 'geotrek.tourism.tests.test_parsers.HOT28v3', verbosity=0)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicContent.objects.count(), 1)
         content = TouristicContent.objects.get()
         self.assertEqual(content.eid, "HOTCEN0280010001")
@@ -504,6 +523,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         source = RecordSourceFactory(name="CDT 28")
         portal = TargetPortalFactory(name="Itinérance")
         call_command('import', 'geotrek.tourism.tests.test_parsers.FMA28', verbosity=0)
+        self.assertTrue(mocked.called)
         self.assertEqual(TouristicEvent.objects.count(), 1)
         event = TouristicEvent.objects.get()
         self.assertEqual(event.eid, "FMACEN0280060359")

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -78,7 +78,7 @@ class FMA28(TouristicEventTourInSoftParser):
 
 
 class ParserTests(TranslationResetMixin, TestCase):
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_apidae_failed(self, mocked):
         mocked.return_value.status_code = 404
         FileType.objects.create(type="Photographie")
@@ -88,7 +88,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         with self.assertRaises(CommandError):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_espritparc_failed(self, mocked):
         mocked.return_value.status_code = 404
         FileType.objects.create(type="Photographie")
@@ -103,7 +103,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         with self.assertRaises(CommandError):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     @override_settings(PARSER_RETRY_SLEEP_TIME=0)
     @mock.patch('geotrek.common.parsers.AttachmentParserMixin.download_attachments', False)
     def test_create_content_espritparc_retry(self, mocked):
@@ -131,7 +131,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser')
         self.assertEqual(TouristicContent.objects.count(), 1)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     @override_settings(PARSER_RETRY_SLEEP_TIME=0)
     def test_create_content_espritparc_retry_fail(self, mocked):
         def mocked_json():
@@ -154,8 +154,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         with self.assertRaisesRegex(CommandError, "Failed to download %s. HTTP status code 503" % EauViveParser.url):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser')
 
-    @mock.patch('requests.get')
-    @mock.patch('requests.head')
+    @mock.patch('geotrek.common.parsers.requests.get')
+    @mock.patch('geotrek.common.parsers.requests.head')
     def test_create_content_espritparc_not_fail_type1_does_not_exist(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
@@ -180,8 +180,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertIn("Type 1 'Miel' does not exist for category 'Miels et produits de la ruche'. Please add it,",
                       output.getvalue())
 
-    @mock.patch('requests.get')
-    @mock.patch('requests.head')
+    @mock.patch('geotrek.common.parsers.requests.get')
+    @mock.patch('geotrek.common.parsers.requests.head')
     def test_create_content_espritparc_not_fail_type2_does_not_exist(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
@@ -207,7 +207,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertIn("Type 2 'Bienvenue à la ferme' does not exist for category 'Miels et produits de la ruche'. Please add it",
                       output.getvalue())
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_apidae(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeContent.json')
@@ -247,7 +247,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(Attachment.objects.count(), 3)
         self.assertEqual(Attachment.objects.first().content_object, content)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_filetype_structure_none(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeContent.json')
@@ -264,7 +264,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=0)
         self.assertEqual(TouristicContent.objects.count(), 1)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_no_event_apidae(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeNoEvent.json')
@@ -278,7 +278,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         call_command('import', 'geotrek.tourism.parsers.TouristicEventApidaeParser', verbosity=2, stdout=output)
         self.assertEqual(TouristicEvent.objects.count(), 0)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_event_apidae(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeEvent.json')
@@ -318,7 +318,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         )
         self.assertEqual(Attachment.objects.count(), 3)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_event_apidae_constant_fields(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeEvent.json')
@@ -343,7 +343,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertQuerysetEqual(event.source.all(), ["Source 1", "Source 2"], transform=str)
         self.assertQuerysetEqual(event.portal.all(), ["Portal 1", "Portal 2"], transform=str)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_apidae_constant_fields(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'apidaeContent.json')
@@ -370,8 +370,8 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertQuerysetEqual(content.source.all(), ["Source 1", "Source 2"], transform=str)
         self.assertQuerysetEqual(content.portal.all(), ["Portal 1", "Portal 2"], transform=str)
 
-    @mock.patch('requests.get')
-    @mock.patch('requests.head')
+    @mock.patch('geotrek.common.parsers.requests.get')
+    @mock.patch('geotrek.common.parsers.requests.head')
     def test_create_esprit(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
@@ -416,7 +416,7 @@ class ParserTests(TranslationResetMixin, TestCase):
             self.assertIn(one.name.lower(), name)
             self.assertEqual(one.category, category)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_tourinsoft_v2(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'tourinsoftContent.json')
@@ -453,7 +453,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(Attachment.objects.count(), 3)
         self.assertEqual(Attachment.objects.first().content_object, content)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_content_tourinsoft_v3(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'tourinsoftContentV3.json')
@@ -490,7 +490,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(Attachment.objects.count(), 3)
         self.assertEqual(Attachment.objects.first().content_object, content)
 
-    @mock.patch('requests.get')
+    @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_event_tourinsoft(self, mocked):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'tourinsoftEvent.json')

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -169,8 +169,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         mocked_get.return_value.content = b'Fake image'
         # Mock HEAD
         mocked_head.return_value.status_code = 200
-        mocked_head.return_value.json = mocked_json
-        mocked_head.return_value.content = b'Fake image'
+        mocked_head.return_value.headers = {'content-length': 666}
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType2Factory(label="Hautes Alpes Naturellement", category=category)
@@ -196,8 +195,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         mocked_get.return_value.content = b'Fake image'
         # Mock HEAD
         mocked_head.return_value.status_code = 200
-        mocked_head.return_value.json = mocked_json
-        mocked_head.return_value.content = b'Fake image'
+        mocked_head.return_value.headers = {'content-length': 666}
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType1Factory(label="Miel", category=category)
@@ -387,8 +385,7 @@ class ParserTests(TranslationResetMixin, TestCase):
         mocked_get.return_value.content = b'Fake image'
         # Mock HEAD
         mocked_head.return_value.status_code = 200
-        mocked_head.return_value.json = mocked_json
-        mocked_head.return_value.content = b'Fake image'
+        mocked_head.return_value.headers = {'content-length': 666}
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType1Factory(label="Miel", category=category)

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -105,7 +105,6 @@ class ParserTests(TranslationResetMixin, TestCase):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser', verbosity=2)
         self.assertTrue(mocked.called)
 
-
     @mock.patch('geotrek.common.parsers.requests.get')
     @override_settings(PARSER_RETRY_SLEEP_TIME=0)
     @mock.patch('geotrek.common.parsers.AttachmentParserMixin.download_attachments', False)

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -155,16 +155,22 @@ class ParserTests(TranslationResetMixin, TestCase):
             call_command('import', 'geotrek.tourism.tests.test_parsers.EauViveParser')
 
     @mock.patch('requests.get')
-    def test_create_content_espritparc_not_fail_type1_does_not_exist(self, mocked):
+    @mock.patch('requests.head')
+    def test_create_content_espritparc_not_fail_type1_does_not_exist(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
             with open(filename, 'r') as f:
                 return json.load(f)
 
         filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
-        mocked.return_value.status_code = 200
-        mocked.return_value.json = mocked_json
-        mocked.return_value.content = b'Fake image'
+        # Mock GET
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.json = mocked_json
+        mocked_get.return_value.content = b'Fake image'
+        # Mock HEAD
+        mocked_head.return_value.status_code = 200
+        mocked_head.return_value.json = mocked_json
+        mocked_head.return_value.content = b'Fake image'
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType2Factory(label="Hautes Alpes Naturellement", category=category)
@@ -176,16 +182,22 @@ class ParserTests(TranslationResetMixin, TestCase):
                       output.getvalue())
 
     @mock.patch('requests.get')
-    def test_create_content_espritparc_not_fail_type2_does_not_exist(self, mocked):
+    @mock.patch('requests.head')
+    def test_create_content_espritparc_not_fail_type2_does_not_exist(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
             with open(filename, 'r') as f:
                 return json.load(f)
 
         filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
-        mocked.return_value.status_code = 200
-        mocked.return_value.json = mocked_json
-        mocked.return_value.content = b'Fake image'
+        # Mock GET
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.json = mocked_json
+        mocked_get.return_value.content = b'Fake image'
+        # Mock HEAD
+        mocked_head.return_value.status_code = 200
+        mocked_head.return_value.json = mocked_json
+        mocked_head.return_value.content = b'Fake image'
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType1Factory(label="Miel", category=category)
@@ -361,16 +373,22 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertQuerysetEqual(content.portal.all(), ["Portal 1", "Portal 2"], transform=str)
 
     @mock.patch('requests.get')
-    def test_create_esprit(self, mocked):
+    @mock.patch('requests.head')
+    def test_create_esprit(self, mocked_head, mocked_get):
         def mocked_json():
             filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
             with open(filename, 'r') as f:
                 return json.load(f)
 
         filename = os.path.join(os.path.dirname(__file__), 'data', 'espritparc.json')
-        mocked.return_value.status_code = 200
-        mocked.return_value.json = mocked_json
-        mocked.return_value.content = b'Fake image'
+        # Mock GET
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.json = mocked_json
+        mocked_get.return_value.content = b'Fake image'
+        # Mock HEAD
+        mocked_head.return_value.status_code = 200
+        mocked_head.return_value.json = mocked_json
+        mocked_head.return_value.content = b'Fake image'
         FileType.objects.create(type="Photographie")
         category = TouristicContentCategoryFactory(label="Miels et produits de la ruche")
         TouristicContentType1Factory(label="Miel", category=category)


### PR DESCRIPTION
Add missing mock for [this HEAD request ](https://github.com/GeotrekCE/Geotrek-admin/blob/97f5d823862c82f6795798744f045054112ddce1/geotrek/common/parsers.py#L597)on attachments' URLs