### PR TITLE
Fix synchro rando after fresh install on Debian

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -117,6 +117,7 @@ if [ "$MANAGE_DB" = "true" ] && [ -z "$2" ]; then
 		cd $dir > /dev/null
 		cp -r * /opt/geotrek-admin/var/media/upload/
 	done
+	chown --recursive geotrek:geotrek /opt/geotrek-admin/var/media/upload/*
 fi
 
 echo "Reload" >&2

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,9 @@ CHANGELOG
 2.87.1+dev (XXXX-XX-XX)
 -----------------------
 
--
+**Bug fixes**
+
+- Fix PermissionError during sync-rando on fresh install from .deb package
 
 
 2.87.1 (2022-09-20)


### PR DESCRIPTION
root owned installed media files from fixtures. Sync rando ran from the web UI (with geotrek system user) could not process those files resulting in a PermissionError.