### PR TITLE
Fix topology geom field migration

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ CHANGELOG
 2.91.1+dev (XXXX-XX-XX)
 -----------------------
 
-**Improvments**
+**Improvements**
 
 - Cache API v2 Detail endpoints and themes list endpoint
 - Sensitive areas are now computed with buffered geometries with settings SENSITIVE_AREA_INTERSECTION_MARGIN. Use ST_INTERSECTS on it is faster.
@@ -18,6 +18,7 @@ CHANGELOG
 **Bug fixes**
 
 - Check geom is valid before save
+- Fix old migration script of Topology.geom (actually causes Django to falsely detect model changes not yet with a migration in NDS mode)
 
 
 2.91.1     (2022-11-18)

--- a/geotrek/core/migrations/0030_auto_20220127_0939.py
+++ b/geotrek/core/migrations/0030_auto_20220127_0939.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='topology',
             name='geom',
-            field=django.contrib.gis.db.models.fields.GeometryField(default=None, editable=False, null=True, spatial_index=False, srid=settings.SRID),
+            field=django.contrib.gis.db.models.fields.GeometryField(default=None, editable=(not settings.TREKKING_TOPOLOGY_ENABLED), null=True, spatial_index=False, srid=settings.SRID),
         ),
         migrations.AddIndex(
             model_name='path',


### PR DESCRIPTION
When a field attribute depends on a setting one has to change the generated migration by hands to reflect the dependance by replacing hard-coded values from the dev environment with the setting.

This was missed on that migration leading to troubles when setting up a NDS instance.