### PR TITLE
Add the "district" attribute to views containing the "cities" attribute in API V2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 - Add information desks link on Treks with AggregatorParsers
 - Add filter by manager to Blades module
 - Add filter "Published" to outdoor course and outdoor site (#2810)
+- Add a "district" attribute to views containing the "cities" attribute in API V2 (#3632)
 
 
 **Improvements**

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -68,7 +68,7 @@ TREK_PROPERTIES_GEOJSON_STRUCTURE = sorted([
     'accessibility_width', 'advice', 'advised_parking', 'altimetric_profile', 'ambiance', 'arrival', 'ascent',
     'attachments', 'attachments_accessibility', 'children', 'cities', 'create_datetime', 'departure', 'departure_geom',
     'descent', 'description', 'description_teaser', 'difficulty', 'departure_city',
-    'disabled_infrastructure', 'duration', 'elevation_area_url', 'elevation_svg_url', 'gear',
+    'disabled_infrastructure', 'districts', 'duration', 'elevation_area_url', 'elevation_svg_url', 'gear',
     'external_id', 'gpx', 'information_desks', 'kml', 'labels', 'length_2d',
     'length_3d', 'max_elevation', 'min_elevation', 'name', 'networks',
     'next', 'parents', 'parking_location', 'pdf', 'points_reference',
@@ -97,7 +97,7 @@ TOURISTIC_CONTENT_CATEGORY_DETAIL_JSON_STRUCTURE = sorted([
 
 TOURISTIC_CONTENT_DETAIL_JSON_STRUCTURE = sorted([
     'accessibility', 'approved', 'attachments', 'category', 'cities', 'contact', 'create_datetime', 'description',
-    'description_teaser', 'departure_city', 'email', 'external_id', 'geometry', 'id', 'label_accessibility', 'name', 'pdf',
+    'description_teaser', 'departure_city', 'districts', 'email', 'external_id', 'geometry', 'id', 'label_accessibility', 'name', 'pdf',
     'portal', 'practical_info', 'provider', 'published', 'reservation_id', 'reservation_system',
     'source', 'structure', 'themes', 'types', 'update_datetime', 'url', 'uuid', 'website',
 ])
@@ -151,7 +151,7 @@ SOURCE_PROPERTIES_JSON_STRUCTURE = sorted(['id', 'name', 'pictogram', 'website']
 RESERVATION_SYSTEM_PROPERTIES_JSON_STRUCTURE = sorted(['name', 'id'])
 
 SITE_PROPERTIES_JSON_STRUCTURE = sorted([
-    'accessibility', 'advice', 'ambiance', 'attachments', 'children', 'cities', 'courses', 'description', 'description_teaser', 'eid',
+    'accessibility', 'advice', 'ambiance', 'attachments', 'children', 'cities', 'courses', 'description', 'description_teaser', 'districts', 'eid',
     'geometry', 'id', 'information_desks', 'labels', 'managers', 'name', 'orientation', 'parent', 'period', 'portal',
     'practice', 'provider', 'pdf', 'ratings', 'sector', 'source', 'structure', 'themes', 'type', 'url', 'uuid',
     'view_points', 'wind', 'web_links'
@@ -177,7 +177,7 @@ SENSITIVE_AREA_SPECIES_PROPERTIES_JSON_STRUCTURE = sorted([
 ])
 
 COURSE_PROPERTIES_JSON_STRUCTURE = sorted([
-    'accessibility', 'advice', 'cities', 'description', 'eid', 'equipment', 'geometry', 'height', 'id',
+    'accessibility', 'advice', 'cities', 'description', 'districts', 'eid', 'equipment', 'geometry', 'height', 'id',
     'length', 'name', 'ratings', 'ratings_description', 'sites', 'structure',
     'type', 'url', 'attachments', 'max_elevation', 'min_elevation', 'parents', 'provider',
     'pdf', 'points_reference', 'children', 'duration', 'gear', 'uuid'
@@ -219,7 +219,7 @@ INFRASTRUCTURE_MAINTENANCE_DIFFICULTY_DETAIL_JSON_STRUCTURE = sorted([
 
 TOURISTIC_EVENT_DETAIL_JSON_STRUCTURE = sorted([
     'id', 'accessibility', 'approved', 'attachments', 'begin_date', 'bookable', 'booking', 'cities', 'contact', 'create_datetime',
-    'description', 'description_teaser', 'duration', 'email', 'end_date', 'external_id', 'geometry',
+    'description', 'description_teaser', 'districts', 'duration', 'email', 'end_date', 'external_id', 'geometry',
     'meeting_point', 'start_time', 'meeting_time', 'end_time', 'name', 'organizer', 'capacity', 'pdf', 'place', 'portal',
     'practical_info', 'provider', 'published', 'source', 'speaker', 'structure', 'target_audience', 'themes',
     'type', 'update_datetime', 'url', 'uuid', 'website', 'cancelled', 'cancellation_reason', 'participant_number'

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -460,7 +460,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.name for district in obj.published_districts]
+            return [district.pk for district in obj.published_districts]
 
         def get_name(self, obj):
             return get_translation_or_dict('name', self, obj)
@@ -768,7 +768,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.name for district in obj.published_districts]
+            return [district.pk for district in obj.published_districts]
 
         def get_departure_city(self, obj):
             geom = self.get_first_point(obj.geom)
@@ -1130,7 +1130,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.name for district in obj.published_districts]
+            return [district.pk for district in obj.published_districts]
 
         def get_courses(self, obj):
             courses = []
@@ -1210,7 +1210,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.name for district in obj.published_districts]
+            return [district.pk for district in obj.published_districts]
 
         def get_equipment(self, obj):
             return get_translation_or_dict('equipment', self, obj)

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -443,6 +443,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
         accessibility = serializers.SerializerMethodField()
         external_id = serializers.CharField(source='eid')
         cities = serializers.SerializerMethodField()
+        districts = serializers.SerializerMethodField()
         name = serializers.SerializerMethodField()
         description = serializers.SerializerMethodField()
         description_teaser = serializers.SerializerMethodField()
@@ -457,6 +458,9 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
+        
+        def get_district(self, obj):
+            return [district.code for district in obj.published_district]
 
         def get_name(self, obj):
             return get_translation_or_dict('name', self, obj)
@@ -655,6 +659,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
         previous = serializers.ReadOnlyField(source='previous_id')
         next = serializers.ReadOnlyField(source='next_id')
         cities = serializers.SerializerMethodField()
+        districts = serializers.SerializerMethodField()
         departure_city = serializers.SerializerMethodField()
         web_links = WebLinkSerializer(many=True)
         view_points = HDViewPointSerializer(many=True)
@@ -761,6 +766,9 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
+        
+        def get_districts(self, obj):
+            return [district.code for district in obj.published_districts]
 
         def get_departure_city(self, obj):
             geom = self.get_first_point(obj.geom)
@@ -1114,11 +1122,15 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
         parent = serializers.SerializerMethodField()
         pdf = serializers.SerializerMethodField('get_pdf_url')
         cities = serializers.SerializerMethodField()
+        districts = serializers.SerializerMethodField()
         web_links = WebLinkSerializer(many=True)
         view_points = HDViewPointSerializer(many=True)
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
+        
+        def get_districts(self, obj):
+            return [district.code for district in obj.published_districts]
 
         def get_courses(self, obj):
             courses = []
@@ -1189,12 +1201,16 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
         points_reference = serializers.SerializerMethodField()
         pdf = serializers.SerializerMethodField('get_pdf_url')
         cities = serializers.SerializerMethodField()
+        districts = serializers.SerializerMethodField()
 
         def get_accessibility(self, obj):
             return get_translation_or_dict('accessibility', self, obj)
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
+        
+        def get_districts(self, obj):
+            return [district.code for district in obj.published_districts]
 
         def get_equipment(self, obj):
             return get_translation_or_dict('equipment', self, obj)

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -458,7 +458,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
-        
+
         def get_district(self, obj):
             return [district.code for district in obj.published_district]
 
@@ -766,7 +766,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
-        
+
         def get_districts(self, obj):
             return [district.code for district in obj.published_districts]
 
@@ -1128,7 +1128,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
-        
+
         def get_districts(self, obj):
             return [district.code for district in obj.published_districts]
 
@@ -1208,7 +1208,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
 
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
-        
+
         def get_districts(self, obj):
             return [district.code for district in obj.published_districts]
 

--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -459,8 +459,8 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
         def get_cities(self, obj):
             return [city.code for city in obj.published_cities]
 
-        def get_district(self, obj):
-            return [district.code for district in obj.published_district]
+        def get_districts(self, obj):
+            return [district.name for district in obj.published_districts]
 
         def get_name(self, obj):
             return get_translation_or_dict('name', self, obj)
@@ -482,7 +482,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
             fields = TimeStampedSerializer.Meta.fields + (
                 'id', 'accessibility', 'attachments', 'approved', 'category', 'description',
                 'description_teaser', 'departure_city', 'geometry', 'label_accessibility',
-                'practical_info', 'url', 'cities',
+                'practical_info', 'url', 'cities', 'districts',
                 'external_id', 'name', 'pdf', 'portal', 'provider', 'published',
                 'source', 'structure', 'themes',
                 'types', 'contact', 'email',
@@ -541,7 +541,7 @@ if 'geotrek.tourism' in settings.INSTALLED_APPS:
             fields = TimeStampedSerializer.Meta.fields + (
                 'id', 'accessibility', 'approved', 'attachments', 'begin_date', 'bookable',
                 'booking', 'cancellation_reason', 'cancelled', 'capacity', 'cities',
-                'contact', 'description', 'description_teaser', 'duration',
+                'contact', 'description', 'description_teaser', 'districts', 'duration',
                 'email', 'end_date', 'end_time', 'external_id', 'geometry', 'meeting_point',
                 'meeting_time', 'name', 'organizer', 'participant_number', 'pdf', 'place',
                 'portal', 'practical_info', 'provider', 'published', 'source', 'speaker',
@@ -768,7 +768,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.code for district in obj.published_districts]
+            return [district.name for district in obj.published_districts]
 
         def get_departure_city(self, obj):
             geom = self.get_first_point(obj.geom)
@@ -802,7 +802,7 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
                 'accessibility_width', 'advice', 'advised_parking', 'altimetric_profile', 'ambiance', 'arrival',
                 'ascent', 'attachments', 'attachments_accessibility', 'children', 'cities', 'create_datetime',
                 'departure', 'departure_city', 'departure_geom', 'descent',
-                'description', 'description_teaser', 'difficulty',
+                'description', 'description_teaser', 'difficulty', 'districts',
                 'disabled_infrastructure', 'duration', 'elevation_area_url',
                 'elevation_svg_url', 'external_id', 'gear', 'geometry', 'gpx',
                 'information_desks', 'kml', 'labels', 'length_2d', 'length_3d',
@@ -1130,7 +1130,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.code for district in obj.published_districts]
+            return [district.name for district in obj.published_districts]
 
         def get_courses(self, obj):
             courses = []
@@ -1181,7 +1181,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
             model = outdoor_models.Site
             fields = (
                 'id', 'accessibility', 'advice', 'ambiance', 'attachments', 'cities', 'children', 'description',
-                'description_teaser', 'eid', 'geometry', 'information_desks', 'labels', 'managers',
+                'description_teaser', 'districts', 'eid', 'geometry', 'information_desks', 'labels', 'managers',
                 'name', 'orientation', 'pdf', 'period', 'parent', 'portal', 'practice', 'provider',
                 'ratings', 'sector', 'source', 'structure', 'themes', 'view_points',
                 'type', 'url', 'uuid', 'courses', 'web_links', 'wind',
@@ -1210,7 +1210,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
             return [city.code for city in obj.published_cities]
 
         def get_districts(self, obj):
-            return [district.code for district in obj.published_districts]
+            return [district.name for district in obj.published_districts]
 
         def get_equipment(self, obj):
             return get_translation_or_dict('equipment', self, obj)
@@ -1244,7 +1244,7 @@ if 'geotrek.outdoor' in settings.INSTALLED_APPS:
         class Meta:
             model = outdoor_models.Course
             fields = (
-                'id', 'accessibility', 'advice', 'attachments', 'children', 'cities', 'description', 'duration', 'eid',
+                'id', 'accessibility', 'advice', 'attachments', 'children', 'cities', 'description', 'districts', 'duration', 'eid',
                 'equipment', 'gear', 'geometry', 'height', 'length', 'max_elevation',
                 'min_elevation', 'name', 'parents', 'pdf', 'points_reference', 'provider', 'ratings', 'ratings_description',
                 'sites', 'structure', 'type', 'url', 'uuid'


### PR DESCRIPTION
Add the "district" attribute to API V2 views that already have a "cities" attribute (
/outdoor_course/
/outdoor_site/
/tour/
/touristiccontent/
/touristicevent/
/trek/
), to include sector information.