### PR TITLE
fix broken signage list view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix trademark missing
-- Fix broken signage list view
+- Fix broken list views using trekking_tags
 
 
 2.75.0     (2022-01-07)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix trademark missing
+- Fix broken signage list view
 
 
 2.75.0     (2022-01-07)


### PR DESCRIPTION
no init.py in templatetags, template tags doesn't exist, signage list Error 500