### PR TITLE
Fix default pictogram for moutain bike practice

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ CHANGELOG
 
 - Fix: do not prevent activity mappings overriding in subclasses of APIDAE Trek parser
 - Fix permissions bypass structure was always needed on accessibility attachments (#3396)
+- Fix default pictogram for mountainbike practice (it was blurry on mobile apps)
 
 
 **Improvements**

--- a/geotrek/trekking/fixtures/upload/practice-mountainbike.svg
+++ b/geotrek/trekking/fixtures/upload/practice-mountainbike.svg
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg"
-     xmlns="http://www.w3.org/2000/svg" id="svg3804" version="1.1" viewBox="0 0 6.3994236 6.7506738">
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" id="svg3804"
+     version="1.1" viewBox="0 0 6.3994236 6.7506738" height="6.7506738mm" width="6.3994236mm">
     <defs id="defs3798"/>
     <metadata id="metadata3801">
         <rdf:RDF>


### PR DESCRIPTION
Add `height` and `width` attributes to the SVG file, it fixes a blurry display on mobile apps after the svg has been converted to png.