### PR TITLE
Fix replacement of service pictogram paths with absolute URLs in API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ CHANGELOG
 - Fix: Remove user group creation in Outdoor fixture (#3524)
 - Fix: Configure nginx to invalidate mobile cache on language change
 - Fix: Configure large_image to use libvips even for PNG images (fixes HD Views for PNGs)
+- Fix: service pictograms' URLs are made absolute in the API output of Trek descriptions (#3321)
 
 
 **Maintenance**

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -297,6 +297,8 @@ class BaseApiTest(TestCase):
                                  '<img src="/media/upload/steep_descent.svg" alt="Descent">' \
                                  '<img src="https://testserver/media/upload/pedestre.svg" alt="" width="1848" height="1848">'
         cls.treks[0].description = html_content_with_imgs
+        cls.treks[0].description_teaser = html_content_with_imgs
+        cls.treks[0].ambiance = html_content_with_imgs
         cls.treks[0].save()
         cls.treks[0].themes.add(cls.theme)
         cls.treks[0].networks.add(cls.network)
@@ -1275,6 +1277,8 @@ class APIAccessAnonymousTestCase(BaseApiTest):
                                '<img alt="Descent" src="http://testserver/media/upload/steep_descent.svg"/>'\
                                '<img alt="" height="1848" src="https://testserver/media/upload/pedestre.svg" width="1848"/>'
         self.assertEqual(response.json()['description']['en'], expected_description)
+        self.assertEqual(response.json()['description_teaser']['en'], expected_description)
+        self.assertEqual(response.json()['ambiance']['en'], expected_description)
 
     def test_difficulty_list(self):
         response = self.get_difficulties_list()

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -293,6 +293,11 @@ class BaseApiTest(TestCase):
             cls.treks = trek_factory.TrekFactory.create_batch(cls.nb_treks, geom=cls.path.geom)
             trek_factory.POIFactory.create_batch(cls.nb_treks, geom=Point(0, 4))
             trek_factory.POIFactory.create_batch(cls.nb_treks, geom=Point(0, 5))
+        html_content_with_imgs = '<p>Some HTML content with images</p>' \
+                                 '<img src="/media/upload/steep_descent.svg" alt="Descent">' \
+                                 '<img src="https://testserver/media/upload/pedestre.svg" alt="" width="1848" height="1848">'
+        cls.treks[0].description = html_content_with_imgs
+        cls.treks[0].save()
         cls.treks[0].themes.add(cls.theme)
         cls.treks[0].networks.add(cls.network)
         cls.treks[0].labels.add(cls.label)
@@ -364,10 +369,7 @@ class BaseApiTest(TestCase):
             reservation_system=cls.reservation_system,
             practice=cls.practice,
             difficulty=cls.difficulty,
-            accessibility_level=cls.accessibility_level,
-            description='<p>Description</p>'
-                        '<img src="/media/upload/steep_descent.svg" alt="Descent">'
-                        '<img src="https://testserver/media/upload/pedestre.svg" alt="" width="1848" height="1848">'
+            accessibility_level=cls.accessibility_level
         )
         cls.parent.accessibilities.add(cls.accessibility)
         cls.parent.source.add(cls.source)
@@ -1264,6 +1266,15 @@ class APIAccessAnonymousTestCase(BaseApiTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['results'][0]['pdf'],
                          f'http://testserver/api/en/treks/{self.child2.pk}/child-2.pdf')
+
+    def test_trek_detail_img_src_are_completed_in_descriptions(self):
+        response = self.get_trek_detail(self.treks[0].pk)
+        self.assertEqual(response.status_code, 200)
+        # Note that tags are sorted and the HTML format slightly changed during the "src" processing.
+        expected_description = '<p>Some HTML content with images</p>'\
+                               '<img alt="Descent" src="http://testserver/media/upload/steep_descent.svg"/>'\
+                               '<img alt="" height="1848" src="https://testserver/media/upload/pedestre.svg" width="1848"/>'
+        self.assertEqual(response.json()['description']['en'], expected_description)
 
     def test_difficulty_list(self):
         response = self.get_difficulties_list()

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -1280,6 +1280,13 @@ class APIAccessAnonymousTestCase(BaseApiTest):
         self.assertEqual(response.json()['description_teaser']['en'], expected_description)
         self.assertEqual(response.json()['ambiance']['en'], expected_description)
 
+        # Same test requesting a specific language
+        response = self.get_trek_detail(self.treks[0].pk, params={'language': 'en'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['description'], expected_description)
+        self.assertEqual(response.json()['description_teaser'], expected_description)
+        self.assertEqual(response.json()['ambiance'], expected_description)
+
     def test_difficulty_list(self):
         response = self.get_difficulties_list()
         self.assertEqual(response.status_code, 200)

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -775,8 +775,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
                 imgs = soup.find_all('img')
                 for img in imgs:
                     if img.attrs['src'][0] == '/':
-                        base_url = self.context.get("request").build_absolute_uri("/")[:-1]
-                        img['src'] = base_url + img.attrs["src"]
+                        img['src'] = self.context.get("request").build_absolute_uri(img.attrs["src"])
                 # Note: beautifulsoup makes a valid HTML doc from the data,
                 # but we don't want <html> or <body> in the output
                 return "".join([str(c) for c in soup.find("body").children])

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -771,14 +771,12 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             def replace(html_content):
                 if not html_content:
                     return html_content
-                soup = BeautifulSoup(html_content, features="lxml")
+                soup = BeautifulSoup(html_content, features="html.parser")
                 imgs = soup.find_all('img')
                 for img in imgs:
                     if img.attrs['src'][0] == '/':
                         img['src'] = self.context.get("request").build_absolute_uri(img.attrs["src"])
-                # Note: beautifulsoup makes a valid HTML doc from the data,
-                # but we don't want <html> or <body> in the output
-                return "".join([str(c) for c in soup.find("body").children])
+                return str(soup)
 
             try:
                 for k, v in data.items():

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -668,30 +668,8 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
         def get_name(self, obj):
             return get_translation_or_dict('name', self, obj)
 
-        def replace_image_paths_with_urls(self, data):
-            def replace(html_content):
-                if not html_content:
-                    return html_content
-                soup = BeautifulSoup(html_content, features="lxml")
-                imgs = soup.find_all('img')
-                for img in imgs:
-                    if img.attrs['src'][0] == '/':
-                        base_url = self.context.get("request").build_absolute_uri("/")[:-1]
-                        img['src'] = base_url + img.attrs["src"]
-                # Note: beautifulsoup makes a valid HTML doc from the data,
-                # but we don't want <html> or <body> in the output
-                return "".join([str(c) for c in soup.find("body").children])
-
-            try:
-                for k, v in data.items():
-                    data[k] = replace(v)
-            except AttributeError:
-                data = replace(data)
-
-            return data
-
         def get_description(self, obj):
-            return self.replace_image_paths_with_urls(get_translation_or_dict('description', self, obj))
+            return self._replace_image_paths_with_urls(get_translation_or_dict('description', self, obj))
 
         def get_access(self, obj):
             return get_translation_or_dict('access', self, obj)
@@ -715,7 +693,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return get_translation_or_dict('accessibility_width', self, obj)
 
         def get_ambiance(self, obj):
-            return self.replace_image_paths_with_urls(get_translation_or_dict('ambiance', self, obj))
+            return self._replace_image_paths_with_urls(get_translation_or_dict('ambiance', self, obj))
 
         def get_disabled_infrastructure(self, obj):
             return get_translation_or_dict('accessibility_infrastructure', self, obj)
@@ -737,7 +715,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return get_translation_or_dict('arrival', self, obj)
 
         def get_description_teaser(self, obj):
-            return self.replace_image_paths_with_urls(get_translation_or_dict('description_teaser', self, obj))
+            return self._replace_image_paths_with_urls(get_translation_or_dict('description_teaser', self, obj))
 
         def get_length_3d(self, obj):
             return round(obj.length_3d_m, 1)
@@ -788,6 +766,28 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             geom = self.get_first_point(obj.geom)
             city = zoning_models.City.objects.all().filter(geom__contains=geom).first()
             return city.code if city else None
+
+        def _replace_image_paths_with_urls(self, data):
+            def replace(html_content):
+                if not html_content:
+                    return html_content
+                soup = BeautifulSoup(html_content, features="lxml")
+                imgs = soup.find_all('img')
+                for img in imgs:
+                    if img.attrs['src'][0] == '/':
+                        base_url = self.context.get("request").build_absolute_uri("/")[:-1]
+                        img['src'] = base_url + img.attrs["src"]
+                # Note: beautifulsoup makes a valid HTML doc from the data,
+                # but we don't want <html> or <body> in the output
+                return "".join([str(c) for c in soup.find("body").children])
+
+            try:
+                for k, v in data.items():
+                    data[k] = replace(v)
+            except AttributeError:
+                data = replace(data)
+
+            return data
 
         class Meta:
             model = trekking_models.Trek

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -715,7 +715,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return get_translation_or_dict('accessibility_width', self, obj)
 
         def get_ambiance(self, obj):
-            return get_translation_or_dict('ambiance', self, obj)
+            return self.replace_image_paths_with_urls(get_translation_or_dict('ambiance', self, obj))
 
         def get_disabled_infrastructure(self, obj):
             return get_translation_or_dict('accessibility_infrastructure', self, obj)
@@ -737,7 +737,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return get_translation_or_dict('arrival', self, obj)
 
         def get_description_teaser(self, obj):
-            return get_translation_or_dict('description_teaser', self, obj)
+            return self.replace_image_paths_with_urls(get_translation_or_dict('description_teaser', self, obj))
 
         def get_length_3d(self, obj):
             return round(obj.length_3d_m, 1)


### PR DESCRIPTION
Also expand to 'description_teaser' and 'ambiance' fields.

Should address issue [#3321](https://github.com/GeotrekCE/Geotrek-admin/issues/3321)