### PR TITLE
Have parsers set is_image field on attachments (generates thumbnails)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ CHANGELOG
 
 - Add `default_language` attribute to Parsers to specify which language to update
 
+**Minor improvements**
+
+- Ensure attachments from parsers have generated thumbnails 
+
 **Bug fixes**
 
 - Fix `provider` is not used properly when parsing TouristicContents

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -747,7 +747,9 @@ class AttachmentParserMixin:
         attachments_to_delete = list(Attachment.objects.attachments_for_object(self.obj))
         updated, attachments = self.generate_attachments(src, val, attachments_to_delete, updated)
         Attachment.objects.bulk_create(attachments)
-
+        # TODO : attachments from parsers should be resized
+        #  See https://github.com/makinacorpus/django-paperclip/blob/master/paperclip/models.py#L124
+        # `bulk_create` does not call this `save` method
         self.remove_attachments(attachments_to_delete)
         return updated
 

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -701,6 +701,7 @@ class AttachmentParserMixin:
             except UnidentifiedImageError:
                 pass
             attachment.attachment_file.save(name, f, save=False)
+            attachment.is_image = attachment.is_an_image()
         else:
             attachment.attachment_link = url
         return True, updated

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -207,6 +207,7 @@ class AttachmentParserTests(TestCase):
         self.assertEqual(attachment.content_object, organism)
         self.assertEqual(attachment.attachment_file.name, 'paperclip/common_organism/{pk}/titi.png'.format(pk=organism.pk))
         self.assertEqual(attachment.filetype, self.filetype)
+        self.assertTrue(attachment.is_image)
         self.assertTrue(os.path.exists(attachment.attachment_file.path), True)
 
     @mock.patch('requests.get')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26015573/191933378-ad7de186-7a70-49cc-8d9b-757901360727.png)
