### PR TITLE
Add filter Published to outdoor course and outdoor site

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ CHANGELOG
 - Enable filtering lists by objects IDs on APIv2 (#3458)
 - Add information desks link on Treks with AggregatorParsers
 - Add filter by manager to Blades module
+- Add filter "Published" to outdoor course and outdoor site (#2810)
 
 
 **Improvements**

--- a/geotrek/outdoor/filters.py
+++ b/geotrek/outdoor/filters.py
@@ -23,7 +23,7 @@ class SiteFilterSet(ZoningFilterSet, StructureRelatedFilterSet):
     class Meta(StructureRelatedFilterSet.Meta):
         model = Site
         fields = StructureRelatedFilterSet.Meta.fields + [
-            'sector', 'practice', 'labels', 'themes', 'portal', 'source', 'information_desks',
+            'published', 'sector', 'practice', 'labels', 'themes', 'portal', 'source', 'information_desks',
             'web_links', 'type', 'orientation', 'wind', 'provider'
         ]
 
@@ -64,7 +64,7 @@ class CourseFilterSet(ZoningFilterSet, StructureRelatedFilterSet):
     class Meta(StructureRelatedFilterSet.Meta):
         model = Course
         fields = StructureRelatedFilterSet.Meta.fields + [
-            'parent_sites', 'parent_sites__practice__sector', 'parent_sites__practice', 'parent_sites__labels', 'parent_sites__themes',
+            'published', 'parent_sites', 'parent_sites__practice__sector', 'parent_sites__practice', 'parent_sites__labels', 'parent_sites__themes',
             'parent_sites__portal', 'parent_sites__source', 'parent_sites__type', 'orientation', 'wind',
             'height', 'provider'
         ]


### PR DESCRIPTION
The new filter allows you to sort outdoor courses and sites into two categories: those already published and those currently undergoing publication.