### PR TITLE
🐛 Recreate cache folders if don't exist

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,6 +1,8 @@
 /opt/geotrek-admin/var/conf/extra_static
 /opt/geotrek-admin/var/log
 /opt/geotrek-admin/var/cache/sessions
+/opt/geotrek-admin/var/cache/api_v2
+/opt/geotrek-admin/var/cache/fat
 /opt/geotrek-admin/var/media/upload
 /opt/geotrek-admin/var/pid
 /opt/geotrek-admin/var/mobile

--- a/debian/postinst
+++ b/debian/postinst
@@ -48,6 +48,9 @@ fi
 mkdir -p /opt/geotrek-admin/var/conf/extra_static || true
 mkdir -p /opt/geotrek-admin/var/log || true
 mkdir -p /opt/geotrek-admin/var/media/upload || true
+mkdir -p /opt/geotrek-admin/var/cache/sessions || true
+mkdir -p /opt/geotrek-admin/var/cache/api_v2 || true
+mkdir -p /opt/geotrek-admin/var/cache/fat || true
 mkdir -p /opt/geotrek-admin/var/pid || true
 mkdir -p /opt/geotrek-admin/var/mobile || true
 chown -R geotrek.geotrek /opt/geotrek-admin/var || true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,8 @@ mkdir -p /opt/geotrek-admin/var/static \
          /opt/geotrek-admin/var/media/upload \
          /opt/geotrek-admin/var/data \
          /opt/geotrek-admin/var/cache/sessions \
+         /opt/geotrek-admin/var/cache/api_v2 \
+         /opt/geotrek-admin/var/cache/fat \
          /opt/geotrek-admin/var/log \
          /opt/geotrek-admin/var/conf/extra_templates \
          /opt/geotrek-admin/var/conf/extra_locale \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,10 @@ In preparation for HD Views developments (PR #3298)
 - Bump django-clearcache to 1.2.1
 - Add libvips to dependencies
 
+**Bug fixes**
+
+- Recreate cache folders if missing.
+
 2.94.0     (2022-12-12)
 -----------------------
 
@@ -290,13 +294,6 @@ In preparation for HD Views developments (PR #3298)
   - django to 3.2.15
   - celery[redis] to 5.1.2
 
-**Warning**
-
-- You will need to delete your cache after this release upgrade.
-
-  - ``rm -r /opt/geotrek-admin/var/cache/*`` (or in <geotrek directory>/var/cache/* on docker)
-  - ``sudo dpkg-reconfigure geotrek-admin`` (or ``docker-compose restart``)
-
 **Suricate Workflow**  (#2366)
 
 - Do not unlock reports when resolving them
@@ -421,11 +418,6 @@ In preparation for HD Views developments (PR #3298)
     - See documentation https://geotrek.readthedocs.io/en/latest/install/installation.html#ubuntu-bionic-postgis-2.5-upgrade)
 
 **Warning**
-
-- You need to delete cache after this release upgrade.
-
-  - ``rm -r /opt/geotrek-admin/var/cache/*`` (or in <geotrek directory>/var/cache/* on docker)
-  - ``sudo dpkg-reconfigure geotrek-admin`` (or ``docker-compose restart``)
 
 - From now, Geotrek-admin is not installable on Ubuntu 18.04 bionic anymore. But upgrade are still available.
 - The default Nginx configuration template `has been improved <https://github.com/GeotrekCE/Geotrek-admin/commit/3d44447893037944f35cd4280e89021f693b3a1f>`_ to increase data loading performances. It is highly recommanded to apply changes to your Nginx configuration template (in ``/opt/geotrek-admin/var/conf/nginx.conf.in``).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ In preparation for HD Views developments (PR #3298)
 
 **Bug fixes**
 
-- Recreate cache folders if missing.
+- Recreate cache folders if missing. (#3384)
 
 2.94.0     (2022-12-12)
 -----------------------


### PR DESCRIPTION
Fix particular case where migrations flush and recreate cache folders, then user follow changelog directives and manually trash var/cache/* folder