### PR TITLE
Fix: Apidae Events parser now handles integer values for capacity

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ CHANGELOG
 - Fix: Configure nginx to invalidate mobile cache on language change
 - Fix: Configure large_image to use libvips even for PNG images (fixes HD Views for PNGs)
 - Fix: service pictograms' URLs are made absolute in the API output of Trek descriptions (#3321)
+- Fix: APIDAE Events parser now handles integer values for capacity (`#3573 <https://github.com/GeotrekCE/Geotrek-admin/issues/3573>`_)
 
 
 **Maintenance**

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -338,6 +338,8 @@ class TouristicEventApidaeParser(AttachmentApidaeParserMixin, ApidaeParser):
         return '<br>'.join(lines)
 
     def filter_capacity(self, src, val):
+        if isinstance(val, int):
+            return val
         if val.isnumeric():
             return int(val)
         else:

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -471,6 +471,9 @@ class ParserTests(TranslationResetMixin, TestCase):
         self.assertEqual(Attachment.objects.count(), 3)
         self.assertEqual(TouristicEventApidaeParser().filter_capacity("capacity", "12"), 12)
 
+    def test_filter_capacity_handles_integers(self):
+        self.assertEqual(TouristicEventApidaeParser().filter_capacity("capacity", 27), 27)
+
     @mock.patch('geotrek.common.parsers.requests.get')
     def test_create_event_apidae_constant_fields(self, mocked):
         def mocked_json():


### PR DESCRIPTION
Issue https://github.com/GeotrekCE/Geotrek-admin/issues/3573