### PR TITLE
Fix bug that does not return a source in API when this source is link…

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.89.1+dev (XXXX-XX-XX)
 -----------------------
  
+**Bug fixes**
+
+- Fix APIv2 does not return sources related to published sites
+
 
 2.89.1 (2022-10-20)
 -----------------------

--- a/geotrek/api/v2/views/common.py
+++ b/geotrek/api/v2/views/common.py
@@ -24,7 +24,7 @@ class ThemeViewSet(api_viewsets.GeotrekViewSet):
 
 
 class SourceViewSet(api_viewsets.GeotrekViewSet):
-    filter_backends = api_viewsets.GeotrekViewSet.filter_backends + (api_filters.TrekRelatedPortalFilter,)
+    filter_backends = api_viewsets.GeotrekViewSet.filter_backends + (api_filters.TreksAndSitesRelatedPortalFilter,)
     serializer_class = api_serializers.RecordSourceSerializer
     queryset = common_models.RecordSource.objects.all()
 


### PR DESCRIPTION
…ed to a published site but not to a trek