### PR TITLE
Remove SVG sizes in pictograms

### DIFF
--- a/geotrek/tourism/fixtures/upload/touristiccontent-accommodation.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-accommodation.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.409px" viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
+	 viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
 <path fill="#FFFFFF" d="M10.282,8.368l0.81-0.426l0.81,0.426l-0.154-0.902l0.655-0.639l-0.906-0.132l-0.405-0.82l-0.405,0.82
 	L9.782,6.828l0.655,0.639L10.282,8.368z M18.272,8.599l-0.239-0.215l-0.237,0.217L8.274,19.346l-0.25,0.229l0.253,0.225l1.635,1.449
 	l0.243,0.215l0.236-0.224l0.416-0.503v6.197H9.296v1.182H26.92v-1.182h-1.494v-6.177l0.371,0.44l0.23,0.212l0.24-0.202l1.682-1.426

--- a/geotrek/tourism/fixtures/upload/touristiccontent-destination.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-destination.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.409px" viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
+	 viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
 <path fill="#FFFFFF" d="M26.2,10.99c0-0.008,0.005-0.016,0.005-0.024V10.93c0-0.433-0.354-0.786-0.785-0.786H24.98
 	c-0.366,0-0.662,0.259-0.747,0.601h-2.315V9.633c0-1.022-0.832-1.855-1.855-1.855h-3.886c-1.022,0-1.855,0.833-1.855,1.855v1.111
 	h-2.404c-0.086-0.341-0.382-0.601-0.749-0.601h-0.438c-0.432,0-0.786,0.354-0.786,0.786v0.036c0,0.018,0.009,0.032,0.01,0.05

--- a/geotrek/tourism/fixtures/upload/touristiccontent-museum.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-museum.svg
@@ -8,8 +8,6 @@
    xml:space="preserve"
    enable-background="new 0 0 100 100"
    viewBox="0 0 100 100"
-   height="100px"
-   width="100px"
    y="0px"
    x="0px"
    id="Livello_1"

--- a/geotrek/tourism/fixtures/upload/touristiccontent-outdoor.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-outdoor.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.409px" viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
+	 viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
 <path fill="#FFFFFF" d="M30.105,24.763l-2.268-2.267c-0.754-0.754-1.916-0.854-2.779-0.301l-2.684-2.684
 	c0.029-0.035,0.059-0.069,0.086-0.104c2.469-3.061,4.514-6.73,6.08-10.905c0.066-0.175,0.023-0.372-0.109-0.504
 	c-0.131-0.132-0.328-0.175-0.504-0.109c-4.174,1.567-7.844,3.612-10.905,6.08c-0.035,0.028-0.069,0.057-0.104,0.086l-2.684-2.684

--- a/geotrek/tourism/fixtures/upload/touristiccontent-products.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-products.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.409px" viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
+	 viewBox="0 0 36.41 36.409" enable-background="new 0 0 36.41 36.409" xml:space="preserve">
 <path fill="#FFFFFF" d="M11.869,16.882c-0.28-2.641,1.314-5.206,3.942-6.052c2.627-0.847,5.419,0.306,6.732,2.613l1.555-0.5
 	c-1.607-3.151-5.305-4.761-8.779-3.643c-3.474,1.12-5.537,4.585-5.002,8.081L11.869,16.882z M22.654,10.474
 	c1.949,0.938,4.611-1.323,4.516-3.229C25.447,6.144,22.432,8.122,22.654,10.474z M21.943,9.892c1.477-0.883,1.281-3.866,0.047-4.757

--- a/geotrek/tourism/fixtures/upload/touristiccontent-restaurants.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-restaurants.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.41px" viewBox="0 0 36.41 36.41" enable-background="new 0 0 36.41 36.41" xml:space="preserve">
+	 viewBox="0 0 36.41 36.41" enable-background="new 0 0 36.41 36.41" xml:space="preserve">
 <path fill="#FFFFFF" d="M25.938,19.137c-0.527-0.875-1.371-1.578-2.355-1.827c-0.018-0.007-0.033-0.014-0.033-0.014l0.328-11.86
 	l-2.238-0.412l0.377,12.282c-0.996,0.243-1.846,0.948-2.379,1.833c-0.661,1.098,0.508,10.818,0.508,10.818h0.76v-9.122h0.756v9.121
 	h0.824v-9.123h0.752v9.123h0.855v-9.123h0.754v9.123h0.584C25.43,29.956,26.598,20.235,25.938,19.137z M14.362,6.948h-0.004

--- a/geotrek/tourism/fixtures/upload/touristiccontent-sites.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-sites.svg
@@ -8,8 +8,6 @@
    xml:space="preserve"
    enable-background="new 6.699 0 92.419 100"
    viewBox="6.699 0 92.419 100"
-   height="100px"
-   width="92.419px"
    y="0px"
    x="0px"
    id="svg30967"

--- a/geotrek/tourism/fixtures/upload/touristiccontent-visits.svg
+++ b/geotrek/tourism/fixtures/upload/touristiccontent-visits.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="36.41px" height="36.41px" viewBox="0 0 36.41 36.41" enable-background="new 0 0 36.41 36.41" xml:space="preserve">
+	 viewBox="0 0 36.41 36.41" enable-background="new 0 0 36.41 36.41" xml:space="preserve">
 <path fill="#FFFFFF" d="M31.125,17.479c-0.227-0.312-5.916-7.331-13.078-7.331c-7.161,0-12.851,7.02-13.077,7.274l-0.227,0.283
 	l0.227,0.283c0.227,0.312,5.916,7.331,13.077,7.331c7.162,0,12.851-7.02,13.078-7.274l0.227-0.283L31.125,17.479z M18.047,24.211
 	c-5.767,0-10.659-5.248-11.752-6.478c1.093-1.257,5.985-6.504,11.752-6.477c5.767,0,10.66,5.248,11.751,6.477

--- a/geotrek/trekking/fixtures/upload/practice-bike.svg
+++ b/geotrek/trekking/fixtures/upload/practice-bike.svg
@@ -9,9 +9,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg18607"
-   viewBox="0 0 32 32.000001"
-   height="32"
-   width="32">
+   viewBox="0 0 32 32.000001">
   <defs
      id="defs18609">
   </defs>

--- a/geotrek/trekking/fixtures/upload/practice-horse.svg
+++ b/geotrek/trekking/fixtures/upload/practice-horse.svg
@@ -9,9 +9,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg18607"
-   viewBox="0 0 32 32.000001"
-   height="32"
-   width="32">
+   viewBox="0 0 32 32.000001">
   <defs
      id="defs18609">
   </defs>

--- a/geotrek/trekking/fixtures/upload/practice-mountainbike.svg
+++ b/geotrek/trekking/fixtures/upload/practice-mountainbike.svg
@@ -1,7 +1,6 @@
 <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg"
-     xmlns="http://www.w3.org/2000/svg" id="svg3804" version="1.1" viewBox="0 0 6.3994236 6.7506738"
-     height="6.7506738mm" width="6.3994236mm">
+     xmlns="http://www.w3.org/2000/svg" id="svg3804" version="1.1" viewBox="0 0 6.3994236 6.7506738">
     <defs id="defs3798"/>
     <metadata id="metadata3801">
         <rdf:RDF>

--- a/geotrek/trekking/fixtures/upload/practice-vttae.svg
+++ b/geotrek/trekking/fixtures/upload/practice-vttae.svg
@@ -1,7 +1,7 @@
 <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg"
      xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="187.68289mm" height="185.80789mm"
+     xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
      viewBox="0 0 187.68289 185.80789" version="1.1" id="svg8" inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
      sodipodi:docname="picto-vttae.svg">
     <defs id="defs2">


### PR DESCRIPTION
As width and height in SVG can generate problems in Geotrek-rando-v3