### PR TITLE
Fix: set back version number in changelog to 2.97.2+dev

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 CHANGELOG
 =========
 
-2.97.3+dev (XXXX-XX-XX)
+2.97.2+dev (XXXX-XX-XX)
 -----------------------
 
 **Bug fixes**


### PR DESCRIPTION
I had misunderstood release process and I thought the version number needed to be incremented. It did not.