### PR TITLE
Update CSS of Altimetry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ CHANGELOG
 - Filter by begin date by default on touristic events in APIv2 (#3597)
 - Add model LinePictogram for each line (#3327)
 - Create Organizer model for touristic events, configurable in admin site (#3625)
+- Improve CSS of the altitude profile of altimetry (#3657)
 
 **Documentation**
 

--- a/geotrek/altimetry/static/altimetry/style.css
+++ b/geotrek/altimetry/static/altimetry/style.css
@@ -1,7 +1,7 @@
 #altitudegraph {
     position: fixed;
-    bottom: 10px;
-    right: 10px;
+    bottom: 24px;
+    right: 14px;
     background-color: white;
     border-radius: 5px;
     border: 1px solid #d4d4d4;
@@ -14,7 +14,7 @@
 }
 
 #altitudegraph.colapsed {
-    width: 20px;
+    width: revert;
 }
 #altitudegraph.colapsed img,
 #altitudegraph.colapsed h4 {


### PR DESCRIPTION
This pull request changes how altitude profiles look. Right now, they look like this:

![OLD_ALTIMETRY](https://github.com/GeotrekCE/Geotrek-admin/assets/92665273/25f77432-26f3-4d5b-8b4a-b30b2249ea0b)

![OLD_ALTIMETRY_DEFILE](https://github.com/GeotrekCE/Geotrek-admin/assets/92665273/c941c00c-7525-4e25-b38c-414217f91cf7)

After this change, they will look like this:

![NEW_ALTIMETRY](https://github.com/GeotrekCE/Geotrek-admin/assets/92665273/6199e814-d848-478e-ae4d-9370ad436857)

![NEW_ALTIMETRY_DEFILE](https://github.com/GeotrekCE/Geotrek-admin/assets/92665273/e8fc5c09-5f36-4064-a1cf-90f8ffb735e6)

As a result, the altitude profile will show higher up on the page, which let some space for the attribution mark.