### PR TITLE
Fix maxZoom level for OpenTopoMap in settings/base.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,10 @@ CHANGELOG
 
 - New common interface github actions
 
+**Bug fixes**
+
+- Set relevant max zoom level for OpenTopoMap in the default config
+
 
 2.85.0     (2022-07-26)
 -----------------------

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -436,7 +436,9 @@ ALTIMETRIC_AREA_MARGIN = 0.15
 LEAFLET_CONFIG = {
     'SRID': 3857,
     'TILES': [
-        ('OpenTopoMap', 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', 'Données: © Contributeurs OpenStreetMap, SRTM | Affichage: © OpenTopoMap (CC-BY-SA)'),
+        ('OpenTopoMap', 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+         {'attribution': 'Données: © Contributeurs OpenStreetMap, SRTM | Affichage: © OpenTopoMap (CC-BY-SA)',
+          'maxZoom': 17}),
         ('OSM', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', '© Contributeurs OpenStreetMap'),
     ],
     'TILES_EXTENT': SPATIAL_EXTENT,


### PR DESCRIPTION
We found out that on maximum zoom the OpenTopoMap disappears. That is because OpenTopoMap max zoom level is 17 (leaflet default is 18).