### PR TITLE
Add 'source', 'portal' and 'structure' to Cirkwi trek exports

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ CHANGELOG
 - Add file type to attachments in API v2 (#3189)
 - Add possibility to use different type of file with import form
 - Add setting MAX_CHARACTERS for rich text fields with Mapentity 8.2.1 (#2901)
-- Set map resizable with Mapentity 8.2.1 (#3162, #3164)
+- Set map resizable with Mapentity 8.2.1 (#3162)
 
 **Minor improvements**
 
@@ -21,7 +21,7 @@ CHANGELOG
 - Change translation for Tag in Feedback module
 - Change concatenation of null value for multiples values from '*' to '_' on sql views
 - Prevent "Internal Error" on API v2 when wrong url parameter is provided
-- Add 'source', 'portal', 'labels' and 'structure' to Cirkwi trek exports (#3220)
+- Add 'source', 'portal', 'labels' and 'structure' to Cirkwi trek exports (#3220, #3164)
 
 **New ci**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ CHANGELOG
 - Change translation for Tag in Feedback module
 - Change concatenation of null value for multiples values from '*' to '_' on sql views
 - Prevent "Internal Error" on API v2 when wrong url parameter is provided
+- Add 'source', 'portal' and 'structure' to Cirkwi trek exports (#3220)
 
 **New ci**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ CHANGELOG
 - Add file type to attachments in API v2 (#3189)
 - Add possibility to use different type of file with import form
 - Add setting MAX_CHARACTERS for rich text fields with Mapentity 8.2.1 (#2901)
-- Set map resizable with Mapentity 8.2.1 (#3162)
+- Set map resizable with Mapentity 8.2.1 (#3162, #3164)
 
 **Minor improvements**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ CHANGELOG
 - Change translation for Tag in Feedback module
 - Change concatenation of null value for multiples values from '*' to '_' on sql views
 - Prevent "Internal Error" on API v2 when wrong url parameter is provided
-- Add 'source', 'portal' and 'structure' to Cirkwi trek exports (#3220)
+- Add 'source', 'portal', 'labels' and 'structure' to Cirkwi trek exports (#3220)
 
 **New ci**
 

--- a/geotrek/cirkwi/serializers.py
+++ b/geotrek/cirkwi/serializers.py
@@ -163,6 +163,14 @@ class CirkwiTrekSerializer(CirkwiPOISerializer):
                 self.serialize_field('tag_public', '', {'id': str(tag.eid), 'nom': tag.name})
             self.xml.endElement('tags_publics')
 
+    def serialize_labels(self, trek):
+        for label in trek.labels.all():
+            value = plain_text(label.advice)
+            self.xml.startElement('information_complementaire', {})
+            self.serialize_field('titre', label.name)
+            self.serialize_field('description', value)
+            self.xml.endElement('information_complementaire')
+
     # TODO: parking location (POI?), points_reference
     def serialize(self, treks):
         self.xml.startDocument()
@@ -185,6 +193,7 @@ class CirkwiTrekSerializer(CirkwiPOISerializer):
                     self.xml.startElement('informations_complementaires', {})
                     for name in self.ADDITIONNAL_INFO:
                         self.serialize_additionnal_info(trek, name)
+                    self.serialize_labels(trek)
                     self.xml.endElement('informations_complementaires')
                 self.serialize_tags(trek)
                 self.xml.endElement('information')

--- a/geotrek/cirkwi/serializers.py
+++ b/geotrek/cirkwi/serializers.py
@@ -111,6 +111,25 @@ class CirkwiTrekSerializer(CirkwiPOISerializer):
         self.serialize_field('description', value)
         self.xml.endElement('information_complementaire')
 
+    def serialize_tracking_info(self, trek):
+        attrs = {}
+        self.xml.startElement('portals', {})
+        for portal in trek.portal.all():
+            attrs['id'] = str(portal.pk)
+            attrs['nom'] = portal.name
+            self.serialize_field('portal', '', attrs)
+        self.xml.endElement('portals')
+        self.xml.startElement('sources', {})
+        for source in trek.source.all():
+            attrs['id'] = str(source.pk)
+            attrs['nom'] = source.name
+            self.serialize_field('source', '', attrs)
+        self.xml.endElement('sources')
+        if trek.structure:
+            attrs['id'] = str(trek.structure.pk)
+            attrs['nom'] = trek.structure.name
+            self.serialize_field('structure', '', attrs)
+
     def serialize_locomotions(self, trek):
         attrs = {}
         if trek.practice and trek.practice.cirkwi:
@@ -176,11 +195,13 @@ class CirkwiTrekSerializer(CirkwiPOISerializer):
             kml_url = reverse('trekking:trek_kml_detail',
                               kwargs={'lang': get_language(), 'pk': trek.pk, 'slug': trek.slug})
             self.serialize_field('fichier_trace', '', {'url': self.request.build_absolute_uri(kml_url)})
-            if not self.exclude_pois:
-                if trek.published_pois:
-                    self.xml.startElement('pois', {})
-                    self.serialize_pois(trek.published_pois.annotate(transformed_geom=Transform('geom', 4326)))
-                    self.xml.endElement('pois')
+            self.xml.startElement('tracking_information', {})
+            self.serialize_tracking_info(trek)
+            self.xml.endElement('tracking_information')
+            if not self.exclude_pois and trek.published_pois:
+                self.xml.startElement('pois', {})
+                self.serialize_pois(trek.published_pois.annotate(transformed_geom=Transform('geom', 4326)))
+                self.xml.endElement('pois')
             self.xml.endElement('circuit')
         self.xml.endElement('circuits')
         self.xml.endDocument()

--- a/geotrek/cirkwi/tests/test_views.py
+++ b/geotrek/cirkwi/tests/test_views.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 
 from django.utils.timezone import utc, make_aware
 
-from geotrek.common.tests.factories import AttachmentFactory, RecordSourceFactory, TargetPortalFactory
+from geotrek.common.tests.factories import AttachmentFactory, LabelFactory, RecordSourceFactory, TargetPortalFactory
 from geotrek.common.tests import TranslationResetMixin
 
 from geotrek.authent.tests.factories import StructureFactory
@@ -33,6 +33,9 @@ class CirkwiTests(TranslationResetMixin, TestCase):
         cls.trek.portal.set([cls.portal_1, cls.portal_2])
         cls.trek.source.set([cls.source_1, cls.source_2])
         POIFactory.create(published=False, paths=[cls.path])
+        cls.label_1 = LabelFactory(advice_fr="Lorep ipsum 1 fr", advice_en="Lorep ipsum 1 en")
+        cls.label_2 = LabelFactory(advice_fr="Lorep ipsum 2 fr", advice_en="Lorep ipsum 2 en")
+        cls.trek.labels.set([cls.label_1, cls.label_2])
 
     def setUp(self):
         self.poi = POIFactory.create(published=True, paths=[self.path])
@@ -69,7 +72,10 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<information_complementaire><titre>Accessibility infrastructure</titre><description>Accessibility infrastructure</description></information_complementaire>'
             '<information_complementaire><titre>Advised parking</titre><description>Advised parking</description></information_complementaire>'
             '<information_complementaire><titre>Public transport</titre><description>Public transport</description></information_complementaire>'
-            '<information_complementaire><titre>Advice</titre><description>Advice</description></information_complementaire></informations_complementaires>'
+            '<information_complementaire><titre>Advice</titre><description>Advice</description></information_complementaire>'
+            '<information_complementaire><titre>Label</titre><description>Lorep ipsum 1 en</description></information_complementaire>'
+            '<information_complementaire><titre>Label</titre><description>Lorep ipsum 2 en</description></information_complementaire>'
+            '</informations_complementaires>'
             '</information>'
             '</informations>'
             '<distance>141</distance>'
@@ -180,7 +186,10 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<information_complementaire><titre>Accessibility infrastructure</titre><description>Accessibility infrastructure</description></information_complementaire>'
             '<information_complementaire><titre>Advised parking</titre><description>Advised parking</description></information_complementaire>'
             '<information_complementaire><titre>Public transport</titre><description>Public transport</description></information_complementaire>'
-            '<information_complementaire><titre>Advice</titre><description>Advice</description></information_complementaire></informations_complementaires>'
+            '<information_complementaire><titre>Advice</titre><description>Advice</description></information_complementaire>'
+            '<information_complementaire><titre>Label</titre><description>Lorep ipsum 1 en</description></information_complementaire>'
+            '<information_complementaire><titre>Label</titre><description>Lorep ipsum 2 en</description></information_complementaire>'
+            '</informations_complementaires>'
             '</information>'
             '</informations>'
             '<distance>141</distance>'

--- a/geotrek/cirkwi/tests/test_views.py
+++ b/geotrek/cirkwi/tests/test_views.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 
 from django.utils.timezone import utc, make_aware
 
-from geotrek.common.tests.factories import AttachmentFactory, TargetPortalFactory
+from geotrek.common.tests.factories import AttachmentFactory, RecordSourceFactory, TargetPortalFactory
 from geotrek.common.tests import TranslationResetMixin
 
 from geotrek.authent.tests.factories import StructureFactory
@@ -26,6 +26,12 @@ class CirkwiTests(TranslationResetMixin, TestCase):
         cls.trek.date_insert = cls.creation
         cls.trek.save()
         TrekFactory.create(published=False, paths=[cls.path])
+        portal_1 = TargetPortalFactory()
+        portal_2 = TargetPortalFactory()
+        source_1 = RecordSourceFactory()
+        source_2 = RecordSourceFactory()
+        cls.trek.portal.set([portal_1, portal_2])
+        cls.trek.source.set([source_1, source_2])
         POIFactory.create(published=False, paths=[cls.path])
 
     def setUp(self):
@@ -69,6 +75,21 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<distance>141</distance>'
             '<locomotions><locomotion duree="5400"></locomotion></locomotions>'
             '<fichier_trace url="http://testserver/api/en/treks/{pk}/trek.kml"></fichier_trace>'
+            '<tracking_information>'
+            '<portals>'
+            '<portal id="3" nom="Target Portal 2">'
+            '</portal>'
+            '<portal id="4" nom="Target Portal 3">'
+            '</portal>'
+            '</portals>'
+            '<sources>'
+            '<source id="1" nom="Record source 0">'
+            '</source>'
+            '<source id="2" nom="Record source 1">'
+            '</source>'
+            '</sources>'
+            '<structure id="4" nom="My structure"></structure>'
+            '</tracking_information>'
             '<pois>'
             '<poi date_creation="1388534400" date_modification="{poi_date_update}" id_poi="{poi_pk}">'
             '<informations>'
@@ -165,6 +186,21 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<distance>141</distance>'
             '<locomotions><locomotion duree="5400"></locomotion></locomotions>'
             '<fichier_trace url="http://testserver/api/en/treks/{pk}/trek.kml"></fichier_trace>'
+            '<tracking_information>'
+            '<portals>'
+            '<portal id="3" nom="Target Portal 2">'
+            '</portal>'
+            '<portal id="4" nom="Target Portal 3">'
+            '</portal>'
+            '</portals>'
+            '<sources>'
+            '<source id="1" nom="Record source 0">'
+            '</source>'
+            '<source id="2" nom="Record source 1">'
+            '</source>'
+            '</sources>'
+            '<structure id="4" nom="My structure"></structure>'
+            '</tracking_information>'
             '</circuit>'
             '</circuits>'.format(**attrs))
 

--- a/geotrek/cirkwi/tests/test_views.py
+++ b/geotrek/cirkwi/tests/test_views.py
@@ -26,12 +26,12 @@ class CirkwiTests(TranslationResetMixin, TestCase):
         cls.trek.date_insert = cls.creation
         cls.trek.save()
         TrekFactory.create(published=False, paths=[cls.path])
-        portal_1 = TargetPortalFactory()
-        portal_2 = TargetPortalFactory()
-        source_1 = RecordSourceFactory()
-        source_2 = RecordSourceFactory()
-        cls.trek.portal.set([portal_1, portal_2])
-        cls.trek.source.set([source_1, source_2])
+        cls.portal_1 = TargetPortalFactory()
+        cls.portal_2 = TargetPortalFactory()
+        cls.source_1 = RecordSourceFactory()
+        cls.source_2 = RecordSourceFactory()
+        cls.trek.portal.set([cls.portal_1, cls.portal_2])
+        cls.trek.source.set([cls.source_1, cls.source_2])
         POIFactory.create(published=False, paths=[cls.path])
 
     def setUp(self):
@@ -77,18 +77,18 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<fichier_trace url="http://testserver/api/en/treks/{pk}/trek.kml"></fichier_trace>'
             '<tracking_information>'
             '<portals>'
-            '<portal id="3" nom="Target Portal 2">'
+            f'<portal id="{self.portal_1.pk}" nom="{self.portal_1.name}">'
             '</portal>'
-            '<portal id="4" nom="Target Portal 3">'
+            f'<portal id="{self.portal_2.pk}" nom="{self.portal_2.name}">'
             '</portal>'
             '</portals>'
             '<sources>'
-            '<source id="1" nom="Record source 0">'
+            f'<source id="{self.source_1.pk}" nom="{self.source_1.name}">'
             '</source>'
-            '<source id="2" nom="Record source 1">'
+            f'<source id="{self.source_2.pk}" nom="{self.source_2.name}">'
             '</source>'
             '</sources>'
-            '<structure id="4" nom="My structure"></structure>'
+            f'<structure id="{self.trek.structure.pk}" nom="My structure"></structure>'
             '</tracking_information>'
             '<pois>'
             '<poi date_creation="1388534400" date_modification="{poi_date_update}" id_poi="{poi_pk}">'
@@ -188,18 +188,18 @@ class CirkwiTests(TranslationResetMixin, TestCase):
             '<fichier_trace url="http://testserver/api/en/treks/{pk}/trek.kml"></fichier_trace>'
             '<tracking_information>'
             '<portals>'
-            '<portal id="3" nom="Target Portal 2">'
+            f'<portal id="{self.portal_1.pk}" nom="{self.portal_1.name}">'
             '</portal>'
-            '<portal id="4" nom="Target Portal 3">'
+            f'<portal id="{self.portal_2.pk}" nom="{self.portal_2.name}">'
             '</portal>'
             '</portals>'
             '<sources>'
-            '<source id="1" nom="Record source 0">'
+            f'<source id="{self.source_1.pk}" nom="{self.source_1.name}">'
             '</source>'
-            '<source id="2" nom="Record source 1">'
+            f'<source id="{self.source_2.pk}" nom="{self.source_2.name}">'
             '</source>'
             '</sources>'
-            '<structure id="4" nom="My structure"></structure>'
+            f'<structure id="{self.trek.structure.pk}" nom="My structure"></structure>'
             '</tracking_information>'
             '</circuit>'
             '</circuits>'.format(**attrs))


### PR DESCRIPTION
```
<tracking_information>
  <portals>
    <portal id="1" nom="Portail 1"/>
    <portal id="2" nom="Portail 2"/>
  </portals>
  <sources>
    <source id="2" nom="Autre source"/>
    <source id="1" nom="IGN"/>
  </sources>
  <structure id="1" nom="CD04"/>
</tracking_information>
```
dans le bloc "informations" de chaque langue on ajoute les labels:

```
<information_complementaire>
    <titre>Coeur de parc</titre>
    <description>Itinéraire au coeur du parc</description>
</information_complementaire>
```