### PR TITLE
Add doc for control characters count in TinyMCE fields

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -200,6 +200,7 @@ Do not use, or set ``ENABLE_REPORT_COLORS_PER_STATUS`` to False, else objects wi
 
 - Server-side list pagination. Better performance for large lists (#2967)
 - Add overlays for objects from Trekking, Maintenance, Infrastructure and Feedback modules (#1300)
+- Add ``MAX_CHARACTERS`` to be used with django-mapentity >= 8.1
 
 **Minor improvements**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -200,7 +200,6 @@ Do not use, or set ``ENABLE_REPORT_COLORS_PER_STATUS`` to False, else objects wi
 
 - Server-side list pagination. Better performance for large lists (#2967)
 - Add overlays for objects from Trekking, Maintenance, Infrastructure and Feedback modules (#1300)
-- Add ``MAX_CHARACTERS`` to be used with django-mapentity >= 8.1
 
 **Minor improvements**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,8 @@ CHANGELOG
 - Add setting ``ALERT_DRAFT`` which send mail whenever a path has been changed to draft (#2904)
 - Add file type to attachments in API v2 (#3189)
 - Add possibility to use different type of file with import form
-- Add setting MAX_CHARACTERS for rich text fields with Mapentity 8.2.0 (#2901)
-- Set map resizable with Mapentity 8.2.0 (#3162)
+- Add setting MAX_CHARACTERS for rich text fields with Mapentity 8.2.1 (#2901)
+- Set map resizable with Mapentity 8.2.1 (#3162)
 
 **Minor improvements**
 
@@ -32,7 +32,7 @@ CHANGELOG
 
 **Maintenance**
 
-- Upgrade mapentity to 8.2.0
+- Upgrade mapentity to 8.2.1
 
 
 2.85.0     (2022-07-26)

--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -365,16 +365,19 @@ This will apply to all text fields.
 For more information on configuration entries available, please refer to the
 official documentation of *TinyMCE version 3*.
 
-Max characters count
-''''''''''''''''''''
 
-It is possible to set a ``MAX_CHARACTERS`` to advise user a max characters number
-to be used in TinyMCE fields.
+Max characters count
+~~~~~~~~~~~~~~~~~~~~
+
+Add ``MAX_CHARACTERS`` setting to be able to define a maximum number of characters
+for text fields (to be used with django-mapentity >= 8.1).
 
 .. code-block :: python
 
     MAPENTITY_CONFIG['MAX_CHARACTERS'] = 1500
 
+This will apply to all text fields.
+See `this issue <https://github.com/GeotrekCE/Geotrek-admin/issues/2901>`_ for details.
 
 View attachments in the browser
 -------------------------------

--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -365,6 +365,16 @@ This will apply to all text fields.
 For more information on configuration entries available, please refer to the
 official documentation of *TinyMCE version 3*.
 
+Max characters count
+''''''''''''''''''''
+
+It is possible to set a ``MAX_CHARACTERS`` to advise user a max characters number
+to be used in TinyMCE fields.
+
+.. code-block :: python
+
+    MAPENTITY_CONFIG['MAX_CHARACTERS'] = 1500
+
 
 View attachments in the browser
 -------------------------------

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -649,7 +649,7 @@ TINYMCE_DEFAULT_CONFIG = {
     'convert_urls': False,
     "toolbar": "bold italic forecolor | bullist numlist link image media | "
                "undo redo | "
-               "removeformat | code",
+               "removeformat | code | wordcount | help",
     "paste_as_text": True
 }
 

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -406,7 +406,8 @@ MAPENTITY_CONFIG = {
                      'arrowColor': 'black', 'arrowSize': 10},
         }
     },
-    'REGEX_PATH_ATTACHMENTS': r'\.\d+x\d+_q\d+(_crop)?(_watermark-\w+)?\.(jpg|png|jpeg)$'
+    'REGEX_PATH_ATTACHMENTS': r'\.\d+x\d+_q\d+(_crop)?(_watermark-\w+)?\.(jpg|png|jpeg)$',
+    'MAX_CHARACTERS': 0,
 }
 
 MAP_STYLES = {}  # backward compatibility. Don't use this settings anymore, use MAPENTITY_CONFIG['MAP_STYLES']

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -407,7 +407,7 @@ MAPENTITY_CONFIG = {
         }
     },
     'REGEX_PATH_ATTACHMENTS': r'\.\d+x\d+_q\d+(_crop)?(_watermark-\w+)?\.(jpg|png|jpeg)$',
-    'MAX_CHARACTERS': 0,
+    'MAX_CHARACTERS': None,
 }
 
 MAP_STYLES = {}  # backward compatibility. Don't use this settings anymore, use MAPENTITY_CONFIG['MAP_STYLES']


### PR DESCRIPTION
This PR allows to control characters count in TinyMCE fields, using max characters count setting `MAX_CHARACTERS` (default = 0)

Can ben merge when this PR is merged and a new release for Mapentity https://github.com/makinacorpus/django-mapentity/pull/237 for details.

