### PR TITLE
Fix EspritParcParser

### DIFF
--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -550,7 +550,7 @@ class HebergementsApidaeParser(TouristicContentApidaeParser):
         return self.apply_filter('type1', src, [val])
 
 
-class EspritParcParser(AttachmentParserMixin, Parser):
+class EspritParcParser(AttachmentParserMixin, TouristicContentMixin, Parser):
     model = TouristicContent
     eid = 'eid'
     separator = None
@@ -654,22 +654,29 @@ class EspritParcParser(AttachmentParserMixin, Parser):
     def filter_type1(self, src, val):
         dst = []
         if val:
-            try:
-                dst.append(TouristicContentType1.objects.get(category=self.obj.category, label=val))
-            except TouristicContentType1.DoesNotExist:
-                self.add_warning(
-                    _("Type 1 '{subval}' does not exist for category '{cat}'. Please add it").format(
-                        subval=val, cat=self.obj.category.label))
+            if isinstance(val, str):
+                val = set(val)
+            for subval in val:
+                try:
+                    dst.append(TouristicContentType1.objects.get(category=self.obj.category, label=subval))
+                except TouristicContentType1.DoesNotExist:
+                    self.add_warning(
+                        _("Type 1 '{subval}' does not exist for category '{cat}'. Please add it").format(
+                            subval=subval, cat=self.obj.category.label))
         return dst
 
     def filter_type2(self, src, val):
         dst = []
         if val:
-            try:
-                dst.append(TouristicContentType2.objects.get(category=self.obj.category, label=val))
-            except TouristicContentType2.DoesNotExist:
-                self.add_warning(_("Type 2 '{subval}' does not exist for category '{cat}'. Please add it").format(
-                    subval=val, cat=self.obj.category.label))
+            if isinstance(val, str):
+                val = set(val)
+            for subval in val:
+                try:
+                    dst.append(TouristicContentType2.objects.get(category=self.obj.category, label=subval))
+                except TouristicContentType2.DoesNotExist:
+                    self.add_warning(
+                        _("Type 1 '{subval}' does not exist for category '{cat}'. Please add it").format(
+                            subval=subval, cat=self.obj.category.label))
         return dst
 
 

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -614,7 +614,7 @@ class EspritParcParser(AttachmentParserMixin, TouristicContentMixin, Parser):
 
     @property
     def items(self):
-        return self.root['responseData']
+        return self.root['responseData'] or []
 
     def next_row(self):
         response = self.request_or_retry(self.url)

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -655,7 +655,7 @@ class EspritParcParser(AttachmentParserMixin, TouristicContentMixin, Parser):
         dst = []
         if val:
             if isinstance(val, str):
-                val = set(val)
+                val = [val]
             for subval in val:
                 try:
                     dst.append(TouristicContentType1.objects.get(category=self.obj.category, label=subval))
@@ -669,13 +669,13 @@ class EspritParcParser(AttachmentParserMixin, TouristicContentMixin, Parser):
         dst = []
         if val:
             if isinstance(val, str):
-                val = set(val)
+                val = [val]
             for subval in val:
                 try:
                     dst.append(TouristicContentType2.objects.get(category=self.obj.category, label=subval))
                 except TouristicContentType2.DoesNotExist:
                     self.add_warning(
-                        _("Type 1 '{subval}' does not exist for category '{cat}'. Please add it").format(
+                        _("Type 2 '{subval}' does not exist for category '{cat}'. Please add it").format(
                             subval=subval, cat=self.obj.category.label))
         return dst
 


### PR DESCRIPTION
- Fix `filter_type1` and `filter_type2` for `EspritParcParser` when `val` is a list
- Fix "'NoneType' object is not iterable" when `responseData` is `null`