### PR TITLE
Fix missing geometries for HD Views in APIv2 (refs #3701)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,11 @@ CHANGELOG
 
 - Reorganize generated release notes
 
+**Bug fixes**
+
+- Fix missing geometries for HD `view_points` in APIv2's `/trek/` route (#3701)
+
+
 
 2.100.1 (2023-09-05)
 -------------------------

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -1317,6 +1317,7 @@ class APIAccessAnonymousTestCase(BaseApiTest):
         self.assertEqual(response.json()['description'], expected_description)
         self.assertEqual(response.json()['description_teaser'], expected_description)
         self.assertEqual(response.json()['ambiance'], expected_description)
+        self.assertEqual(response.json()['view_points'][0]['geometry'], {'type': 'Point', 'coordinates': [-1.3630812, -5.9838563]})
 
     def test_difficulty_list(self):
         response = self.get_difficulties_list()

--- a/geotrek/api/v2/views/trekking.py
+++ b/geotrek/api/v2/views/trekking.py
@@ -41,7 +41,7 @@ class TrekViewSet(api_viewsets.GeotrekGeometricViewset):
                               Prefetch('web_links',
                                        queryset=trekking_models.WebLink.objects.select_related('category')),
                               Prefetch('view_points',
-                                       queryset=HDViewPoint.objects.select_related('content_type', 'license'))) \
+                                       queryset=HDViewPoint.objects.select_related('content_type', 'license').annotate(geom_transformed=Transform(F('geom'), settings.API_SRID)))) \
             .annotate(geom3d_transformed=Transform(F('geom_3d'), settings.API_SRID),
                       length_3d_m=Length3D('geom_3d')) \
             .order_by("name")  # Required for reliable pagination


### PR DESCRIPTION
Fix missing geometries for HD Views in APIv2 

## Description

`geometry` from `HDViewPointSerializer` is failing silently when accessed through `/trek/` route

APIv2 output before:
 ```
        "view_points": [
            {
                "create_datetime": "2023-08-29T09:23:17.896176Z",
                "update_datetime": "2023-09-07T12:27:51.272475Z",
                "id": 20,
                "annotations":  null,
                "author": "",
                "legend": "",
                "license": null,
                "metadata_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/info/metadata",
                "picture_tiles_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/tiles/%7Bz%7D/%7Bx%7D/%7By%7D.png?source=vips",
                "poi": null,
                "title": "bigff",
                "site": null,
                "trek": {
                    "uuid": "820d9e27-3edc-40c5-93b9-7662387a9150",
                    "id": 396
                },
                "thumbnail_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/data/thumbnail.png?source=vips",
                "uuid": "43f1c4fa-4bfa-415d-9761-2ae876868f0c"
            }
           ]
  ``` 
 
 APIv2 output after:
 ```
        "view_points": [
            {
                "create_datetime": "2023-08-29T09:23:17.896176Z",
                "update_datetime": "2023-09-07T12:27:51.272475Z",
                "id": 20,
                "annotations":  null,
                "author": "",
                "geometry": {
                    "type": "Point",
                    "coordinates": [
                        3.4409666,
                        44.1214521
                    ]
                },
                "legend": "",
                "license": null,
                "metadata_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/info/metadata",
                "picture_tiles_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/tiles/%7Bz%7D/%7Bx%7D/%7By%7D.png?source=vips",
                "poi": null,
                "title": "bigff",
                "site": null,
                "trek": {
                    "uuid": "820d9e27-3edc-40c5-93b9-7662387a9150",
                    "id": 396
                },
                "thumbnail_url": "http://geotrek.local:8000/api/hdviewpoint/drf/hdviewpoints/20/data/thumbnail.png?source=vips",
                "uuid": "43f1c4fa-4bfa-415d-9761-2ae876868f0c"
            }
           ]
  ```

## Related Issue

 [#3701](https://github.com/GeotrekCE/Geotrek-admin/issues/3701) 

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [ ] <s> I have commented my code, particularly in hard-to-understand areas </s>
- [ ] <s> I have made corresponding changes to the documentation</s>
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
