### PR TITLE
Feat/eventlegacy

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,7 @@ CHANGELOG
 
 **Breaking change**
 
-- Rename `participant_number` to `capacity` for TouristicEvent: APIv2 serialisation for TouristicEvent now exposes `capacity` instead of `participant_number`
+- Rename `participant_number` to `capacity` for TouristicEvent: APIv2 serialisation for TouristicEvent now exposes `capacity` instead of `participant_number`.  The field is still available in api v2 for compatibility but will be remove in few month
 
 
 2.87.2 (2022-09-23)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,7 @@ CHANGELOG
 
 **Breaking change**
 
-- Rename `meeting_time` to `start_time` for TouristicEvent: APIv2 serialisation for TouristicEvent now exposes `start_time` instead of `meeting_time`
+- Rename `meeting_time` to `start_time` for TouristicEvent: APIv2 serialisation for TouristicEvent now exposes `start_time` instead of `meeting_time`. The field is still available in api v2 for compatibility but will be remove in few month
 
 **Breaking change**
 

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -3024,11 +3024,12 @@ class TouristicEventTestCase(BaseApiTest):
 
     def test_touristic_event_legacy(self):
         response = self.get_touristicevent_list({'fields': 'meeting_time'})
-        self.assertEqual(sorted(response.json().get('features')[0].get('properties').keys()),
+        
+        self.assertEqual(sorted(response.json().get('results')[0].keys()),
                             ['meeting_time'])
 
         response = self.get_touristicevent_list({'fields': 'meeting_time,start_time'})
-        self.assertEqual(sorted(response.json().get('features')[0].get('properties').keys()),
+        self.assertEqual(sorted(response.json().get('results')[0].keys()),
                             ['meeting_time', 'start_time'])
 
 

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -3024,13 +3024,12 @@ class TouristicEventTestCase(BaseApiTest):
 
     def test_touristic_event_legacy(self):
         response = self.get_touristicevent_list({'fields': 'meeting_time'})
-        
-        self.assertEqual(sorted(response.json().get('results')[0].keys()),
-                            ['meeting_time'])
-
+        self.assertEqual(sorted(response.json().get('results')[0].keys()), ['meeting_time'])
         response = self.get_touristicevent_list({'fields': 'meeting_time,start_time'})
         self.assertEqual(sorted(response.json().get('results')[0].keys()),
                             ['meeting_time', 'start_time'])
+        response = self.get_touristicevent_list({'fields': 'participant_number'})
+        self.assertEqual(sorted(response.json().get('results')[0].keys()), ['participant_number'])
 
 
 class TouristicEventTypeTestCase(BaseApiTest):

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -216,8 +216,6 @@ TOURISTIC_EVENT_DETAIL_JSON_STRUCTURE = sorted([
     'meeting_point', 'start_time', 'end_time', 'name', 'organizer', 'capacity', 'pdf', 'portal',
     'practical_info', 'provider', 'published', 'source', 'speaker', 'structure', 'target_audience', 'themes',
     'type', 'update_datetime', 'url', 'uuid', 'website', 'cancelled', 'cancellation_reason', 
-    # LEGACY TO REMOVE
-    'meeting_time'
 ])
 
 TOURISTIC_EVENT_TYPE_DETAIL_JSON_STRUCTURE = sorted([
@@ -3023,6 +3021,15 @@ class TouristicEventTestCase(BaseApiTest):
         self.assertEqual(response.json().get("count"), 1)
         response = self.get_touristicevent_list({'bookable': 'False'})
         self.assertEqual(response.json().get("count"), 2)
+
+    def test_touristic_event_legacy(self):
+        response = self.get_touristicevent_list({'fields': 'meeting_time'})
+        self.assertEqual(sorted(response.json().get('features')[0].get('properties').keys()),
+                            ['meeting_time'])
+
+        response = self.get_touristicevent_list({'fields': 'meeting_time,start_time'})
+        self.assertEqual(sorted(response.json().get('features')[0].get('properties').keys()),
+                            ['meeting_time', 'start_time'])
 
 
 class TouristicEventTypeTestCase(BaseApiTest):

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -215,7 +215,9 @@ TOURISTIC_EVENT_DETAIL_JSON_STRUCTURE = sorted([
     'description', 'description_teaser', 'duration', 'email', 'end_date', 'external_id', 'geometry',
     'meeting_point', 'start_time', 'end_time', 'name', 'organizer', 'capacity', 'pdf', 'portal',
     'practical_info', 'provider', 'published', 'source', 'speaker', 'structure', 'target_audience', 'themes',
-    'type', 'update_datetime', 'url', 'uuid', 'website', 'cancelled', 'cancellation_reason'
+    'type', 'update_datetime', 'url', 'uuid', 'website', 'cancelled', 'cancellation_reason', 
+    # LEGACY TO REMOVE
+    'meeting_time'
 ])
 
 TOURISTIC_EVENT_TYPE_DETAIL_JSON_STRUCTURE = sorted([

--- a/geotrek/api/v2/mixins.py
+++ b/geotrek/api/v2/mixins.py
@@ -32,3 +32,22 @@ class PDFSerializerMixin:
             for language in settings.MODELTRANSLATION_LANGUAGES:
                 data[language] = self._get_pdf_url_lang(obj, language, portal)
         return data
+
+
+class LegacyFieldMixin:
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if not getattr(self, 'legacy_mapping'):
+            return representation
+
+        if not self.context.get('request').query_params.get('fields', None):
+            return representation
+
+        field_list = self.context.get('request').query_params['fields'].split(',')
+        legacy_field = [f for f in field_list if f in self.legacy_mapping.keys()]
+
+        for field in legacy_field:
+            representation[field] = getattr(instance, self.legacy_mapping[field])
+        return representation

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -7,6 +7,7 @@ from django.db.models import F
 from django.urls import reverse
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
+
 from drf_dynamic_fields import DynamicFieldsMixin
 from easy_thumbnails.alias import aliases
 from easy_thumbnails.exceptions import InvalidImageFormatError
@@ -448,6 +449,12 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
         end_date = serializers.SerializerMethodField()
         type = serializers.SerializerMethodField()
         cancellation_reason = serializers.SerializerMethodField()
+        meeting_time = serializers.TimeField(
+            source='start_time',
+            allow_null=True,
+            read_only=True,
+            label="DO NOT USE ANYMORE, will be removed in a few months. Old start_time field"
+        )
 
         def get_cancellation_reason(self, obj):
             if not obj.cancellation_reason:
@@ -472,7 +479,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
                 'start_time', 'end_time', 'name', 'organizer', 'capacity', 'pdf', 'portal',
                 'practical_info', 'published', 'provider', 'source', 'speaker', 'structure',
                 'target_audience', 'themes', 'type', 'update_datetime', 'url', 'uuid', 'website',
-                'cancelled', 'cancellation_reason'
+                'cancelled', 'cancellation_reason', 'meeting_time'
             )
 
     class InformationDeskTypeSerializer(DynamicFieldsMixin, serializers.ModelSerializer):

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -451,7 +451,8 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
         cancellation_reason = serializers.SerializerMethodField()
       
         legacy_mapping = {
-            'meeting_time': 'start_time'
+            'meeting_time': 'start_time',
+            'participant_number': 'capacity'
         }
 
         def get_cancellation_reason(self, obj):


### PR DESCRIPTION
Add rename fields in event api v2 :
- [x] create LegacyFieldMixin
- [x] meeting_time -> start_time
- [ ] participant_number -> capacity