### PR TITLE
Precise formats handled by `loadXX` commands

### DIFF
--- a/docs/import.rst
+++ b/docs/import.rst
@@ -116,7 +116,7 @@ Open the top right menu and clic on ``imports``.
 Import from a file
 ------------------
 
-You can also use some of Geotrek commands to import data from a file.
+You can also use some of Geotrek commands to import data from a file which format is handled by https://docs.djangoproject.com/en/4.0/ref/contrib/gis/gdal/(Django GDAL API) (e.g.: Shapefile, GeoJSON, etc.)
 
 Possible data are e.g.: POI, infrastructures, signages, cities, districts, restricted areas.
 


### PR DESCRIPTION
If I understand correctly, all GDAL API-handled formats can be imported via `loadpoi`, `loadsignage` (etc.) commands or Geotrek-admin UI. It's useful to know it, so correct the PR with the correct formats if i'm wrong.