### PR TITLE
Fix a template break in mapentity

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ CHANGELOG
 2.74.0+dev (XXXX-XX-XX)
 -----------------------
 
+**Bug fixes**
+
+- Fix blank line due to mapentity template error
+
+**Maintenance**
+
+- Update to mapentity 7.0.5
+
 
 2.74.0     (2021-12-17)
 -----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,7 +183,7 @@ landez==2.5.0
     # via geotrek (setup.py)
 lxml==4.7.1
     # via mapentity
-mapentity==7.0.4
+mapentity==7.0.5
     # via geotrek (setup.py)
 markupsafe==1.1.1
     # via jinja2

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     scripts=['manage.py'],
     install_requires=[
         'Django==3.1.*',
-        'mapentity==7.0.4',
+        'mapentity==7.0.5',
         'env_file',
         # pinned by requirements.txt
         'python-memcached',


### PR DESCRIPTION
Chevron en haut à gauche de la page de login (présent sur le template de base mapentity):

![Capture d’écran du 2021-12-21 11-25-20](https://user-images.githubusercontent.com/7448208/146921374-af2918e3-39f3-45ed-9b66-b8bb55ae590b.png)

Provoque un espace blanc supplémentaire sous le header et des barres de défilement en trop :

![Capture d’écran du 2021-12-21 10-59-59](https://user-images.githubusercontent.com/7448208/146920994-f57ebadf-1e21-461f-b9d6-7117e5242627.png)
au lieu de :
![Capture d’écran du 2021-12-21 11-00-24](https://user-images.githubusercontent.com/7448208/146921018-620b5eee-225f-4051-9e39-8de060734680.png)

Ce décalage peut influer sur les captures de carte et la génération des PDF
