### PR TITLE
Change default color of imported filelayer

### DIFF
--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -403,6 +403,8 @@ MAPENTITY_CONFIG = {
         'workmanagement': {'weight': 4, 'color': 'red', 'opacity': 1.0},
         'signagemanagement': {'weight': 5, 'color': 'red', 'opacity': 1.0},
 
+        'filelayer': {'color': 'blue', 'opacity': 1.0, 'fillOpacity': 0.9, 'weight': 3, 'radius': 5},
+
         'detail': {'color': '#ffff00'},
         'others': {'color': '#ffff00'},
 


### PR DESCRIPTION
As mentionned in ticket #306, the red color of imported file layer can't be seen easily in front of path color. Other structures encountered the same problem resulting in us frequently changing the path color in Geotrek customization.