### PR TITLE
Fixes on bootstrap4 upgrade

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,9 +7,10 @@ CHANGELOG
 
 **Bug fixes**
 
-- Fix confirm delete attachment modal
+- Fix confirm delete attachment modal not visible
 - Fix required '*geom' position
 - Fix scroll unwanted when list is full
+- Fix responsive on dataTable
 
 2.59.0 (2021-06-07)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,8 +7,9 @@ CHANGELOG
 
 **Bug fixes**
 
--
-
+- Fix confirm delete attachment modal
+- Fix required '*geom' position
+- Fix scroll unwanted when list is full
 
 2.59.0 (2021-06-07)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,11 @@ CHANGELOG
 - Fix confirm delete attachment modal not visible
 - Fix required '*geom' position
 - Fix scroll unwanted when list is full
-- Fix responsive on dataTable
+- Fix responsive on dataTables
+
+**Maintenance**
+
+- Update to django-mapentity 2.3.2
 
 2.59.0 (2021-06-07)
 -------------------

--- a/geotrek/core/templates/core/path_list.html
+++ b/geotrek/core/templates/core/path_list.html
@@ -118,7 +118,7 @@
       <div class="modal-body">
         <h4></h4>
       </div>
-      <div class="modal-footer">test
+      <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">
           {% trans "Cancel" %}
         </button>

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -1,9 +1,6 @@
 
 /***** Bootstrap customizations ******/
-/* Override bad order in modal from paperclip */
-.modal-header .close {
-    order: 2;
-}
+
 .dropdown-menu {
     z-index: 9999;
 }

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -143,6 +143,12 @@ select[multiple] {
 .list-container {
     height: calc(100vh - 65px);
 }
+@media (max-width: 767px) {
+    .map-panel {
+        height: 350px;
+    }
+}
+
 #panelleft {
     padding-left: 0;
 }
@@ -297,19 +303,11 @@ tr.selected-row td {
 /***** Entity List ******/
 
 #list-panel {
-    padding: 4px;
+    padding: 4px 0;
     height: calc(100vh - 65px);
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-}
-
-@media (max-height: 960px) {
-    #list-panel {
-        width: calc(100% - 44px);
-        height: auto;
-        min-height: 350px;
-    }
 }
 
 #list-panel .list-title {

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -305,10 +305,16 @@ tr.selected-row td {
 
 #list-panel {
     padding-left: 10px;
-    height: calc(100vh - 65px);
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+}
+
+@media (min-width: 768px) {
+    #list-panel {
+        padding-left: 10px;
+        height: calc(100vh - 65px);
+    }
 }
 
 #list-panel .list-title {
@@ -381,9 +387,20 @@ tr.selected-row td {
 
 /* Datatables customization for filters and pagination */
 
+.table-responsive {
+    height: 350px;
+    display: flex;
+    flex-direction: column;
+}
+@media (min-width: 768px) {
+    .table-responsive {
+        flex-grow: 1;
+    }
+}
 .dataTables_wrapper {
     flex-grow: 1;
 }
+
 div.dataTables_wrapper div.dataTables_paginate {
     float: right;
 }

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -1,5 +1,6 @@
 
 /***** Bootstrap customizations ******/
+/* Override bad order in modal from paperclip */
 .modal-header .close {
     order: 2;
 }

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -303,7 +303,7 @@ tr.selected-row td {
 /***** Entity List ******/
 
 #list-panel {
-    padding: 4px 0;
+    padding-left: 10px;
     height: calc(100vh - 65px);
     flex-grow: 1;
     display: flex;

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -1,6 +1,8 @@
 
 /***** Bootstrap customizations ******/
-
+.modal-header .close {
+    order: 2;
+}
 .dropdown-menu {
     z-index: 9999;
 }

--- a/mapentity/static/mapentity/style.css
+++ b/mapentity/static/mapentity/style.css
@@ -833,7 +833,7 @@ TODO: please help;
     padding: 5px;
     border-radius: 5px;
     top: 9px;
-    left: 48px;
+    left: 75px;
     width: auto;
 }
 

--- a/mapentity/templates/mapentity/base.html
+++ b/mapentity/templates/mapentity/base.html
@@ -111,7 +111,7 @@
           <script type="text/javascript" src="{% static 'mapentity/vendor/bootstrap-datepicker-1.9.0/js/bootstrap-datepicker.min.js' %}"></script>
         {% endif %}
         <script src="{% static 'mapentity/jquery.hoverIntent.js' %}"></script>
-        <script src="{% static 'paperclip/bootstrap-3-confirm.js' %}"></script>
+        <script src="{% static 'paperclip/bootstrap-4-confirm.js' %}"></script>
         {% for lang in LANGUAGES %}
             {% if lang.0 != 'en' %}<script type="text/javascript" src="{% get_static_prefix %}mapentity/vendor/bootstrap-datepicker-1.9.0/locales/bootstrap-datepicker.{{ lang.0 }}.min.js"  charset="UTF-8"></script>{% endif %}
         {% endfor %}

--- a/mapentity/templates/mapentity/base.html
+++ b/mapentity/templates/mapentity/base.html
@@ -111,7 +111,7 @@
           <script type="text/javascript" src="{% static 'mapentity/vendor/bootstrap-datepicker-1.9.0/js/bootstrap-datepicker.min.js' %}"></script>
         {% endif %}
         <script src="{% static 'mapentity/jquery.hoverIntent.js' %}"></script>
-        <script src="{% static 'paperclip/bootstrap-confirm.js' %}"></script>
+        <script src="{% static 'paperclip/bootstrap-3-confirm.js' %}"></script>
         {% for lang in LANGUAGES %}
             {% if lang.0 != 'en' %}<script type="text/javascript" src="{% get_static_prefix %}mapentity/vendor/bootstrap-datepicker-1.9.0/locales/bootstrap-datepicker.{{ lang.0 }}.min.js"  charset="UTF-8"></script>{% endif %}
         {% endfor %}

--- a/mapentity/templates/mapentity/base.html
+++ b/mapentity/templates/mapentity/base.html
@@ -12,7 +12,7 @@
 
   {% compress css %}
     {% if DEBUG %}
-        <link rel="stylesheet" href="{% static 'mapentity/vendor/bootstrap-4.6.0/css/bootstrap.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'mapentity/vendor/bootstrap-4.6.0/css/bootstrap.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'mapentity/vendor/DataTables-1.10.23/css/dataTables.bootstrap4.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'mapentity/vendor/bootstrap-datepicker-1.9.0/css/bootstrap-datepicker.css' %}">
     {% else %}

--- a/mapentity/templates/mapentity/mapentity_list.html
+++ b/mapentity/templates/mapentity/mapentity_list.html
@@ -49,6 +49,8 @@
         </div>
 
         {% block mainlist %}
+        <div class="table-responsive">
+
         <table id="objects-list" class="table table-striped table-bordered">
           <thead>
           <tr>
@@ -60,6 +62,7 @@
           <tbody>
           </tbody>
         </table>
+        </div>
 
         <div id="list-download-toolbar">
           <div class="btn-group {% if not can_export %}disabled{% endif %}">

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ mbutil==0.3.0
 mccabe==0.6.1
 netifaces==0.10.9
 openapi-codec==1.3.2
-paperclip==2.2.6
+paperclip==2.3.2
 Pillow==8.1.1  --no-binary Pillow
 psycopg2==2.8.6 --no-binary psycopg2
 public==2019.4.13


### PR DESCRIPTION
- Fix confirm delete attachment modal

    - Update to django-mapentity 2.3.2
    - Use bootstrap-4-confirm.js to have correct markup
    - Override modal close position in modal-header : in Paperclip a `bootstrap-4-confirm.js` must be added with correct markup

- Fix required '*geom' position
- Fix scroll unwanted when list is full 
- Fix responsive on dataTables