### PR TITLE
Fix bootstrap messages (XMas PR 🎅)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.74.1+dev (XXXX-XX-XX)
 -----------------------
 
+**Bug fixes**
+
+- Fix bootstrap theme in warning and error messages or alerts
+
 
 2.74.1     (2021-12-21)
 -----------------------

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -582,8 +582,8 @@ MESSAGE_TAGS = {
     messages.SUCCESS: 'alert-success',
     messages.INFO: 'alert-info',
     messages.DEBUG: 'alert-info',
-    messages.WARNING: 'alert-error',
-    messages.ERROR: 'alert-error',
+    messages.WARNING: 'alert-warning',
+    messages.ERROR: 'alert-danger',
 }
 
 CACHE_TIMEOUT_LAND_LAYERS = 60 * 60 * 24


### PR DESCRIPTION
Fix conf to use right bootstrap tags in alert and messages in geotrek / mapentity.

![Capture d’écran du 2021-12-24 16-10-40](https://user-images.githubusercontent.com/7448208/147361283-5838151f-0f0a-4be5-8c3d-4dce2c55e659.png)

Transparent background will be replaced by yellow for warning and light red for errors