### PR TITLE
Fix generation altimetry profile

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ CHANGELOG
 **Bug fixes**
 
 - Database: fix sql cleanup that delete foreign key on core_pathaggregation.path_id -> core_path.id. (#2819)
+- Fix generation altimetry profile (dem.json)
 
 
 2.71.0 (2021-11-03)

--- a/geotrek/altimetry/helpers.py
+++ b/geotrek/altimetry/helpers.py
@@ -153,13 +153,13 @@ class AltimetryHelper:
                          (SELECT COUNT(y) AS y FROM lines)   AS lin
                 ),
                 points2d AS (
-                    SELECT row_number() OVER () AS id,
+                    SELECT row_number() OVER (ORDER BY lines.y, columns.x) AS id,
                            ST_SetSRID(ST_MakePoint(x, y), {srid}) AS geom,
                            ST_Transform(ST_SetSRID(ST_MakePoint(x, y), {srid}), 4326) AS geomll
-                    FROM lines, columns
+                    FROM columns, lines
                 ),
                 draped AS (
-                    SELECT id, ST_Value(altimetry_dem.rast, p.geom)::int AS altitude
+                    SELECT id, CASE WHEN ST_Value(altimetry_dem.rast, p.geom)::int = -99999 THEN 0 ELSE ST_Value(altimetry_dem.rast, p.geom)::int END AS altitude
                     FROM altimetry_dem, points2d AS p
                     WHERE ST_Intersects(altimetry_dem.rast, p.geom)
                 ),


### PR DESCRIPTION
Issue with the generation of altimetry profiles :
![Capture_d_écran_de_2021-11-02_09-39-42](https://user-images.githubusercontent.com/26329336/140774355-4c18ba35-d2af-42f0-82d8-79af6b77ab62.png)
The generation used a matrix to get every altimetry for each points on the area every x meters.
The problem was related to the way we crossed the array before generate the points. We can cross the array, firstly increasing x then y or the opposite. 

After that we create a matrix of all elevations, but the matrix is not the same depending on the first array :

2 differents array order:

1.  [[x0, y0], [x0, y1], [x0, y2], [x1, y0], [x1, y1], [x1, y2]] 
2.  [[x0, y0], [x1, y0], [x0, y1], [x1, y1], [x0, y2], [x1, y2]]

- x0,y0 = z0
- x0, y1 = z1
- x0, y2 = z2
- x1, y0 = z3
- x1, y1 = z4
- x1, y2 = z5

Generate an array of elevations depending on the length of all Xs (2)
 1. [[z0, z1], [z2, z3], [z4, z5]]
 2. [[z0, z3], [z1, z4], [z2, z5]]
 
 We had to order the query to get all the time the same result.