### PR TITLE
fix translation

### DIFF
--- a/geotrek/sensitivity/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/sensitivity/locale/fr/LC_MESSAGES/django.po
@@ -87,7 +87,7 @@ msgid "Description"
 msgstr "Description"
 
 msgid "Rule"
-msgstr "Règlement"
+msgstr "Règle"
 
 msgid "Rules"
 msgstr "Règlements"

--- a/geotrek/sensitivity/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/sensitivity/locale/fr/LC_MESSAGES/django.po
@@ -90,7 +90,7 @@ msgid "Rule"
 msgstr "Règle"
 
 msgid "Rules"
-msgstr "Règlements"
+msgstr "Règles"
 
 msgid "Sport practice"
 msgstr "Pratique sportive"

--- a/geotrek/sensitivity/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/sensitivity/locale/it/LC_MESSAGES/django.po
@@ -89,7 +89,7 @@ msgid "Rule"
 msgstr "Regola"
 
 msgid "Rules"
-msgstr "Regolamenti"
+msgstr "Regole"
 
 msgid "Sport practice"
 msgstr ""

--- a/geotrek/sensitivity/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/sensitivity/locale/it/LC_MESSAGES/django.po
@@ -86,7 +86,7 @@ msgid "Description"
 msgstr "Descrizione"
 
 msgid "Rule"
-msgstr "Regolamento"
+msgstr "Regola"
 
 msgid "Rules"
 msgstr "Regolamenti"


### PR DESCRIPTION
Fix Rule translation: 

              Il faudrait traduire ça en "Règle" et non "Règlement"

_Originally posted by @camillemonchicourt in https://github.com/GeotrekCE/Geotrek-admin/pull/3386#discussion_r1106753998_