### PR TITLE
Improve APIDAE Trek parser output with entities external IDs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ CHANGELOG
 2.95.0+dev (XXXX-XX-XX)
 -----------------------
 
+**Minor improvements**
+
+- APIDAE Trek Parser output now shows APIDAE IDs of entities triggering warnings during import
+
+
 **Bug fixes**
 
 - Fix intervention datatable list if one intervention has no target

--- a/geotrek/trekking/locale/de/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: 2015-10-21 11:16+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -515,6 +515,10 @@ msgstr ""
 
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
+msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
 #. Translators: This is a slug (without space, accent or special char)

--- a/geotrek/trekking/locale/en/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -500,6 +500,10 @@ msgstr ""
 
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
+msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
 #. Translators: This is a slug (without space, accent or special char)

--- a/geotrek/trekking/locale/es/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: 2015-10-21 11:16+0200\n"
 "Last-Translator: jean-etienne.castagnede@makina-corpus.com\n"
 "Language-Team: \n"
@@ -500,6 +500,10 @@ msgstr ""
 
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
+msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
 #. Translators: This is a slug (without space, accent or special char)

--- a/geotrek/trekking/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: 2020-09-22 15:57+0000\n"
 "Last-Translator: Emmanuelle Helly <emmanuelle.helly@makina-corpus.com>\n"
 "Language-Team: French <https://weblate.makina-corpus.net/projects/geotrek-"
@@ -531,6 +531,10 @@ msgstr ""
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
 msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
+msgstr "Itinéraire APIDAE %(eid_val)s à la ligne %(line)s"
 
 #. Translators: This is a slug (without space, accent or special char)
 msgid "itinerancy"

--- a/geotrek/trekking/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: 2015-10-21 11:16+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -512,6 +512,10 @@ msgstr ""
 
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
+msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
 #. Translators: This is a slug (without space, accent or special char)

--- a/geotrek/trekking/locale/nl/LC_MESSAGES/django.po
+++ b/geotrek/trekking/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-12 16:05+0000\n"
+"POT-Creation-Date: 2023-01-31 11:17+0100\n"
 "PO-Revision-Date: 2015-10-21 11:16+0200\n"
 "Last-Translator: jean-etienne.castagnede@makina-corpus.com\n"
 "Language-Team: \n"
@@ -500,6 +500,10 @@ msgstr ""
 
 msgid ""
 "An error occured in children generation : {getattr(e, 'message', repr(e))}"
+msgstr ""
+
+#, python-format
+msgid "APIDAE Trek #%(eid_val)s at line %(line)s"
 msgstr ""
 
 #. Translators: This is a slug (without space, accent or special char)

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -614,6 +614,11 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
                 val = val.get(get_language())
         return val
 
+    def add_warning(self, msg):
+        key = _("APIDAE Trek #%(eid_val)s at line %(line)s") % {"eid_val": self.eid_val, "line": self.line}
+        warnings = self.warnings.setdefault(key, [])
+        warnings.append(msg)
+
     def end(self):
         self._finalize_related_treks_association()
 


### PR DESCRIPTION
La rapport d'import ressemble maintenant à :

> 
> 71/71 lignes importées.
> 64 enregistrements mis à jour.
> 5 enregistrements non modifiés.
> 2 avertissements :
> 
>     # APIDAE Trek #320507 at line 19:
>     - Le champ required 'multimedias' est manquant,
>     # APIDAE Trek #4787235 at line 44:
>     - The trek from APIDAE has no attachment with the type "PLAN",

Précedemment seul le numéro de ligne durant l'import était visible.