### PR TITLE
Implement workflow - Solve report, with tests

### DIFF
--- a/geotrek/feedback/fixtures/management_workflow.json
+++ b/geotrek/feedback/fixtures/management_workflow.json
@@ -34,5 +34,14 @@
             "label_fr": "Intervention termin\u00e9e",
             "suricate_id": "intervention_solved"
         }
+    },
+    {
+        "model": "feedback.reportstatus",
+        "fields": {
+            "label": "R\u00e9solu",
+            "label_en": "Resolved",
+            "label_fr": "R\u00e9solu",
+            "suricate_id": "resolved"
+        }
     }
 ]

--- a/geotrek/feedback/forms.py
+++ b/geotrek/feedback/forms.py
@@ -7,13 +7,18 @@ from geotrek.common.forms import CommonForm
 
 from .models import Report, ReportStatus, TimerEvent
 
-# This dict stores status order in management workflow
+# This dict stores constraints for status changes in management workflow
 # {'current_status': ['allowed_next_status', 'other_allowed_status']}
+# Empty status should not be changed from this form
 SURICATE_MANAGEMENT_WORKFLOW = {
-    'filed': ['classified', 'filed'],
-    'classified': ['classified'],
-    'waiting': ['waiting', 'filed'],
-    'programmed': ['waiting', 'filed']
+    'filed': ['classified'],
+    'classified': [],
+    'waiting': [],
+    'programmed': [],
+    'resolution_late': [],
+    'intervention_late': [],
+    'intervention_solved': ['resolved'],
+    'resolved': []
 }
 
 
@@ -94,4 +99,6 @@ class ReportForm(CommonForm):
             if 'status' in self.changed_data or 'assigned_user' in self.changed_data:
                 msg = self.cleaned_data.get('message', "")
                 report.send_notifications_on_status_change(self.old_status_id, msg)
+            if 'status' in self.changed_data and self.old_status_id == 'intervention_solved':
+                report.unlock_in_suricate()
         return report

--- a/geotrek/feedback/helpers.py
+++ b/geotrek/feedback/helpers.py
@@ -53,18 +53,18 @@ class SuricateRequestManager:
         # Include alert ID in check when needed
         if "uid_alerte" in url_params:
             id_alert = str(url_params["uid_alerte"])
-            check = f"&check={md5((self.PRIVATE_KEY_CLIENT_SERVER + id_alert + self.ID_ORIGIN).encode()).hexdigest()}"
+            check = f"&check={md5((self.PRIVATE_KEY_CLIENT_SERVER + self.ID_ORIGIN + id_alert).encode()).hexdigest()}"
         else:
             check = self.CHECK_CLIENT
         # If HTTP Auth required, add to request
         if self.USE_AUTH:
             response = requests.get(
-                f"{self.URL}{endpoint}{origin_param}{extra_url_params}{check}",
+                f"{self.URL}{endpoint}{origin_param}&{extra_url_params}{check}",
                 auth=self.AUTH,
             )
         else:
             response = requests.get(
-                f"{self.URL}{endpoint}{origin_param}{extra_url_params}{check}",
+                f"{self.URL}{endpoint}{origin_param}&{extra_url_params}{check}",
             )
         return response
 

--- a/geotrek/feedback/models.py
+++ b/geotrek/feedback/models.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 
 # This dict stores status changes that send an email and an API request
 NOTIFY_SURICATE_AND_SENTINEL = {
-    'filed': ['classified', 'waiting']
+    'filed': ['classified', 'waiting'],
+    'intervention_solved': ['resolved']
 }
 
 STATUS_WHEN_REPORT_IS_LATE = {
@@ -199,8 +200,7 @@ class Report(MapEntityMixin, PicturesMixin, TimeStampedModelMixin, NoDeleteMixin
                 SuricateMessenger().post_report(self)
             else:  # This new report comes from Suricate : save
                 super().save(*args, **kwargs)
-        else:  # This is an update
-            # TODO We'll need to implement some of the workflow here Todo do we need to remove this
+        else:  # Report updates should do nothing more
             super().save(*args, **kwargs)
 
     def notify_assigned_user(self):

--- a/geotrek/feedback/tests/test_suricate_sync.py
+++ b/geotrek/feedback/tests/test_suricate_sync.py
@@ -72,7 +72,7 @@ class SuricateTests(TestCase):
             elif "GetAlerts" in url:
                 mock_response.content = mocked_json("suricate_alerts.json")
                 mock_response.status_code = 200
-            elif "wsLockAlert" in url:
+            elif "wsLockAlert" in url or "wsUnlockAlert" in url:
                 mock_response.content = mocked_json("suricate_positive.json")
                 mock_response.status_code = 200
             elif cause_JPG_error:
@@ -403,6 +403,7 @@ class SuricateWorkflowTests(SuricateTests):
         cls.intervention_late_status = ReportStatusFactory(suricate_id='intervention_late', label="Intervention en retard")
         cls.resolution_late_status = ReportStatusFactory(suricate_id='resolution_late', label="Resolution en retard")
         cls.intervention_solved_status = ReportStatusFactory(suricate_id='intervention_solved', label="Intervention terminée")
+        cls.resolved_status = ReportStatusFactory(suricate_id='resolved', label="Résolu")
         cls.report = ReportFactory(status=cls.filed_status, uid=uuid.uuid4())
         cls.admin = SuperUserFactory(username="Admiin", password="drowssap")
         cls.user = UserFactory(username="Maxou", password="drowssap")


### PR DESCRIPTION
### Bascule 5 du schéma de référence - Cloturer un signalement

Action :
- Un signalement est passé du statut "Intervention terminée" au statut "Résolu"

Conséquences :
- Le changement de statut est transféré a Suricate via API
- Le signalement est déverouillé dans Suricate via API
- Un message est envoyé à la sentinelle via Suricate API
