### PR TITLE
Improve filter module list css

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,12 @@ CHANGELOG
 
 - Published by language depending on each portals and languages.
 - Use default value with parsers when no value is found
+- Improve filter popover (#2968)
+- Add a scroll bar into filter form and module list (#2849)
+
+**Maintenance**
+
+- Upgrade `django-mapentity`
 
 
 2.98.1 (2023-05-30)

--- a/requirements.txt
+++ b/requirements.txt
@@ -206,7 +206,7 @@ large-image-source-vips==1.17.2
     # via geotrek (setup.py)
 lxml==4.9.1
     # via mapentity
-mapentity==8.5.3
+mapentity==8.5.4
     # via geotrek (setup.py)
 markdown==3.4.1
     # via geotrek (setup.py)


### PR DESCRIPTION
Upgrade `django-mapentity` to 8.5.4:

- Improve filter popover (#2968)
- Add a scroll bar into filter form and module list (#2849)