### PR TITLE
 Display completeness fields if object is not complete and raise an error if needed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,10 @@ CHANGELOG
 
 - Display link to attachment in admin site for attachments
 - Add license field on attachments (#3089) [thanks to Paul Florence]
+- If `COMPLETENESS_FIELDS` is set for a model an object is published,
+    display completeness fields if missing on page detail
+- Avoid publication or review if `COMPLETENESS_FIELDS` is set for a model,
+    and `COMPLETENESS_LEVEL` is one of 'error_on_publication' and 'error_on_review'
 
 **Bug fixes**
 

--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -855,6 +855,26 @@ For each module, use the following syntax to configure fields to hide in the cre
 Please refer to the "settings detail" section for a complete list of modules and hideable fields.
 
 
+Configure form fields required or needed for review or publication
+-------------------------------------------------------------------
+
+Set 'error_on_publication' to avoid publication without completeness fields
+and 'error_on_review' if you want this fields to be required before sending to review.
+
+::
+
+    COMPLETENESS_LEVEL = 'warning'
+
+For each module, configure fields to be needed or required on review or publication
+
+::
+
+    COMPLETENESS_FIELDS = {
+        'trek': ['practice', 'departure', 'duration', 'difficulty', 'description_teaser'],
+        'dive': ['practice', 'difficulty', 'description_teaser'],
+    }
+
+
 ================
 Settings details
 ================

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -129,6 +129,12 @@ class CommonForm(MapEntityForm):
                 else:
                     self.fields[field_to_hide].widget = HiddenInput()
 
+        # If COMPLETENESS_MODE is 'error', set completeness fields required
+        if settings.COMPLETENESS_LEVEL == 'error':
+            for field_key in settings.COMPLETENESS_FIELDS[self._meta.model._meta.model_name]:
+                self.fields[field_key].required = True
+
+
     def clean(self):
         structure = self.cleaned_data.get('structure')
         if not structure:

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -129,12 +129,6 @@ class CommonForm(MapEntityForm):
                 else:
                     self.fields[field_to_hide].widget = HiddenInput()
 
-        # If COMPLETENESS_MODE is 'error', set completeness fields required
-        if settings.COMPLETENESS_LEVEL == 'error':
-            for field_key in settings.COMPLETENESS_FIELDS[self._meta.model._meta.model_name]:
-                self.fields[field_key].required = True
-
-
     def clean(self):
         structure = self.cleaned_data.get('structure')
         if not structure:

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -17,6 +17,7 @@ from mapentity.forms import MapEntityForm
 
 from geotrek.authent.models import default_structure, StructureRelated, StructureOrNoneRelated
 from geotrek.common.models import AccessibilityAttachment
+from geotrek.common.utils.translation import get_translated_fields
 
 from .mixins.models import NoDeleteMixin
 
@@ -154,12 +155,16 @@ class CommonForm(MapEntityForm):
                 self.check_structure(field, structure, name)
 
         # If COMPLETENESS_MODE is 'error_on_publication', set completeness fields required
-        if self.instance.any_published and settings.COMPLETENESS_LEVEL == 'error_on_publication':
+        translated_fields = get_translated_fields(self._meta.model)
+
+        if 'published' in translated_fields and self.instance.any_published and settings.COMPLETENESS_LEVEL == 'error_on_publication':
             self.completeness_fields = settings.COMPLETENESS_FIELDS.get(self._meta.model._meta.model_name, [])
             if self.completeness_fields:
                 msg = _('This field is required to publish object.')
                 missing_fields = []
                 for field_required in self.completeness_fields:
+                    if field_required in translated_fields:
+                        field_required = f'{field_required}_fr'
                     if not self.cleaned_data[field_required]:
                         self.add_error(field_required, msg)
                         missing_fields.append(field_required)

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -11,7 +11,7 @@ from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.forms.widgets import HiddenInput
 from django.urls import reverse
 from django.utils.text import format_lazy
-from django.utils.translation import get_language, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from mapentity.forms import MapEntityForm
 

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -159,6 +159,7 @@ class CommonForm(MapEntityForm):
         # If model is publishable or reviewable,
         # check if completeness fields are required, and raise error if some fields are missing
         if self.completeness_fields_are_required():
+            missing_fields = []
             completeness_fields = settings.COMPLETENESS_FIELDS.get(self._meta.model._meta.model_name, [])
             if settings.COMPLETENESS_LEVEL == 'error_on_publication':
                 missing_fields = self._get_missing_completeness_fields(completeness_fields,
@@ -166,8 +167,6 @@ class CommonForm(MapEntityForm):
             elif settings.COMPLETENESS_LEVEL == 'error_on_review':
                 missing_fields = self._get_missing_completeness_fields(completeness_fields,
                                                                        _('This field is required to review object.'))
-            else:
-                missing_fields = []
 
             if missing_fields:
                 raise ValidationError(
@@ -200,8 +199,7 @@ class CommonForm(MapEntityForm):
             return [language for language in languages if self.cleaned_data.get(f'published_{language}', None)]
         elif self.any_published:
             return languages
-        else:
-            return []
+        return []
 
     def completeness_fields_are_required(self):
         """Return True if the completeness fields are required"""

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -197,9 +197,9 @@ class CommonForm(MapEntityForm):
         languages = [language[0] for language in settings.MAPENTITY_CONFIG['TRANSLATED_LANGUAGES']]
         if settings.PUBLISHED_BY_LANG:
             return [language for language in languages if self.cleaned_data.get(f'published_{language}', None)]
-        elif self.any_published:
-            return languages
-        return []
+        else:
+            if self.any_published:
+                return languages
 
     def completeness_fields_are_required(self):
         """Return True if the completeness fields are required"""

--- a/geotrek/common/forms.py
+++ b/geotrek/common/forms.py
@@ -17,7 +17,7 @@ from mapentity.forms import MapEntityForm
 
 from geotrek.authent.models import default_structure, StructureRelated, StructureOrNoneRelated
 from geotrek.common.models import AccessibilityAttachment
-from geotrek.common.mixins import PublishableMixin
+from geotrek.common.mixins.models import PublishableMixin
 from geotrek.common.utils.translation import get_translated_fields
 
 from .mixins.models import NoDeleteMixin
@@ -182,18 +182,25 @@ class CommonForm(MapEntityForm):
 
     @property
     def completeness_fields_required(self):
-        """Return if the completeness fields are required"""
+        """Return True if the completeness fields are required"""
         if not issubclass(self._meta.model, PublishableMixin):
             return False
 
-        completeness_fields = settings.COMPLETENESS_FIELDS.get(self._meta.model._meta.model_name, [])
-        if completeness_fields:
+        # Check if form has published in at least one of the language
+        if not settings.PUBLISHED_BY_LANG:
+            any_published = self.cleaned_data.get('published')
+
+        for language in settings.MAPENTITY_CONFIG['TRANSLATED_LANGUAGES']:
+            if self.cleaned_data.get(f'published_{language[0]}', False):
+                any_published = True
+
+        if self.instance.is_complete:
             if settings.COMPLETENESS_LEVEL == 'error_on_publication':
-                if self.instance.any_published:
+                if any_published:
                     return True
             elif settings.COMPLETENESS_LEVEL == 'error_on_review':
                 # Error on review implies error on publication
-                if self.instance.review or self.instance.any_published:
+                if self.cleaned_data['review'] or any_published:
                     return True
 
         return False

--- a/geotrek/common/locale/de/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/de/LC_MESSAGES/django.po
@@ -32,6 +32,13 @@ msgstr ""
 msgid "max %s"
 msgstr ""
 
+msgid "This field is required to publish object."
+msgstr ""
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "Please select a choice related to all structures (without brackets) or "
@@ -499,6 +506,9 @@ msgid "Object is published but"
 msgstr ""
 
 msgid "looks incomplete;"
+msgstr ""
+
+msgid "these fields should be completed:"
 msgstr ""
 
 msgid "has invalid geometry;"

--- a/geotrek/common/locale/en/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/en/LC_MESSAGES/django.po
@@ -32,6 +32,13 @@ msgstr ""
 msgid "max %s"
 msgstr ""
 
+msgid "This field is required to publish object."
+msgstr ""
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "Please select a choice related to all structures (without brackets) or "
@@ -499,6 +506,9 @@ msgid "Object is published but"
 msgstr ""
 
 msgid "looks incomplete;"
+msgstr ""
+
+msgid "these fields should be completed:"
 msgstr ""
 
 msgid "has invalid geometry;"

--- a/geotrek/common/locale/es/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/es/LC_MESSAGES/django.po
@@ -32,6 +32,13 @@ msgstr "min %s"
 msgid "max %s"
 msgstr "max %s"
 
+msgid "This field is required to publish object."
+msgstr ""
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "Please select a choice related to all structures (without brackets) or "
@@ -500,6 +507,9 @@ msgstr ""
 
 msgid "looks incomplete;"
 msgstr "parece incompleto;"
+
+msgid "these fields should be completed:"
+msgstr ""
 
 msgid "has invalid geometry;"
 msgstr "tiene una geometría invalida;"

--- a/geotrek/common/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/fr/LC_MESSAGES/django.po
@@ -33,6 +33,13 @@ msgstr "min %s"
 msgid "max %s"
 msgstr "max %s"
 
+msgid "This field is required to publish object."
+msgstr "Ce champs est obligatoire pour publier l'objet."
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
+msgstr "Ces champs doivent être renseignés pour publier l'objet : %(fields)s"
+
 #, python-brace-format
 msgid ""
 "Please select a choice related to all structures (without brackets) or "
@@ -412,7 +419,9 @@ msgid "Init sync ..."
 msgstr "Début de synchro"
 
 msgid "Photos to illustrate information related to the accessibility of treks."
-msgstr "Photos pour illustrer les informations liées à l'accessibilité des randonnées."
+msgstr ""
+"Photos pour illustrer les informations liées à l'accessibilité des "
+"randonnées."
 
 msgid "Photos accessibility"
 msgstr "Photos accessibilité"
@@ -518,6 +527,9 @@ msgstr "L'objet est publié mais"
 
 msgid "looks incomplete;"
 msgstr "semble incomplet ;"
+
+msgid "these fields should be completed:"
+msgstr "ces champs doivent être renseignés :"
 
 msgid "has invalid geometry;"
 msgstr "a une géométrie invalide ;"

--- a/geotrek/common/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/it/LC_MESSAGES/django.po
@@ -32,6 +32,13 @@ msgstr "min %s"
 msgid "max %s"
 msgstr "max %s"
 
+msgid "This field is required to publish object."
+msgstr ""
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
+msgstr ""
+
 #, python-brace-format
 msgid ""
 "Please select a choice related to all structures (without brackets) or "
@@ -499,6 +506,9 @@ msgid "Object is published but"
 msgstr ""
 
 msgid "looks incomplete;"
+msgstr ""
+
+msgid "these fields should be completed:"
 msgstr ""
 
 msgid "has invalid geometry;"

--- a/geotrek/common/locale/nl/LC_MESSAGES/django.po
+++ b/geotrek/common/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-25 09:07+0000\n"
+"POT-Creation-Date: 2022-03-29 10:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,13 @@ msgstr ""
 
 #, python-format
 msgid "max %s"
+msgstr ""
+
+msgid "This field is required to publish object."
+msgstr ""
+
+#, python-format
+msgid "Fields are missing to publish object: %(fields)s"
 msgstr ""
 
 #, python-brace-format
@@ -499,6 +506,9 @@ msgid "Object is published but"
 msgstr ""
 
 msgid "looks incomplete;"
+msgstr ""
+
+msgid "these fields should be completed:"
 msgstr ""
 
 msgid "has invalid geometry;"

--- a/geotrek/common/mixins/views.py
+++ b/geotrek/common/mixins/views.py
@@ -237,5 +237,7 @@ class CompletenessMixin:
         context = super().get_context_data(**kwargs)
         modelname = self.get_model()._meta.object_name.lower()
         if modelname in settings.COMPLETENESS_FIELDS:
-            context['completeness_fields'] = settings.COMPLETENESS_FIELDS[modelname]
+            obj = context['object']
+            completeness_fields = settings.COMPLETENESS_FIELDS[modelname]
+            context['completeness_fields'] = [obj._meta.get_field(field).verbose_name for field in completeness_fields]
         return context

--- a/geotrek/common/mixins/views.py
+++ b/geotrek/common/mixins/views.py
@@ -228,3 +228,14 @@ class DocumentPublicMixin:
         modelname = self.get_model()._meta.object_name.lower()
         context['mapimage_ratio'] = settings.EXPORT_MAP_IMAGE_SIZE[modelname]
         return context
+
+
+class CompletenessMixin:
+    """Mixin for completeness fields"""
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        modelname = self.get_model()._meta.object_name.lower()
+        if modelname in settings.COMPLETENESS_FIELDS:
+            context['completeness_fields'] = settings.COMPLETENESS_FIELDS[modelname]
+        return context

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -29,10 +29,10 @@ from paperclip.models import attachment_upload
 
 from geotrek.authent.models import default_structure
 from geotrek.common.models import FileType, Attachment
+from geotrek.common.utils.translation import get_translated_fields
 
 if 'modeltranslation' in settings.INSTALLED_APPS:
     from modeltranslation.fields import TranslationField
-    from modeltranslation.translator import translator, NotRegistered
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +90,7 @@ class Parser:
         self.user = user
         self.structure = user and user.profile.structure or default_structure()
         self.encoding = encoding
-
-        try:
-            mto = translator.get_options_for_model(self.model)
-        except NotRegistered:
-            self.translated_fields = []
-        else:
-            self.translated_fields = mto.fields.keys()
+        self.translated_fields = get_translated_fields(self.model)
 
         if self.fields is None:
             self.fields = {

--- a/geotrek/common/templates/common/publishable_completeness_fragment.html
+++ b/geotrek/common/templates/common/publishable_completeness_fragment.html
@@ -9,7 +9,11 @@
 {% else %}
     {% if not object.is_publishable %}
         <div class="alert alert-danger"><strong>{% trans "Object is published but" %}</strong>
-        {% if not object.is_complete %}{% trans "looks incomplete;" %}{% endif %}
+        {% if not object.is_complete %}
+            {% trans "looks incomplete;" %}
+            {% trans "these fields should be completed:" %}<br/>
+            {{ completeness_fields|join:', ' }}
+        {% endif %}
         {% if not object.has_geom_valid %}{% trans "has invalid geometry;" %}{% endif %}
         </div>
     {% endif %}

--- a/geotrek/common/utils/translation.py
+++ b/geotrek/common/utils/translation.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+
+if 'modeltranslation' in settings.INSTALLED_APPS:
+    from modeltranslation.fields import TranslationField
+    from modeltranslation.translator import translator, NotRegistered
+
+
+def get_translated_fields(model):
+    """Get translated fields from a model"""
+    try:
+        mto = translator.get_options_for_model(model)
+    except NotRegistered:
+        translated_fields = []
+    else:
+        translated_fields = mto.fields.keys()
+    return translated_fields

--- a/geotrek/common/utils/translation.py
+++ b/geotrek/common/utils/translation.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 if 'modeltranslation' in settings.INSTALLED_APPS:
-    from modeltranslation.fields import TranslationField
     from modeltranslation.translator import translator, NotRegistered
 
 

--- a/geotrek/common/views.py
+++ b/geotrek/common/views.py
@@ -104,6 +104,15 @@ class MarkupPublic(PublicOrReadPermMixin, DocumentPublicMixin, mapentity_views.M
     pass
 
 
+class CompletenessMixin:
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        modelname = self.get_model()._meta.object_name.lower()
+        if modelname in settings.COMPLETENESS_FIELDS:
+            context['completeness_fields'] = settings.COMPLETENESS_FIELDS[modelname]
+        return context
+
+
 #
 # Concrete views
 # ..............................

--- a/geotrek/common/views.py
+++ b/geotrek/common/views.py
@@ -104,15 +104,6 @@ class MarkupPublic(PublicOrReadPermMixin, DocumentPublicMixin, mapentity_views.M
     pass
 
 
-class CompletenessMixin:
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        modelname = self.get_model()._meta.object_name.lower()
-        if modelname in settings.COMPLETENESS_FIELDS:
-            context['completeness_fields'] = settings.COMPLETENESS_FIELDS[modelname]
-        return context
-
-
 #
 # Concrete views
 # ..............................

--- a/geotrek/diving/views.py
+++ b/geotrek/diving/views.py
@@ -13,7 +13,7 @@ from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
 from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
 from geotrek.common.models import RecordSource, TargetPortal
-from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
+from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic, CompletenessMixin
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.trekking.models import POI, Service
 from geotrek.trekking.serializers import POIAPIGeojsonSerializer, ServiceAPIGeojsonSerializer
@@ -50,7 +50,7 @@ class DiveFormatList(MapEntityFormat, DiveList):
     ]
 
 
-class DiveDetail(MapEntityDetail):
+class DiveDetail(CompletenessMixin, MapEntityDetail):
     queryset = Dive.objects.existing()
 
     def dispatch(self, *args, **kwargs):

--- a/geotrek/diving/views.py
+++ b/geotrek/diving/views.py
@@ -11,9 +11,9 @@ from rest_framework import permissions as rest_permissions, viewsets
 
 from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
-from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
+from geotrek.common.mixins.views import CompletenessMixin, CustomColumnsMixin, MetaMixin
 from geotrek.common.models import RecordSource, TargetPortal
-from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic, CompletenessMixin
+from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.trekking.models import POI, Service
 from geotrek.trekking.serializers import POIAPIGeojsonSerializer, ServiceAPIGeojsonSerializer

--- a/geotrek/outdoor/views.py
+++ b/geotrek/outdoor/views.py
@@ -7,8 +7,8 @@ from mapentity.views import (MapEntityLayer, MapEntityList, MapEntityDetail, Map
 
 from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
-from geotrek.common.mixins.views import CustomColumnsMixin
-from geotrek.common.views import CompletenessMixin, DocumentBookletPublic, DocumentPublic, MarkupPublic
+from geotrek.common.mixins.views import CompletenessMixin, CustomColumnsMixin
+from geotrek.common.views import DocumentBookletPublic, DocumentPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.outdoor.filters import SiteFilterSet, CourseFilterSet
 from geotrek.outdoor.forms import SiteForm, CourseForm

--- a/geotrek/outdoor/views.py
+++ b/geotrek/outdoor/views.py
@@ -31,7 +31,7 @@ class SiteList(CustomColumnsMixin, MapEntityList):
     searchable_columns = ['id', 'name']
 
 
-class SiteDetail(MapEntityDetail):
+class SiteDetail(CompletenessMixin, MapEntityDetail):
     queryset = Site.objects.all()
 
     def get_context_data(self, *args, **kwargs):

--- a/geotrek/outdoor/views.py
+++ b/geotrek/outdoor/views.py
@@ -8,7 +8,7 @@ from mapentity.views import (MapEntityLayer, MapEntityList, MapEntityDetail, Map
 from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
 from geotrek.common.mixins.views import CustomColumnsMixin
-from geotrek.common.views import DocumentBookletPublic, DocumentPublic, MarkupPublic
+from geotrek.common.views import CompletenessMixin, DocumentBookletPublic, DocumentPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.outdoor.filters import SiteFilterSet, CourseFilterSet
 from geotrek.outdoor.forms import SiteForm, CourseForm
@@ -153,7 +153,7 @@ class CourseList(CustomColumnsMixin, MapEntityList):
     searchable_columns = ['id', 'name']
 
 
-class CourseDetail(MapEntityDetail):
+class CourseDetail(CompletenessMixin, MapEntityDetail):
     queryset = Course.objects.prefetch_related('type').all()
 
     def get_context_data(self, *args, **kwargs):

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -506,7 +506,7 @@ EXPORT_HEADER_IMAGE_SIZE = {
 }
 
 COMPLETENESS_FIELDS = {
-    'trek': ['practice', 'duration', 'difficulty', ],
+    'trek': ['practice', 'departure', 'duration', 'difficulty', 'description_teaser'],
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
 

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -511,6 +511,7 @@ COMPLETENESS_FIELDS = {
 }
 
 # Set 'error_on_publication' to avoid publication without completeness fields
+# and 'error_on_review' if you want this fields to be required before sending to review.
 COMPLETENESS_LEVEL = 'warning'
 
 EMBED_VIDEO_BACKENDS = (

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -506,11 +506,11 @@ EXPORT_HEADER_IMAGE_SIZE = {
 }
 
 COMPLETENESS_FIELDS = {
-    'trek': ['practice', 'departure', 'duration', 'difficulty', 'description_teaser'],
+    'trek': ['practice', 'duration', 'difficulty', ],
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
 
-COMPLETENESS_LEVEL = 'warning' # Set 'error' to avoid publication without completeness fields
+COMPLETENESS_LEVEL = 'error_on_publication' # Set 'error_on_publication' to avoid publication without completeness fields
 
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -511,7 +511,7 @@ COMPLETENESS_FIELDS = {
 }
 
 # Set 'error_on_publication' to avoid publication without completeness fields
-COMPLETENESS_LEVEL = 'error_on_publication'
+COMPLETENESS_LEVEL = 'warning'
 
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -505,14 +505,15 @@ EXPORT_HEADER_IMAGE_SIZE = {
     'course': (10.7, 5.35),  # Keep ratio of THUMBNAIL_ALIASES['print']
 }
 
+# Set 'error_on_publication' to avoid publication without completeness fields
+# and 'error_on_review' if you want this fields to be required before sending to review.
+COMPLETENESS_LEVEL = 'warning'
+
+# Set fields required or needed for review or publication, for each model
 COMPLETENESS_FIELDS = {
     'trek': ['practice', 'departure', 'duration', 'difficulty', 'description_teaser'],
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
-
-# Set 'error_on_publication' to avoid publication without completeness fields
-# and 'error_on_review' if you want this fields to be required before sending to review.
-COMPLETENESS_LEVEL = 'warning'
 
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -510,6 +510,8 @@ COMPLETENESS_FIELDS = {
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
 
+COMPLETENESS_LEVEL = 'warning' # Set 'error' to avoid publication without completeness fields
+
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',
     'geotrek.common.embed.backends.DailymotionBackend',

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -510,8 +510,6 @@ COMPLETENESS_FIELDS = {
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
 
-COMPLETENESS_LEVEL = 'warning' # Set 'error' to avoid publication without completeness fields
-
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',
     'geotrek.common.embed.backends.DailymotionBackend',

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -510,7 +510,8 @@ COMPLETENESS_FIELDS = {
     'dive': ['practice', 'difficulty', 'description_teaser'],
 }
 
-COMPLETENESS_LEVEL = 'error_on_publication' # Set 'error_on_publication' to avoid publication without completeness fields
+# Set 'error_on_publication' to avoid publication without completeness fields
+COMPLETENESS_LEVEL = 'error_on_publication'
 
 EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',

--- a/geotrek/tourism/views.py
+++ b/geotrek/tourism/views.py
@@ -21,7 +21,7 @@ from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
 from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
 from geotrek.common.models import RecordSource, TargetPortal
-from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
+from geotrek.common.views import CompletenessMixin, DocumentPublic, DocumentBookletPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.trekking.models import Trek
 from .filters import TouristicContentFilterSet, TouristicEventFilterSet, TouristicEventApiFilterSet
@@ -66,7 +66,7 @@ class TouristicContentFormatList(MapEntityFormat, TouristicContentList):
     ]
 
 
-class TouristicContentDetail(MapEntityDetail):
+class TouristicContentDetail(CompletenessMixin, MapEntityDetail):
     queryset = TouristicContent.objects.existing()
 
     def get_context_data(self, *args, **kwargs):
@@ -215,7 +215,7 @@ class TouristicEventFormatList(MapEntityFormat, TouristicEventList):
     ]
 
 
-class TouristicEventDetail(MapEntityDetail):
+class TouristicEventDetail(CompletenessMixin, MapEntityDetail):
     queryset = TouristicEvent.objects.existing()
 
     def get_context_data(self, *args, **kwargs):

--- a/geotrek/tourism/views.py
+++ b/geotrek/tourism/views.py
@@ -19,9 +19,9 @@ from rest_framework.views import APIView
 
 from geotrek.authent.decorators import same_structure_required
 from geotrek.common.mixins.api import APIViewSet
-from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
+from geotrek.common.mixins.views import CompletenessMixin, CustomColumnsMixin, MetaMixin
 from geotrek.common.models import RecordSource, TargetPortal
-from geotrek.common.views import CompletenessMixin, DocumentPublic, DocumentBookletPublic, MarkupPublic
+from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.trekking.models import Trek
 from .filters import TouristicContentFilterSet, TouristicEventFilterSet, TouristicEventApiFilterSet

--- a/geotrek/trekking/forms.py
+++ b/geotrek/trekking/forms.py
@@ -214,6 +214,7 @@ class TrekForm(BaseTrekForm):
 
             # init hidden field with children order
             self.fields['hidden_ordered_children'].initial = ",".join(str(x) for x in queryset_children.values_list('child__id', flat=True))
+
         for scale in RatingScale.objects.all():
             ratings = None
             if self.instance.pk:
@@ -227,6 +228,7 @@ class TrekForm(BaseTrekForm):
             )
             right_after_type_index = self.fieldslayout[0][1][0].fields.index('practice') + 1
             self.fieldslayout[0][1][0].insert(right_after_type_index, fieldname)
+
         if self.instance.pk:
             self.fields['pois_excluded'].queryset = self.instance.all_pois.all()
         else:

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -83,6 +83,7 @@ class TreckCompletenessTest(TestCase):
         cls.trek = TrekFactory.create(structure=structure)
 
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
+    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error(self):
         """Test completeness fields on error if empty"""
         data = {
@@ -100,7 +101,7 @@ class TreckCompletenessTest(TestCase):
 
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: practice, departure_fr, duration, difficulty, description_teaser_fr'):
+                                    'Fields are missing to publish object: practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
 

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -82,6 +82,7 @@ class TreckCompletenessTest(TestCase):
         cls.path = PathFactory.create()
         cls.trek = TrekFactory.create(structure=structure)
 
+    @override_settings(COMPLETENESS_LEVEL='error_on_publication')
     def test_completeness_error(self):
         """Test completeness fields on error if empty"""
         data = {
@@ -95,13 +96,12 @@ class TreckCompletenessTest(TestCase):
         else:
             data['geom'] = 'SRID=4326;LINESTRING (0.0 0.0, 1.0 1.0)'
 
-        with override_settings(COMPLETENESS_MODE='error_on_publication'):
-            form = TrekForm(user=self.user, instance=self.trek, data=data)
+        form = TrekForm(user=self.user, instance=self.trek, data=data)
 
-            self.assertFalse(form.is_valid())
-            with self.assertRaisesRegex(ValidationError,
-                                        'Fields are missing to publish object: practice, departure_fr, duration, difficulty, description_teaser_fr'):
-                form.clean()
+        self.assertFalse(form.is_valid())
+        with self.assertRaisesRegex(ValidationError,
+                                    'Fields are missing to publish object: practice, departure_fr, duration, difficulty, description_teaser_fr'):
+            form.clean()
 
 
 class TrekItinerancyTestCase(TestCase):

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -98,6 +98,17 @@ class TrekCompletenessTest(TestCase):
     def test_completeness_warning(self):
         """Test form is valid if completeness level is only warning"""
         data = self.data
+        data['published_en'] = True
+        form = TrekForm(user=self.user, data=data)
+        self.assertTrue(form.is_valid())
+
+    @override_settings(COMPLETENESS_LEVEL='error_on_publication')
+    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
+    def test_completeness_error_on_publish_not_published(self):
+        """Test form is valid if completeness level is error on publication but published in no language"""
+        data = self.data
+        data['published_en'] = False
+
         form = TrekForm(user=self.user, data=data)
         self.assertTrue(form.is_valid())
 

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from geotrek.authent.tests.factories import UserFactory
+from geotrek.authent.tests.factories import UserFactory, StructureFactory
 from geotrek.core.tests.factories import PathFactory
 from .factories import TrekFactory, RatingFactory
 from ..models import OrderedTrekChild
@@ -78,8 +78,9 @@ class TreckCompletenessTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory.create()
+        structure = StructureFactory.create()
         cls.path = PathFactory.create()
-        cls.trek = TrekFactory()
+        cls.trek = TrekFactory.create(structure=structure)
 
     def test_completeness_error(self):
         """Test completeness fields on error if empty"""
@@ -96,8 +97,10 @@ class TreckCompletenessTest(TestCase):
 
         with override_settings(COMPLETENESS_MODE='error_on_publication'):
             form = TrekForm(user=self.user, instance=self.trek, data=data)
+
             self.assertFalse(form.is_valid())
-            with self.assertRaises(ValidationError, 'One of the rating scale used is not part of the practice chosen'):
+            with self.assertRaisesRegex(ValidationError,
+                                        'Fields are missing to publish object: practice, departure_fr, duration, difficulty, description_teaser_fr'):
                 form.clean()
 
 

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -105,6 +105,19 @@ class TrekCompletenessTest(TestCase):
                                     'Fields are missing to publish object: practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
+    @override_settings(COMPLETENESS_LEVEL='error_on_publication')
+    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
+    def test_completeness_error_on_publish(self):
+        """Test completeness fields on error if empty"""
+        data = self.data
+        data['published_fr'] = True
+
+        form = TrekForm(user=self.user, data=data)
+        self.assertFalse(form.is_valid())
+        with self.assertRaisesRegex(ValidationError,
+                                    'Fields are missing to publish object: practice, departure_fr, duration, description_teaser_fr'):
+            form.clean()
+
     @override_settings(PUBLISHED_BY_LANG=False)
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
     @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -1,17 +1,19 @@
 import json
 from django.conf import settings
+from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
+from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from geotrek.authent.tests.factories import UserFactory, StructureFactory
+from geotrek.authent.tests.factories import UserFactory
 from geotrek.core.tests.factories import PathFactory
 from .factories import TrekFactory, RatingFactory
 from ..models import OrderedTrekChild
 from ..forms import TrekForm
 
 
-class TrekFormTest(TestCase):
+class TrekRatingFormTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory.create()
@@ -73,33 +75,45 @@ class TrekFormTest(TestCase):
             form.clean()
 
 
-class TreckCompletenessTest(TestCase):
+class TrekCompletenessTest(TestCase):
     """Test completeness fields on error if empty"""
     @classmethod
     def setUpTestData(cls):
+        call_command('update_geotrek_permissions', verbosity=0)
         cls.user = UserFactory.create()
-        structure = StructureFactory.create()
-        cls.path = PathFactory.create()
-        cls.trek = TrekFactory.create(structure=structure)
+        cls.user.user_permissions.add(Permission.objects.get(codename='publish_trek'))
+        path = PathFactory.create()
         cls.data = {
             'name_en': 'Trek',
         }
 
         if settings.TREKKING_TOPOLOGY_ENABLED:
-            cls.data['topology'] = json.dumps({"paths": [cls.path.pk]})
-
+            cls.data['topology'] = json.dumps({"paths": [path.pk]})
         else:
             cls.data['geom'] = 'SRID=4326;LINESTRING (0.0 0.0, 1.0 1.0)'
 
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
     @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
-    def test_completeness_on_publish(self):
+    def test_completeness_error_on_publish(self):
         """Test completeness fields on error if empty"""
         data = self.data
         data['published_en'] = True
 
-        form = TrekForm(user=self.user, instance=self.trek, data=data)
+        form = TrekForm(user=self.user, data=data)
+        self.assertFalse(form.is_valid())
+        with self.assertRaisesRegex(ValidationError,
+                                    'Fields are missing to publish object: practice, departure_en, duration, description_teaser_en'):
+            form.clean()
 
+    @override_settings(PUBLISHED_BY_LANG=False)
+    @override_settings(COMPLETENESS_LEVEL='error_on_publication')
+    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
+    def test_completeness_error_on_publish_nolang(self):
+        """Test completeness fields on error if empty (when PUBLISHED_BY_LANG=False)"""
+        data = self.data
+        data['published'] = True
+
+        form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
                                     'Fields are missing to publish object: practice, departure_en, duration, description_teaser_en'):
@@ -108,11 +122,21 @@ class TreckCompletenessTest(TestCase):
     @override_settings(COMPLETENESS_LEVEL='error_on_review')
     @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_review(self):
-        """Test completeness fields on error if empty"""
+        """Test completeness fields on error if empty and is review, with 'error_on_review'"""
         data = self.data
+        data['published_en'] = False
         data['review'] = True
+        form = TrekForm(user=self.user, data=data)
 
-        form = TrekForm(user=self.user, instance=self.trek, data=data)
+        self.assertFalse(form.is_valid())
+        with self.assertRaisesRegex(ValidationError,
+                                    'Fields are missing to publish object: practice, departure_en, duration, description_teaser_en'):
+            form.clean()
+
+        # Exception should raise also if object is to be published
+        data['published_en'] = True
+        data['review'] = True
+        form = TrekForm(user=self.user, data=data)
 
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -75,8 +75,9 @@ class TrekRatingFormTest(TestCase):
             form.clean()
 
 
+@override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
 class TrekCompletenessTest(TestCase):
-    """Test completeness fields on error if empty"""
+    """Test completeness fields on error if empty, according to COMPLETENESS_LEVEL setting"""
 
     @classmethod
     def setUpTestData(cls):
@@ -94,16 +95,15 @@ class TrekCompletenessTest(TestCase):
         else:
             cls.data['geom'] = 'SRID=4326;LINESTRING (0.0 0.0, 1.0 1.0)'
 
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_warning(self):
         """Test form is valid if completeness level is only warning"""
         data = self.data
         data['published_en'] = True
+
         form = TrekForm(user=self.user, data=data)
         self.assertTrue(form.is_valid())
 
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_publish_not_published(self):
         """Test form is valid if completeness level is error on publication but published in no language"""
         data = self.data
@@ -113,7 +113,6 @@ class TrekCompletenessTest(TestCase):
         self.assertTrue(form.is_valid())
 
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_publish_en(self):
         """Test completeness fields on error if empty"""
         data = self.data
@@ -121,13 +120,13 @@ class TrekCompletenessTest(TestCase):
 
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
-        with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish or review object: '
-                                    'practice, departure_en, duration, description_teaser_en'):
+        with self.assertRaisesRegex(
+                ValidationError,
+                'Fields are missing to publish or review object: '
+                'practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_publish_fr(self):
         """Test completeness fields on error if empty"""
         data = self.data
@@ -136,14 +135,14 @@ class TrekCompletenessTest(TestCase):
 
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
-        with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish or review object: '
-                                    'practice, departure_fr, duration, description_teaser_fr'):
+        with self.assertRaisesRegex(
+                ValidationError,
+                'Fields are missing to publish or review object: '
+                'practice, departure_fr, duration, description_teaser_fr'):
             form.clean()
 
     @override_settings(PUBLISHED_BY_LANG=False)
     @override_settings(COMPLETENESS_LEVEL='error_on_publication')
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_publish_nolang(self):
         """Test completeness fields on error if empty (when PUBLISHED_BY_LANG=False)"""
         data = self.data
@@ -152,15 +151,15 @@ class TrekCompletenessTest(TestCase):
 
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
-        with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish or review object: '
-                                    'practice, departure_en, departure_es, departure_fr, departure_it, duration, '
-                                    'description_teaser_en, description_teaser_es, '
-                                    'description_teaser_fr, description_teaser_it'):
+        with self.assertRaisesRegex(
+                ValidationError,
+                'Fields are missing to publish or review object: '
+                'practice, departure_en, departure_es, departure_fr, departure_it, duration, '
+                'description_teaser_en, description_teaser_es, '
+                'description_teaser_fr, description_teaser_it'):
             form.clean()
 
     @override_settings(COMPLETENESS_LEVEL='error_on_review')
-    @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_review(self):
         """Test completeness fields on error if empty and is review, with 'error_on_review'"""
         data = self.data
@@ -169,9 +168,10 @@ class TrekCompletenessTest(TestCase):
         form = TrekForm(user=self.user, data=data)
 
         self.assertFalse(form.is_valid())
-        with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish or review object: '
-                                    'practice, departure_en, duration, description_teaser_en'):
+        with self.assertRaisesRegex(
+                ValidationError,
+                'Fields are missing to publish or review object: '
+                'practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
         # Exception should raise also if object is to be published
@@ -181,9 +181,10 @@ class TrekCompletenessTest(TestCase):
         form = TrekForm(user=self.user, data=data)
 
         self.assertFalse(form.is_valid())
-        with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish or review object: '
-                                    'practice, departure_fr, duration, description_teaser_fr'):
+        with self.assertRaisesRegex(
+                ValidationError,
+                'Fields are missing to publish or review object: '
+                'practice, departure_fr, duration, description_teaser_fr'):
             form.clean()
 
 

--- a/geotrek/trekking/tests/test_trek_forms.py
+++ b/geotrek/trekking/tests/test_trek_forms.py
@@ -77,6 +77,7 @@ class TrekRatingFormTest(TestCase):
 
 class TrekCompletenessTest(TestCase):
     """Test completeness fields on error if empty"""
+
     @classmethod
     def setUpTestData(cls):
         call_command('update_geotrek_permissions', verbosity=0)
@@ -110,7 +111,7 @@ class TrekCompletenessTest(TestCase):
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: '
+                                    'Fields are missing to publish or review object: '
                                     'practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
@@ -125,7 +126,7 @@ class TrekCompletenessTest(TestCase):
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: '
+                                    'Fields are missing to publish or review object: '
                                     'practice, departure_fr, duration, description_teaser_fr'):
             form.clean()
 
@@ -135,17 +136,18 @@ class TrekCompletenessTest(TestCase):
     def test_completeness_error_on_publish_nolang(self):
         """Test completeness fields on error if empty (when PUBLISHED_BY_LANG=False)"""
         data = self.data
-        data['published'] = True
+        data['published_en'] = True
+        data['published_fr'] = False
 
         form = TrekForm(user=self.user, data=data)
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: '
-                                    'practice, departure_en, departure_fr, duration, '
-                                    'description_teaser_en, description_teaser_fr'):
+                                    'Fields are missing to publish or review object: '
+                                    'practice, departure_en, departure_es, departure_fr, departure_it, duration, '
+                                    'description_teaser_en, description_teaser_es, '
+                                    'description_teaser_fr, description_teaser_it'):
             form.clean()
 
-    @override_settings(LANGUAGE_CODE='fr')
     @override_settings(COMPLETENESS_LEVEL='error_on_review')
     @override_settings(COMPLETENESS_FIELDS={'trek': ['practice', 'departure', 'duration', 'description_teaser']})
     def test_completeness_error_on_review(self):
@@ -157,20 +159,20 @@ class TrekCompletenessTest(TestCase):
 
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: '
-                                    'practice, departure_fr, duration, description_teaser_fr'):
+                                    'Fields are missing to publish or review object: '
+                                    'practice, departure_en, duration, description_teaser_en'):
             form.clean()
 
         # Exception should raise also if object is to be published
-        data['published_en'] = True
+        data['published_en'] = False
+        data['published_fr'] = True
         data['review'] = False
         form = TrekForm(user=self.user, data=data)
 
         self.assertFalse(form.is_valid())
         with self.assertRaisesRegex(ValidationError,
-                                    'Fields are missing to publish object: '
-                                    'practice, departure_en, departure_fr, duration, '
-                                    'description_teaser_en, description_teaser_fr'):
+                                    'Fields are missing to publish or review object: '
+                                    'practice, departure_fr, duration, description_teaser_fr'):
             form.clean()
 
 

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -469,16 +469,6 @@ class TrekViewsTest(GeotrekAPITestCase, CommonTest):
             self.assertEqual(row['Cities'], "Trifouilli, Refouilli")
             self.assertEqual(row['Districts'], self.district.name)
 
-    def test_completeness_publish(self):
-        """Test form post with completeness level"""
-        with override_settings(COMPLETENESS_MODE='error_on_publication'):
-            self.client.force_login(user=self.user)
-            data = self.get_good_data()
-            data['published'] = True
-
-            response = self.client.post(self.get_add_url(), data)
-            self.assertEqual(response.status_code, 302)
-
 
 class TrekViewsLiveTests(CommonLiveTest):
     model = Trek

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -469,6 +469,16 @@ class TrekViewsTest(GeotrekAPITestCase, CommonTest):
             self.assertEqual(row['Cities'], "Trifouilli, Refouilli")
             self.assertEqual(row['Districts'], self.district.name)
 
+    def test_completeness_publish(self):
+        """Test form post with completeness level"""
+        with override_settings(COMPLETENESS_MODE='error_on_publication'):
+            self.client.force_login(user=self.user)
+            data = self.get_good_data()
+            data['published'] = True
+
+            response = self.client.post(self.get_add_url(), data)
+            self.assertEqual(response.status_code, 302)
+
 
 class TrekViewsLiveTests(CommonLiveTest):
     model = Trek

--- a/geotrek/trekking/views.py
+++ b/geotrek/trekking/views.py
@@ -338,7 +338,7 @@ class POIFormatList(MapEntityFormat, POIList):
             yield poi
 
 
-class POIDetail(MapEntityDetail):
+class POIDetail(CompletenessMixin, MapEntityDetail):
     queryset = POI.objects.existing()
 
     def get_context_data(self, *args, **kwargs):

--- a/geotrek/trekking/views.py
+++ b/geotrek/trekking/views.py
@@ -20,12 +20,10 @@ from geotrek.common.forms import AttachmentAccessibilityForm
 from geotrek.common.functions import Length
 from geotrek.common.mixins.api import APIViewSet
 from geotrek.common.mixins.forms import FormsetMixin
-from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
+from geotrek.common.mixins.views import CompletenessMixin, CustomColumnsMixin, MetaMixin
 from geotrek.common.models import Attachment, RecordSource, TargetPortal, Label
-from geotrek.common.views import (FormsetMixin, MetaMixin, DocumentPublic,
-                                  DocumentBookletPublic, MarkupPublic)
 from geotrek.common.permissions import PublicOrReadPermMixin
-from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic, CompletenessMixin
+from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.core.models import AltimetryMixin
 from geotrek.core.views import CreateFromTopologyMixin

--- a/geotrek/trekking/views.py
+++ b/geotrek/trekking/views.py
@@ -22,8 +22,10 @@ from geotrek.common.mixins.api import APIViewSet
 from geotrek.common.mixins.forms import FormsetMixin
 from geotrek.common.mixins.views import CustomColumnsMixin, MetaMixin
 from geotrek.common.models import Attachment, RecordSource, TargetPortal, Label
+from geotrek.common.views import (FormsetMixin, MetaMixin, DocumentPublic,
+                                  DocumentBookletPublic, MarkupPublic)
 from geotrek.common.permissions import PublicOrReadPermMixin
-from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic
+from geotrek.common.views import DocumentPublic, DocumentBookletPublic, MarkupPublic, CompletenessMixin
 from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.core.models import AltimetryMixin
 from geotrek.core.views import CreateFromTopologyMixin
@@ -32,6 +34,7 @@ from geotrek.infrastructure.serializers import InfrastructureAPIGeojsonSerialize
 from geotrek.signage.models import Signage
 from geotrek.signage.serializers import SignageAPIGeojsonSerializer
 from geotrek.zoning.models import District, City, RestrictedArea
+
 from .filters import TrekFilterSet, POIFilterSet, ServiceFilterSet
 from .forms import TrekForm, TrekRelationshipFormSet, POIForm, WebLinkCreateFormPopup, ServiceForm
 from .models import Trek, POI, WebLink, Service, TrekRelationship, OrderedTrekChild
@@ -104,7 +107,7 @@ class TrekKMLDetail(LastModifiedMixin, PublicOrReadPermMixin, BaseDetailView):
         return response
 
 
-class TrekDetail(MapEntityDetail):
+class TrekDetail(CompletenessMixin, MapEntityDetail):
     queryset = Trek.objects.existing()
 
     @property


### PR DESCRIPTION
Display completeness fields in detail view if object is not complete, for models with PublishableMixin:

- Trek, POI
- TouristicContent, TouristicEvent
- Dive
- Site, Course

With `COMPLETENESS_LEVEL = 'error_on_publication'`, form raises a validation error on publish, and with  or `COMPLETENESS_LEVEL = 'error_on_review'` it also raises error on review.