### PR TITLE
🐛 Use X-Forwarded-Proto header to define API v2 cache key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ In preparation for HD Views developments (PR #3298)
 
 - Recreate cache folders if missing. (#3384)
 - Modify site's geometry before saving to avoid edition and export of shapefiles (#3399)
+- Fix API V2 cache key with X-Forwarded-Proto header (#3404)
 
 
 2.94.0     (2022-12-12)

--- a/geotrek/api/v2/viewsets.py
+++ b/geotrek/api/v2/viewsets.py
@@ -33,7 +33,8 @@ class GeotrekViewSet(RetrieveCacheResponseMixin, viewsets.ReadOnlyModelViewSet):
 
     def get_base_cache_string(self):
         """ return cache string as url path + ordered query params """
-        return f"{self.request.path}:{self.get_ordered_query_params()}:{self.request.accepted_renderer.format}"
+        proto_scheme = self.request.headers.get('X-Forwarded-Proto', self.request.scheme)  # take care about scheme defined in nginx.conf
+        return f"{self.request.path}:{self.get_ordered_query_params()}:{self.request.accepted_renderer.format}:{proto_scheme}"
 
     def get_object_cache_key(self, pk):
         """ return specific object cache key based on object date_update column"""


### PR DESCRIPTION
fix #3404 