### PR TITLE
Fix: APIDAE Trek parser now raises an error on not continuous segments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ CHANGELOG
 - Fix intervention datatable list if one intervention has no target
 - Fix intervention datatable list with interventions on lands
 - Fix signage's blade detail
+- APIDAE Trek parser now raises an import error on geometry with not continuous segments
 
 **Development**
 

--- a/geotrek/trekking/locale/de/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/de/LC_MESSAGES/django.po
@@ -521,6 +521,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr ""
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr "Roaming"

--- a/geotrek/trekking/locale/en/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/en/LC_MESSAGES/django.po
@@ -506,6 +506,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr ""
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr ""

--- a/geotrek/trekking/locale/es/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/es/LC_MESSAGES/django.po
@@ -506,6 +506,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr ""
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr ""

--- a/geotrek/trekking/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/fr/LC_MESSAGES/django.po
@@ -536,6 +536,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr "Itinéraire APIDAE %(eid_val)s à la ligne %(line)s"
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr "La géométrie ne peut pas être convertie en une unique feature continue de type LineString"
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr "itinerance"

--- a/geotrek/trekking/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/it/LC_MESSAGES/django.po
@@ -518,6 +518,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr ""
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr "itineranza"

--- a/geotrek/trekking/locale/nl/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/nl/LC_MESSAGES/django.po
@@ -506,6 +506,10 @@ msgstr ""
 msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
+msgid ""
+"The geometry cannot be converted to a single continuous LineString feature"
+msgstr ""
+
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"
 msgstr ""

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -962,6 +962,8 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         geos = ApidaeTrekParser._convert_to_geos(first_feature.geom)
         if geos.geom_type == 'MultiLineString':
             geos = geos.merged
+            if geos.geom_type == 'MultiLineString':
+                raise RowImportError(_("The geometry cannot be converted to a single continuous LineString feature"))
         return geos
 
     @staticmethod

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_not_continuous_segments.gpx
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_not_continuous_segments.gpx
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="GDAL 3.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="http://www.topografix.com/GPX/1/1"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+    <trk>
+        <trkseg>
+            <trkpt lon="3.41789" lat="46.12124"></trkpt>
+            <trkpt lon="3.41802" lat="46.121"></trkpt>
+            <trkpt lon="3.41816" lat="46.1209"></trkpt>
+            <trkpt lon="3.41841" lat="46.12076"></trkpt>
+            <trkpt lon="3.41865" lat="46.12068"></trkpt>
+            <trkpt lon="3.41877" lat="46.12066"></trkpt>
+            <trkpt lon="3.41887" lat="46.12064"></trkpt>
+            <trkpt lon="3.41886" lat="46.12061"></trkpt>
+            <trkpt lon="3.41884" lat="46.12057"></trkpt>
+        </trkseg>
+        <trkseg>
+            <trkpt lon="3.41573" lat="46.142"></trkpt>
+            <trkpt lon="3.41561" lat="46.14182"></trkpt>
+            <trkpt lon="3.41545" lat="46.14173"></trkpt>
+            <trkpt lon="3.41539" lat="46.14164"></trkpt>
+            <trkpt lon="3.41541" lat="46.14152"></trkpt>
+            <trkpt lon="3.41546" lat="46.14115"></trkpt>
+        </trkseg>
+        <trkseg>
+            <trkpt lon="3.41886" lat="46.12056"></trkpt>
+            <trkpt lon="3.41841" lat="46.12025"></trkpt>
+            <trkpt lon="3.41834" lat="46.12018"></trkpt>
+            <trkpt lon="3.41831" lat="46.12013"></trkpt>
+            <trkpt lon="3.41802" lat="46.11992"></trkpt>
+            <trkpt lon="3.41769" lat="46.11968"></trkpt>
+            <trkpt lon="3.41578" lat="46.11824"></trkpt>
+            <trkpt lon="3.41537" lat="46.11792"></trkpt>
+            <trkpt lon="3.4155" lat="6.11785"></trkpt>
+            <trkpt lon="3.41567" lat="46.11776"></trkpt>
+            <trkpt lon="3.41606" lat="46.11783"></trkpt>
+            <trkpt lon="3.41652" lat="46.11786"></trkpt>
+        </trkseg>
+    </trk>
+</gpx>

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1217,6 +1217,12 @@ class GpxToGeomTests(SimpleTestCase):
         self.assertAlmostEqual(first_point[0], 977776.9, delta=0.1)
         self.assertAlmostEqual(first_point[1], 6547354.8, delta=0.1)
 
+    def test_it_raises_an_error_on_not_continuous_segments(self):
+        gpx = self._get_gpx_from('geotrek/trekking/tests/data/apidae_trek_parser/trace_with_not_continuous_segments.gpx')
+
+        with self.assertRaises(RowImportError):
+            ApidaeTrekParser._get_geom_from_gpx(gpx)
+
     def test_it_handles_segment_with_single_point(self):
         gpx = self._get_gpx_from(
             'geotrek/trekking/tests/data/apidae_trek_parser/trace_with_single_point_segment.gpx'


### PR DESCRIPTION
If the `merge` action from django/gis's GEOS object fails to produce a single LineString feature a RowImportError exception is raised and the Trek from APIDAE is not imported.

This is necessary because the altimetry profile cannot be computed for geometries which are not a continuous LineString.