### PR TITLE
Uniformize documentation section of the doc

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ CHANGELOG
 - Update loading_data section to add information about MNT values that needs to be integer (#1891)
 - Add details and template for the pull requests process
 - Update documentation fr translation files
+- Uniformize documentation section
 
 **CI**
 

--- a/docs/contribute/development.rst
+++ b/docs/contribute/development.rst
@@ -253,27 +253,3 @@ UML diagrams of data model
 UML diagrams of Geotrek-admin data models are available in ``docs/data-model`` directory.
 To regenerate them from PostgreSQL, install postgresql-autodoc and graphviz Ubuntu packages
 and run ``make uml``.
-
-Documentation
-=============
-
-A container based on sphinx image is created using docker-compose-dev.yml,
-documentation is built in watch mode thanks to sphinx-autobuild.
-
-Access to documentation built in html : http://0.0.0.0:8800
-
-
-Translate documentation
------------------------
-
-- Generate .pot if needed
-
-.. code-block :: python
-
-    docker-compose run --rm sphinx make gettext
-
-- Generate .po files
-
-.. code-block :: python
-
-    docker-compose run --rm sphinx sphinx-intl update -p _build/locale -l fr

--- a/docs/contribute/documentation.rst
+++ b/docs/contribute/documentation.rst
@@ -3,8 +3,30 @@ Documentation
 
 We use sphinx doc and sphinx-rtd-theme. Requirements are included.
 
+A container based on sphinx image is created using docker-compose-dev.yml,
+documentation is built in watch mode thanks to sphinx-autobuild.
+
 To compile and test documentation on local environment, run :
 
 .. code-block :: bash
 
     docker-compose up -d sphinx
+
+
+Access to documentation built in html : http://0.0.0.0:8800
+
+
+Translate documentation
+-----------------------
+
+- Generate .pot if needed
+
+.. code-block :: python
+
+    docker-compose run --rm sphinx make gettext
+
+- Generate .po files
+
+.. code-block :: python
+
+    docker-compose run --rm sphinx sphinx-intl update -p _build/locale -l fr

--- a/docs/locales/fr/LC_MESSAGES/changelog.po
+++ b/docs/locales/fr/LC_MESSAGES/changelog.po
@@ -1,14 +1,11 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2013-2014, Makina Corpus
 # This file is distributed under the same license as the Geotrek package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Geotrek 2.38\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-08 08:02+0000\n"
+"POT-Creation-Date: 2023-09-08 12:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,12 +22,12 @@ msgstr ""
 msgid "2.100.1+dev (XXXX-XX-XX)"
 msgstr ""
 
-#: ../../changelog.rst:8 ../../changelog.rst:29 ../../changelog.rst:54
-#: ../../changelog.rst:92 ../../changelog.rst:121 ../../changelog.rst:142
-#: ../../changelog.rst:182 ../../changelog.rst:238 ../../changelog.rst:257
-#: ../../changelog.rst:321 ../../changelog.rst:367 ../../changelog.rst:375
-#: ../../changelog.rst:393 ../../changelog.rst:412 ../../changelog.rst:5122
-#: ../../changelog.rst:5148
+#: ../../changelog.rst:8 ../../changelog.rst:36 ../../changelog.rst:61
+#: ../../changelog.rst:99 ../../changelog.rst:128 ../../changelog.rst:149
+#: ../../changelog.rst:189 ../../changelog.rst:245 ../../changelog.rst:264
+#: ../../changelog.rst:328 ../../changelog.rst:374 ../../changelog.rst:382
+#: ../../changelog.rst:400 ../../changelog.rst:419 ../../changelog.rst:5129
+#: ../../changelog.rst:5155
 msgid "**Improvements**"
 msgstr ""
 
@@ -38,12 +35,12 @@ msgstr ""
 msgid "Remove 'review' field on ServiceType (#1669)"
 msgstr ""
 
-#: ../../changelog.rst:12 ../../changelog.rst:25 ../../changelog.rst:67
-#: ../../changelog.rst:161 ../../changelog.rst:216 ../../changelog.rst:431
-#: ../../changelog.rst:673 ../../changelog.rst:769 ../../changelog.rst:1016
-#: ../../changelog.rst:1503 ../../changelog.rst:1544 ../../changelog.rst:1564
-#: ../../changelog.rst:2835 ../../changelog.rst:2975 ../../changelog.rst:4019
-#: ../../changelog.rst:4290 ../../changelog.rst:4324
+#: ../../changelog.rst:12 ../../changelog.rst:32 ../../changelog.rst:74
+#: ../../changelog.rst:168 ../../changelog.rst:223 ../../changelog.rst:438
+#: ../../changelog.rst:680 ../../changelog.rst:776 ../../changelog.rst:1023
+#: ../../changelog.rst:1510 ../../changelog.rst:1551 ../../changelog.rst:1571
+#: ../../changelog.rst:2842 ../../changelog.rst:2982 ../../changelog.rst:4026
+#: ../../changelog.rst:4297 ../../changelog.rst:4331
 msgid "**Documentation**"
 msgstr ""
 
@@ -57,420 +54,434 @@ msgstr ""
 msgid "Add details and template for the pull requests process"
 msgstr ""
 
+#: ../../changelog.rst:16
+msgid "Update documentation fr translation files"
+msgstr ""
+
 #: ../../changelog.rst:17
-msgid "**CI**"
+msgid "Uniformize documentation section"
 msgstr ""
 
 #: ../../changelog.rst:19
+msgid "**CI**"
+msgstr ""
+
+#: ../../changelog.rst:21
 msgid "Reorganize generated release notes"
 msgstr ""
 
-#: ../../changelog.rst:23
-msgid "2.100.1 (2023-09-05)"
-msgstr ""
-
-#: ../../changelog.rst:27
-msgid "Replace broken link"
-msgstr ""
-
-#: ../../changelog.rst:31
-msgid "Add rules data on ``v_sensitivearea`` view  (#3613)"
-msgstr ""
-
-#: ../../changelog.rst:33
-msgid "**Clean**"
-msgstr ""
-
-#: ../../changelog.rst:35
-msgid "Remove unused folder 'bulkimport' from project (#3673)"
-msgstr ""
-
-#: ../../changelog.rst:39
-msgid "2.100.0 (2023-09-05)"
-msgstr ""
-
-#: ../../changelog.rst:41
-msgid "**DO NOT USE**"
-msgstr ""
-
-#: ../../changelog.rst:43 ../../changelog.rst:108 ../../changelog.rst:129
-#: ../../changelog.rst:177 ../../changelog.rst:190 ../../changelog.rst:198
-#: ../../changelog.rst:210 ../../changelog.rst:234 ../../changelog.rst:262
-#: ../../changelog.rst:326 ../../changelog.rst:353 ../../changelog.rst:385
-#: ../../changelog.rst:398 ../../changelog.rst:423 ../../changelog.rst:439
-#: ../../changelog.rst:450 ../../changelog.rst:460 ../../changelog.rst:472
-#: ../../changelog.rst:480 ../../changelog.rst:501 ../../changelog.rst:533
-#: ../../changelog.rst:565 ../../changelog.rst:575 ../../changelog.rst:597
-#: ../../changelog.rst:643 ../../changelog.rst:678 ../../changelog.rst:694
-#: ../../changelog.rst:715 ../../changelog.rst:761 ../../changelog.rst:789
-#: ../../changelog.rst:801 ../../changelog.rst:824 ../../changelog.rst:873
-#: ../../changelog.rst:911 ../../changelog.rst:927 ../../changelog.rst:940
-#: ../../changelog.rst:953 ../../changelog.rst:972 ../../changelog.rst:993
-#: ../../changelog.rst:1020 ../../changelog.rst:1034 ../../changelog.rst:1062
-#: ../../changelog.rst:1094 ../../changelog.rst:1118 ../../changelog.rst:1140
-#: ../../changelog.rst:1158 ../../changelog.rst:1175 ../../changelog.rst:1222
-#: ../../changelog.rst:1236 ../../changelog.rst:1275 ../../changelog.rst:1294
-#: ../../changelog.rst:1318 ../../changelog.rst:1339 ../../changelog.rst:1375
-#: ../../changelog.rst:1404 ../../changelog.rst:1421 ../../changelog.rst:1429
-#: ../../changelog.rst:1452 ../../changelog.rst:1495 ../../changelog.rst:1512
-#: ../../changelog.rst:1525 ../../changelog.rst:1533 ../../changelog.rst:1568
-#: ../../changelog.rst:1601 ../../changelog.rst:1623 ../../changelog.rst:1635
-#: ../../changelog.rst:1659 ../../changelog.rst:1673 ../../changelog.rst:1687
-#: ../../changelog.rst:1706 ../../changelog.rst:1734 ../../changelog.rst:1752
-#: ../../changelog.rst:1778 ../../changelog.rst:1786 ../../changelog.rst:1828
-#: ../../changelog.rst:1854 ../../changelog.rst:1881 ../../changelog.rst:1894
-#: ../../changelog.rst:1907 ../../changelog.rst:1915 ../../changelog.rst:1930
-#: ../../changelog.rst:1950 ../../changelog.rst:1958 ../../changelog.rst:1980
-#: ../../changelog.rst:1994 ../../changelog.rst:2016 ../../changelog.rst:2056
-#: ../../changelog.rst:2075 ../../changelog.rst:2083 ../../changelog.rst:2098
-#: ../../changelog.rst:2118 ../../changelog.rst:2130 ../../changelog.rst:2146
-#: ../../changelog.rst:2158 ../../changelog.rst:2175 ../../changelog.rst:2192
-#: ../../changelog.rst:2208 ../../changelog.rst:2216 ../../changelog.rst:2228
-#: ../../changelog.rst:2236 ../../changelog.rst:2245 ../../changelog.rst:2255
-#: ../../changelog.rst:2263 ../../changelog.rst:2286 ../../changelog.rst:2329
-#: ../../changelog.rst:2363 ../../changelog.rst:2372 ../../changelog.rst:2385
-#: ../../changelog.rst:2398 ../../changelog.rst:2414 ../../changelog.rst:2430
-#: ../../changelog.rst:2438 ../../changelog.rst:2446 ../../changelog.rst:2456
-#: ../../changelog.rst:2464 ../../changelog.rst:2503 ../../changelog.rst:2511
-#: ../../changelog.rst:2519 ../../changelog.rst:2536 ../../changelog.rst:2551
-#: ../../changelog.rst:2560 ../../changelog.rst:2573 ../../changelog.rst:2583
-#: ../../changelog.rst:2595 ../../changelog.rst:2608 ../../changelog.rst:2617
-#: ../../changelog.rst:2625 ../../changelog.rst:2638 ../../changelog.rst:2650
-#: ../../changelog.rst:2674 ../../changelog.rst:2695 ../../changelog.rst:2713
-#: ../../changelog.rst:2736 ../../changelog.rst:2752 ../../changelog.rst:2777
-#: ../../changelog.rst:2797 ../../changelog.rst:2805 ../../changelog.rst:2814
-#: ../../changelog.rst:2847 ../../changelog.rst:2856 ../../changelog.rst:2869
-#: ../../changelog.rst:2879 ../../changelog.rst:2888 ../../changelog.rst:2896
-#: ../../changelog.rst:2908 ../../changelog.rst:2918 ../../changelog.rst:2931
-#: ../../changelog.rst:2942 ../../changelog.rst:2950 ../../changelog.rst:2958
-#: ../../changelog.rst:2983 ../../changelog.rst:2995 ../../changelog.rst:3003
-#: ../../changelog.rst:3024 ../../changelog.rst:3032 ../../changelog.rst:3041
-#: ../../changelog.rst:3049 ../../changelog.rst:3084 ../../changelog.rst:3093
-#: ../../changelog.rst:3107 ../../changelog.rst:3128 ../../changelog.rst:3147
-#: ../../changelog.rst:3155 ../../changelog.rst:3167 ../../changelog.rst:3176
-#: ../../changelog.rst:3190 ../../changelog.rst:3207 ../../changelog.rst:3223
-#: ../../changelog.rst:3243 ../../changelog.rst:3257 ../../changelog.rst:3277
-#: ../../changelog.rst:3287 ../../changelog.rst:3304 ../../changelog.rst:3316
-#: ../../changelog.rst:3329 ../../changelog.rst:3347 ../../changelog.rst:3363
-#: ../../changelog.rst:3386 ../../changelog.rst:3423 ../../changelog.rst:3447
-#: ../../changelog.rst:3462 ../../changelog.rst:3473 ../../changelog.rst:3489
-#: ../../changelog.rst:3508 ../../changelog.rst:3517 ../../changelog.rst:3525
-#: ../../changelog.rst:3533 ../../changelog.rst:3560 ../../changelog.rst:3591
-#: ../../changelog.rst:3599 ../../changelog.rst:3618 ../../changelog.rst:3627
-#: ../../changelog.rst:3651 ../../changelog.rst:3682 ../../changelog.rst:3696
-#: ../../changelog.rst:3710 ../../changelog.rst:3720 ../../changelog.rst:3746
-#: ../../changelog.rst:3754 ../../changelog.rst:3770 ../../changelog.rst:3779
-#: ../../changelog.rst:3793 ../../changelog.rst:3801 ../../changelog.rst:3816
-#: ../../changelog.rst:3828 ../../changelog.rst:3837 ../../changelog.rst:3850
-#: ../../changelog.rst:3867 ../../changelog.rst:3877 ../../changelog.rst:3888
-#: ../../changelog.rst:3902 ../../changelog.rst:3912 ../../changelog.rst:3919
-#: ../../changelog.rst:3927 ../../changelog.rst:3936 ../../changelog.rst:3954
-#: ../../changelog.rst:3970 ../../changelog.rst:3984 ../../changelog.rst:4008
-#: ../../changelog.rst:4045 ../../changelog.rst:4054 ../../changelog.rst:4066
-#: ../../changelog.rst:4084 ../../changelog.rst:4089 ../../changelog.rst:4097
-#: ../../changelog.rst:4107 ../../changelog.rst:4115 ../../changelog.rst:4124
-#: ../../changelog.rst:4149 ../../changelog.rst:4158 ../../changelog.rst:4170
-#: ../../changelog.rst:4184 ../../changelog.rst:4200 ../../changelog.rst:4233
-#: ../../changelog.rst:4249 ../../changelog.rst:4258 ../../changelog.rst:4266
-#: ../../changelog.rst:4274 ../../changelog.rst:4284 ../../changelog.rst:4313
-#: ../../changelog.rst:4336 ../../changelog.rst:4349 ../../changelog.rst:4368
-#: ../../changelog.rst:4401 ../../changelog.rst:4447 ../../changelog.rst:4459
-#: ../../changelog.rst:4490 ../../changelog.rst:4518 ../../changelog.rst:4528
-#: ../../changelog.rst:4536 ../../changelog.rst:4560 ../../changelog.rst:4578
-#: ../../changelog.rst:4589 ../../changelog.rst:4747 ../../changelog.rst:4766
-#: ../../changelog.rst:4775
+#: ../../changelog.rst:23 ../../changelog.rst:50 ../../changelog.rst:115
+#: ../../changelog.rst:136 ../../changelog.rst:184 ../../changelog.rst:197
+#: ../../changelog.rst:205 ../../changelog.rst:217 ../../changelog.rst:241
+#: ../../changelog.rst:269 ../../changelog.rst:333 ../../changelog.rst:360
+#: ../../changelog.rst:392 ../../changelog.rst:405 ../../changelog.rst:430
+#: ../../changelog.rst:446 ../../changelog.rst:457 ../../changelog.rst:467
+#: ../../changelog.rst:479 ../../changelog.rst:487 ../../changelog.rst:508
+#: ../../changelog.rst:540 ../../changelog.rst:572 ../../changelog.rst:582
+#: ../../changelog.rst:604 ../../changelog.rst:650 ../../changelog.rst:685
+#: ../../changelog.rst:701 ../../changelog.rst:722 ../../changelog.rst:768
+#: ../../changelog.rst:796 ../../changelog.rst:808 ../../changelog.rst:831
+#: ../../changelog.rst:880 ../../changelog.rst:918 ../../changelog.rst:934
+#: ../../changelog.rst:947 ../../changelog.rst:960 ../../changelog.rst:979
+#: ../../changelog.rst:1000 ../../changelog.rst:1027 ../../changelog.rst:1041
+#: ../../changelog.rst:1069 ../../changelog.rst:1101 ../../changelog.rst:1125
+#: ../../changelog.rst:1147 ../../changelog.rst:1165 ../../changelog.rst:1182
+#: ../../changelog.rst:1229 ../../changelog.rst:1243 ../../changelog.rst:1282
+#: ../../changelog.rst:1301 ../../changelog.rst:1325 ../../changelog.rst:1346
+#: ../../changelog.rst:1382 ../../changelog.rst:1411 ../../changelog.rst:1428
+#: ../../changelog.rst:1436 ../../changelog.rst:1459 ../../changelog.rst:1502
+#: ../../changelog.rst:1519 ../../changelog.rst:1532 ../../changelog.rst:1540
+#: ../../changelog.rst:1575 ../../changelog.rst:1608 ../../changelog.rst:1630
+#: ../../changelog.rst:1642 ../../changelog.rst:1666 ../../changelog.rst:1680
+#: ../../changelog.rst:1694 ../../changelog.rst:1713 ../../changelog.rst:1741
+#: ../../changelog.rst:1759 ../../changelog.rst:1785 ../../changelog.rst:1793
+#: ../../changelog.rst:1835 ../../changelog.rst:1861 ../../changelog.rst:1888
+#: ../../changelog.rst:1901 ../../changelog.rst:1914 ../../changelog.rst:1922
+#: ../../changelog.rst:1937 ../../changelog.rst:1957 ../../changelog.rst:1965
+#: ../../changelog.rst:1987 ../../changelog.rst:2001 ../../changelog.rst:2023
+#: ../../changelog.rst:2063 ../../changelog.rst:2082 ../../changelog.rst:2090
+#: ../../changelog.rst:2105 ../../changelog.rst:2125 ../../changelog.rst:2137
+#: ../../changelog.rst:2153 ../../changelog.rst:2165 ../../changelog.rst:2182
+#: ../../changelog.rst:2199 ../../changelog.rst:2215 ../../changelog.rst:2223
+#: ../../changelog.rst:2235 ../../changelog.rst:2243 ../../changelog.rst:2252
+#: ../../changelog.rst:2262 ../../changelog.rst:2270 ../../changelog.rst:2293
+#: ../../changelog.rst:2336 ../../changelog.rst:2370 ../../changelog.rst:2379
+#: ../../changelog.rst:2392 ../../changelog.rst:2405 ../../changelog.rst:2421
+#: ../../changelog.rst:2437 ../../changelog.rst:2445 ../../changelog.rst:2453
+#: ../../changelog.rst:2463 ../../changelog.rst:2471 ../../changelog.rst:2510
+#: ../../changelog.rst:2518 ../../changelog.rst:2526 ../../changelog.rst:2543
+#: ../../changelog.rst:2558 ../../changelog.rst:2567 ../../changelog.rst:2580
+#: ../../changelog.rst:2590 ../../changelog.rst:2602 ../../changelog.rst:2615
+#: ../../changelog.rst:2624 ../../changelog.rst:2632 ../../changelog.rst:2645
+#: ../../changelog.rst:2657 ../../changelog.rst:2681 ../../changelog.rst:2702
+#: ../../changelog.rst:2720 ../../changelog.rst:2743 ../../changelog.rst:2759
+#: ../../changelog.rst:2784 ../../changelog.rst:2804 ../../changelog.rst:2812
+#: ../../changelog.rst:2821 ../../changelog.rst:2854 ../../changelog.rst:2863
+#: ../../changelog.rst:2876 ../../changelog.rst:2886 ../../changelog.rst:2895
+#: ../../changelog.rst:2903 ../../changelog.rst:2915 ../../changelog.rst:2925
+#: ../../changelog.rst:2938 ../../changelog.rst:2949 ../../changelog.rst:2957
+#: ../../changelog.rst:2965 ../../changelog.rst:2990 ../../changelog.rst:3002
+#: ../../changelog.rst:3010 ../../changelog.rst:3031 ../../changelog.rst:3039
+#: ../../changelog.rst:3048 ../../changelog.rst:3056 ../../changelog.rst:3091
+#: ../../changelog.rst:3100 ../../changelog.rst:3114 ../../changelog.rst:3135
+#: ../../changelog.rst:3154 ../../changelog.rst:3162 ../../changelog.rst:3174
+#: ../../changelog.rst:3183 ../../changelog.rst:3197 ../../changelog.rst:3214
+#: ../../changelog.rst:3230 ../../changelog.rst:3250 ../../changelog.rst:3264
+#: ../../changelog.rst:3284 ../../changelog.rst:3294 ../../changelog.rst:3311
+#: ../../changelog.rst:3323 ../../changelog.rst:3336 ../../changelog.rst:3354
+#: ../../changelog.rst:3370 ../../changelog.rst:3393 ../../changelog.rst:3430
+#: ../../changelog.rst:3454 ../../changelog.rst:3469 ../../changelog.rst:3480
+#: ../../changelog.rst:3496 ../../changelog.rst:3515 ../../changelog.rst:3524
+#: ../../changelog.rst:3532 ../../changelog.rst:3540 ../../changelog.rst:3567
+#: ../../changelog.rst:3598 ../../changelog.rst:3606 ../../changelog.rst:3625
+#: ../../changelog.rst:3634 ../../changelog.rst:3658 ../../changelog.rst:3689
+#: ../../changelog.rst:3703 ../../changelog.rst:3717 ../../changelog.rst:3727
+#: ../../changelog.rst:3753 ../../changelog.rst:3761 ../../changelog.rst:3777
+#: ../../changelog.rst:3786 ../../changelog.rst:3800 ../../changelog.rst:3808
+#: ../../changelog.rst:3823 ../../changelog.rst:3835 ../../changelog.rst:3844
+#: ../../changelog.rst:3857 ../../changelog.rst:3874 ../../changelog.rst:3884
+#: ../../changelog.rst:3895 ../../changelog.rst:3909 ../../changelog.rst:3919
+#: ../../changelog.rst:3926 ../../changelog.rst:3934 ../../changelog.rst:3943
+#: ../../changelog.rst:3961 ../../changelog.rst:3977 ../../changelog.rst:3991
+#: ../../changelog.rst:4015 ../../changelog.rst:4052 ../../changelog.rst:4061
+#: ../../changelog.rst:4073 ../../changelog.rst:4091 ../../changelog.rst:4096
+#: ../../changelog.rst:4104 ../../changelog.rst:4114 ../../changelog.rst:4122
+#: ../../changelog.rst:4131 ../../changelog.rst:4156 ../../changelog.rst:4165
+#: ../../changelog.rst:4177 ../../changelog.rst:4191 ../../changelog.rst:4207
+#: ../../changelog.rst:4240 ../../changelog.rst:4256 ../../changelog.rst:4265
+#: ../../changelog.rst:4273 ../../changelog.rst:4281 ../../changelog.rst:4291
+#: ../../changelog.rst:4320 ../../changelog.rst:4343 ../../changelog.rst:4356
+#: ../../changelog.rst:4375 ../../changelog.rst:4408 ../../changelog.rst:4454
+#: ../../changelog.rst:4466 ../../changelog.rst:4497 ../../changelog.rst:4525
+#: ../../changelog.rst:4535 ../../changelog.rst:4543 ../../changelog.rst:4567
+#: ../../changelog.rst:4585 ../../changelog.rst:4596 ../../changelog.rst:4754
+#: ../../changelog.rst:4773 ../../changelog.rst:4782
 msgid "**Bug fixes**"
 msgstr ""
 
-#: ../../changelog.rst:45
-msgid "Fix: unable to search within a list of services (#3521)"
+#: ../../changelog.rst:25
+msgid ""
+"Fix missing geometries for HD `view_points` in APIv2's `/trek/` route "
+"(#3701)"
+msgstr ""
+
+#: ../../changelog.rst:30
+msgid "2.100.1 (2023-09-05)"
+msgstr ""
+
+#: ../../changelog.rst:34
+msgid "Replace broken link"
+msgstr ""
+
+#: ../../changelog.rst:38
+msgid "Add rules data on ``v_sensitivearea`` view  (#3613)"
+msgstr ""
+
+#: ../../changelog.rst:40
+msgid "**Clean**"
+msgstr ""
+
+#: ../../changelog.rst:42
+msgid "Remove unused folder 'bulkimport' from project (#3673)"
 msgstr ""
 
 #: ../../changelog.rst:46
+msgid "2.100.0 (2023-09-05)"
+msgstr ""
+
+#: ../../changelog.rst:48
+msgid "**DO NOT USE**"
+msgstr ""
+
+#: ../../changelog.rst:52
+msgid "Fix: unable to search within a list of services (#3521)"
+msgstr ""
+
+#: ../../changelog.rst:53
 msgid "Fix: Unpublish trek in all languages when path is deleted (#1321)"
 msgstr ""
 
-#: ../../changelog.rst:47
+#: ../../changelog.rst:54
 msgid "Fix: duplication on sites now does not duplicate children sites (#3665)"
 msgstr ""
 
-#: ../../changelog.rst:49 ../../changelog.rst:80 ../../changelog.rst:285
-#: ../../changelog.rst:468 ../../changelog.rst:494 ../../changelog.rst:517
-#: ../../changelog.rst:549 ../../changelog.rst:557 ../../changelog.rst:583
-#: ../../changelog.rst:620 ../../changelog.rst:662 ../../changelog.rst:702
-#: ../../changelog.rst:752 ../../changelog.rst:813 ../../changelog.rst:849
-#: ../../changelog.rst:901 ../../changelog.rst:919 ../../changelog.rst:984
-#: ../../changelog.rst:1043 ../../changelog.rst:1070 ../../changelog.rst:1114
-#: ../../changelog.rst:1165 ../../changelog.rst:1183 ../../changelog.rst:1214
-#: ../../changelog.rst:1232 ../../changelog.rst:1244 ../../changelog.rst:1267
-#: ../../changelog.rst:1285 ../../changelog.rst:1307 ../../changelog.rst:1328
-#: ../../changelog.rst:1353 ../../changelog.rst:1369 ../../changelog.rst:1384
-#: ../../changelog.rst:1415 ../../changelog.rst:1437 ../../changelog.rst:1447
-#: ../../changelog.rst:1507 ../../changelog.rst:1521 ../../changelog.rst:1537
-#: ../../changelog.rst:1681 ../../changelog.rst:1712 ../../changelog.rst:1741
-#: ../../changelog.rst:2340 ../../changelog.rst:2475 ../../changelog.rst:2486
-#: ../../changelog.rst:2686 ../../changelog.rst:2704 ../../changelog.rst:2825
-#: ../../changelog.rst:2864 ../../changelog.rst:2927 ../../changelog.rst:3070
-#: ../../changelog.rst:3078 ../../changelog.rst:3199 ../../changelog.rst:3236
-#: ../../changelog.rst:3264 ../../changelog.rst:3439 ../../changelog.rst:3457
-#: ../../changelog.rst:3484 ../../changelog.rst:3502 ../../changelog.rst:3548
-#: ../../changelog.rst:3577 ../../changelog.rst:3662 ../../changelog.rst:3732
-#: ../../changelog.rst:3789 ../../changelog.rst:3809 ../../changelog.rst:3846
-#: ../../changelog.rst:3863 ../../changelog.rst:3896 ../../changelog.rst:3946
-#: ../../changelog.rst:3964 ../../changelog.rst:3979 ../../changelog.rst:3999
-#: ../../changelog.rst:4031 ../../changelog.rst:4062 ../../changelog.rst:4076
-#: ../../changelog.rst:4140 ../../changelog.rst:4178 ../../changelog.rst:4192
-#: ../../changelog.rst:4222 ../../changelog.rst:4245 ../../changelog.rst:4294
-#: ../../changelog.rst:4388 ../../changelog.rst:4476 ../../changelog.rst:4545
-#: ../../changelog.rst:4598 ../../changelog.rst:4694
+#: ../../changelog.rst:56 ../../changelog.rst:87 ../../changelog.rst:292
+#: ../../changelog.rst:475 ../../changelog.rst:501 ../../changelog.rst:524
+#: ../../changelog.rst:556 ../../changelog.rst:564 ../../changelog.rst:590
+#: ../../changelog.rst:627 ../../changelog.rst:669 ../../changelog.rst:709
+#: ../../changelog.rst:759 ../../changelog.rst:820 ../../changelog.rst:856
+#: ../../changelog.rst:908 ../../changelog.rst:926 ../../changelog.rst:991
+#: ../../changelog.rst:1050 ../../changelog.rst:1077 ../../changelog.rst:1121
+#: ../../changelog.rst:1172 ../../changelog.rst:1190 ../../changelog.rst:1221
+#: ../../changelog.rst:1239 ../../changelog.rst:1251 ../../changelog.rst:1274
+#: ../../changelog.rst:1292 ../../changelog.rst:1314 ../../changelog.rst:1335
+#: ../../changelog.rst:1360 ../../changelog.rst:1376 ../../changelog.rst:1391
+#: ../../changelog.rst:1422 ../../changelog.rst:1444 ../../changelog.rst:1454
+#: ../../changelog.rst:1514 ../../changelog.rst:1528 ../../changelog.rst:1544
+#: ../../changelog.rst:1688 ../../changelog.rst:1719 ../../changelog.rst:1748
+#: ../../changelog.rst:2347 ../../changelog.rst:2482 ../../changelog.rst:2493
+#: ../../changelog.rst:2693 ../../changelog.rst:2711 ../../changelog.rst:2832
+#: ../../changelog.rst:2871 ../../changelog.rst:2934 ../../changelog.rst:3077
+#: ../../changelog.rst:3085 ../../changelog.rst:3206 ../../changelog.rst:3243
+#: ../../changelog.rst:3271 ../../changelog.rst:3446 ../../changelog.rst:3464
+#: ../../changelog.rst:3491 ../../changelog.rst:3509 ../../changelog.rst:3555
+#: ../../changelog.rst:3584 ../../changelog.rst:3669 ../../changelog.rst:3739
+#: ../../changelog.rst:3796 ../../changelog.rst:3816 ../../changelog.rst:3853
+#: ../../changelog.rst:3870 ../../changelog.rst:3903 ../../changelog.rst:3953
+#: ../../changelog.rst:3971 ../../changelog.rst:3986 ../../changelog.rst:4006
+#: ../../changelog.rst:4038 ../../changelog.rst:4069 ../../changelog.rst:4083
+#: ../../changelog.rst:4147 ../../changelog.rst:4185 ../../changelog.rst:4199
+#: ../../changelog.rst:4229 ../../changelog.rst:4252 ../../changelog.rst:4301
+#: ../../changelog.rst:4395 ../../changelog.rst:4483 ../../changelog.rst:4552
+#: ../../changelog.rst:4605 ../../changelog.rst:4701
 msgid "**New features**"
 msgstr ""
 
-#: ../../changelog.rst:51
+#: ../../changelog.rst:58
 msgid ""
 "Filter trek and outdoor site labels according to whether they are "
 "published or not (#3529)"
 msgstr ""
 
-#: ../../changelog.rst:52
+#: ../../changelog.rst:59
 msgid "Respond 404 JSON if page not found in API v2"
 msgstr ""
 
-#: ../../changelog.rst:56
+#: ../../changelog.rst:63
 msgid "Filter by multiple structures on Blades list (#3646)"
 msgstr ""
 
-#: ../../changelog.rst:57
+#: ../../changelog.rst:64
 msgid "Add a multiselect to filter the Blades by more than one manager"
 msgstr ""
 
-#: ../../changelog.rst:58
+#: ../../changelog.rst:65
 msgid "Filter by begin date by default on touristic events in APIv2 (#3597)"
 msgstr ""
 
-#: ../../changelog.rst:59
+#: ../../changelog.rst:66
 msgid "Add model LinePictogram for each line (#3327)"
 msgstr ""
 
-#: ../../changelog.rst:60
+#: ../../changelog.rst:67
 msgid ""
 "Create Organizer model for touristic events, configurable in admin site "
 "(#3625)"
 msgstr ""
 
-#: ../../changelog.rst:61
+#: ../../changelog.rst:68
 msgid "Improve CSS of the altitude profile of altimetry (#3657)"
 msgstr ""
 
-#: ../../changelog.rst:62
+#: ../../changelog.rst:69
 msgid ""
 "Remove elliptic annotations from HD Views (they cannot be displayed on "
 "Leaflet)"
 msgstr ""
 
-#: ../../changelog.rst:63
+#: ../../changelog.rst:70
 msgid "Serve GeoJS script locally"
 msgstr ""
 
-#: ../../changelog.rst:64
+#: ../../changelog.rst:71
 msgid ""
 "To delete parent outdoor sites you must first delete their children "
 "(#3151)"
 msgstr ""
 
-#: ../../changelog.rst:69
+#: ../../changelog.rst:76
 msgid "Add configuration file for readthedocs"
 msgstr ""
 
-#: ../../changelog.rst:70
+#: ../../changelog.rst:77
 msgid "Update architecture schema"
 msgstr ""
 
-#: ../../changelog.rst:72 ../../changelog.rst:100 ../../changelog.rst:117
-#: ../../changelog.rst:303 ../../changelog.rst:604 ../../changelog.rst:648
-#: ../../changelog.rst:744 ../../changelog.rst:780 ../../changelog.rst:829
-#: ../../changelog.rst:858 ../../changelog.rst:887 ../../changelog.rst:945
-#: ../../changelog.rst:999 ../../changelog.rst:1089 ../../changelog.rst:1132
-#: ../../changelog.rst:1144 ../../changelog.rst:1463 ../../changelog.rst:1485
-#: ../../changelog.rst:1550 ../../changelog.rst:1577 ../../changelog.rst:1618
-#: ../../changelog.rst:1942 ../../changelog.rst:2295 ../../changelog.rst:2336
-#: ../../changelog.rst:2499
+#: ../../changelog.rst:79 ../../changelog.rst:107 ../../changelog.rst:124
+#: ../../changelog.rst:310 ../../changelog.rst:611 ../../changelog.rst:655
+#: ../../changelog.rst:751 ../../changelog.rst:787 ../../changelog.rst:836
+#: ../../changelog.rst:865 ../../changelog.rst:894 ../../changelog.rst:952
+#: ../../changelog.rst:1006 ../../changelog.rst:1096 ../../changelog.rst:1139
+#: ../../changelog.rst:1151 ../../changelog.rst:1470 ../../changelog.rst:1492
+#: ../../changelog.rst:1557 ../../changelog.rst:1584 ../../changelog.rst:1625
+#: ../../changelog.rst:1949 ../../changelog.rst:2302 ../../changelog.rst:2343
+#: ../../changelog.rst:2506
 msgid "**Maintenance**"
 msgstr ""
 
-#: ../../changelog.rst:74 ../../changelog.rst:102
+#: ../../changelog.rst:81 ../../changelog.rst:109
 msgid "Upgrade `django-mapentity`"
 msgstr ""
 
-#: ../../changelog.rst:78
+#: ../../changelog.rst:85
 msgid "2.99.0 (2023-07-18)"
 msgstr ""
 
-#: ../../changelog.rst:82
+#: ../../changelog.rst:89
 msgid "Add field ``access`` to Signage and Infrastructure models (#3605)"
 msgstr ""
 
-#: ../../changelog.rst:83
+#: ../../changelog.rst:90
 msgid "Enable filtering lists by objects IDs on APIv2 (#3458)"
 msgstr ""
 
-#: ../../changelog.rst:84
+#: ../../changelog.rst:91
 msgid "Add information desks link on Treks with AggregatorParsers"
 msgstr ""
 
-#: ../../changelog.rst:85
+#: ../../changelog.rst:92
 msgid "Add filter by manager to Blades module"
 msgstr ""
 
-#: ../../changelog.rst:86
+#: ../../changelog.rst:93
 msgid "Add filter \"Published\" to outdoor course and outdoor site (#2810)"
 msgstr ""
 
-#: ../../changelog.rst:87
+#: ../../changelog.rst:94
 msgid ""
 "Add a \"district\" attribute to views containing the \"cities\" attribute"
 " in API V2 (#3632)"
 msgstr ""
 
-#: ../../changelog.rst:88
+#: ../../changelog.rst:95
 msgid "Make signage blade lines text optional (#3326)"
 msgstr ""
 
-#: ../../changelog.rst:89
+#: ../../changelog.rst:96
 msgid ""
 "Add path information on API V2 about departure, arrival, comfort, source,"
 " networks, usages and stake (#3262)"
 msgstr ""
 
-#: ../../changelog.rst:94
+#: ../../changelog.rst:101
 msgid "Published by language depending on each portals and languages."
 msgstr ""
 
-#: ../../changelog.rst:95
+#: ../../changelog.rst:102
 msgid "Use default value with parsers when no value is found"
 msgstr ""
 
-#: ../../changelog.rst:96
+#: ../../changelog.rst:103
 msgid "Improve filter popover (#2968)"
 msgstr ""
 
-#: ../../changelog.rst:97
+#: ../../changelog.rst:104
 msgid "Add a scroll bar into filter form and module list (#2849)"
 msgstr ""
 
-#: ../../changelog.rst:98
+#: ../../changelog.rst:105
 msgid "In projects, start year must be before end year (#3567)"
 msgstr ""
 
-#: ../../changelog.rst:106
+#: ../../changelog.rst:113
 msgid "2.98.1 (2023-05-30)"
 msgstr ""
 
-#: ../../changelog.rst:110
+#: ../../changelog.rst:117
 msgid "Fix: Remove user group creation in Outdoor fixture (#3524)"
 msgstr ""
 
-#: ../../changelog.rst:111
+#: ../../changelog.rst:118
 msgid "Fix: Configure nginx to invalidate mobile cache on language change"
 msgstr ""
 
-#: ../../changelog.rst:112
+#: ../../changelog.rst:119
 msgid ""
 "Fix: service pictograms' URLs are made absolute in the API output of Trek"
 " descriptions (#3321)"
 msgstr ""
 
-#: ../../changelog.rst:113
+#: ../../changelog.rst:120
 msgid ""
 "Fix: APIDAE Events parser now handles integer values for capacity (`#3573"
 " <https://github.com/GeotrekCE/Geotrek-admin/issues/3573>`_)"
 msgstr ""
 
-#: ../../changelog.rst:114
+#: ../../changelog.rst:121
 msgid ""
 "Fix: Configure `large_image` to use `libvips` even for PNG images (fixes "
 "HD Views for PNGs)"
 msgstr ""
 
-#: ../../changelog.rst:115
+#: ../../changelog.rst:122
 msgid "Fix: Deleting signages must also delete their blades"
 msgstr ""
 
-#: ../../changelog.rst:119
+#: ../../changelog.rst:126
 msgid "Upgrade `django-large-image` and `pip-tools`"
 msgstr ""
 
-#: ../../changelog.rst:123
+#: ../../changelog.rst:130
 msgid ""
 "Improve cascading deletions logic, and log them to LogEntry model to "
 "maintain history of deletions"
 msgstr ""
 
-#: ../../changelog.rst:127
+#: ../../changelog.rst:134
 msgid "2.98.0     (2023-03-27)"
 msgstr ""
 
-#: ../../changelog.rst:131
+#: ../../changelog.rst:138
 msgid ""
 "Fix: trekparser allowed to create trek with other geometry than "
 "linestrings"
 msgstr ""
 
-#: ../../changelog.rst:132
+#: ../../changelog.rst:139
 msgid ""
 "Fix: do not prevent activity mappings overriding in subclasses of APIDAE "
 "Trek parser"
 msgstr ""
 
-#: ../../changelog.rst:133
+#: ../../changelog.rst:140
 msgid ""
 "Fix permissions bypass structure was always needed on accessibility "
 "attachments (#3396)"
 msgstr ""
 
-#: ../../changelog.rst:134
+#: ../../changelog.rst:141
 msgid ""
 "Fix default pictogram for mountainbike practice (it was blurry on mobile "
 "apps)"
 msgstr ""
 
-#: ../../changelog.rst:135
+#: ../../changelog.rst:142
 msgid "Fix: `delete=True` mode now works for APIDAE Trek parser"
 msgstr ""
 
-#: ../../changelog.rst:136
+#: ../../changelog.rst:143
 msgid ""
 "Fix missing insert and update date in fixtures for Sensitivity and "
 "Outdoor modules"
 msgstr ""
 
-#: ../../changelog.rst:137
+#: ../../changelog.rst:144
 msgid "Fix target should not be ordonnable for interventions"
 msgstr ""
 
-#: ../../changelog.rst:138
+#: ../../changelog.rst:145
 msgid "Fix: filter geometries on right geometry types in synchro mobile"
 msgstr ""
 
-#: ../../changelog.rst:139
+#: ../../changelog.rst:146
 msgid ""
 "Fix: trek deletion was not possible without removing report link to this "
 "trek"
 msgstr ""
 
-#: ../../changelog.rst:140
+#: ../../changelog.rst:147
 msgid "Fix: duplication attachments"
 msgstr ""
 
-#: ../../changelog.rst:144
+#: ../../changelog.rst:151
 msgid "Add arguments loadsignage : sealing / manager (#3377)"
 msgstr ""
 
-#: ../../changelog.rst:145
+#: ../../changelog.rst:152
 msgid "Various minor improvements for APIDAE Trek parser"
 msgstr ""
 
-#: ../../changelog.rst:146
+#: ../../changelog.rst:153
 msgid ""
 "The \"near_xxx\" API filters now use the topological link regarding "
 "topological objects. This will provide better performances for those "
@@ -479,172 +490,172 @@ msgid ""
 "<https://github.com/GeotrekCE/Geotrek-admin/issues/3505>`_."
 msgstr ""
 
-#: ../../changelog.rst:147
+#: ../../changelog.rst:154
 msgid "Enable using Suricate workflow without moderation steps"
 msgstr ""
 
-#: ../../changelog.rst:149 ../../changelog.rst:2103 ../../changelog.rst:2171
-#: ../../changelog.rst:2282 ../../changelog.rst:2357 ../../changelog.rst:2393
-#: ../../changelog.rst:2410 ../../changelog.rst:2527 ../../changelog.rst:2546
-#: ../../changelog.rst:2569 ../../changelog.rst:2970 ../../changelog.rst:2991
-#: ../../changelog.rst:3101 ../../changelog.rst:3120 ../../changelog.rst:3136
-#: ../../changelog.rst:3159 ../../changelog.rst:3181 ../../changelog.rst:3227
-#: ../../changelog.rst:3273 ../../changelog.rst:3296 ../../changelog.rst:3308
-#: ../../changelog.rst:3321 ../../changelog.rst:3342 ../../changelog.rst:3368
-#: ../../changelog.rst:3390 ../../changelog.rst:3406 ../../changelog.rst:3415
-#: ../../changelog.rst:3553 ../../changelog.rst:3568 ../../changelog.rst:3581
-#: ../../changelog.rst:3608 ../../changelog.rst:3642 ../../changelog.rst:3656
-#: ../../changelog.rst:3675 ../../changelog.rst:3691 ../../changelog.rst:3705
-#: ../../changelog.rst:3724 ../../changelog.rst:3742 ../../changelog.rst:3758
-#: ../../changelog.rst:3766 ../../changelog.rst:4664
+#: ../../changelog.rst:156 ../../changelog.rst:2110 ../../changelog.rst:2178
+#: ../../changelog.rst:2289 ../../changelog.rst:2364 ../../changelog.rst:2400
+#: ../../changelog.rst:2417 ../../changelog.rst:2534 ../../changelog.rst:2553
+#: ../../changelog.rst:2576 ../../changelog.rst:2977 ../../changelog.rst:2998
+#: ../../changelog.rst:3108 ../../changelog.rst:3127 ../../changelog.rst:3143
+#: ../../changelog.rst:3166 ../../changelog.rst:3188 ../../changelog.rst:3234
+#: ../../changelog.rst:3280 ../../changelog.rst:3303 ../../changelog.rst:3315
+#: ../../changelog.rst:3328 ../../changelog.rst:3349 ../../changelog.rst:3375
+#: ../../changelog.rst:3397 ../../changelog.rst:3413 ../../changelog.rst:3422
+#: ../../changelog.rst:3560 ../../changelog.rst:3575 ../../changelog.rst:3588
+#: ../../changelog.rst:3615 ../../changelog.rst:3649 ../../changelog.rst:3663
+#: ../../changelog.rst:3682 ../../changelog.rst:3698 ../../changelog.rst:3712
+#: ../../changelog.rst:3731 ../../changelog.rst:3749 ../../changelog.rst:3765
+#: ../../changelog.rst:3773 ../../changelog.rst:4671
 msgid "**Minor changes**"
 msgstr ""
 
-#: ../../changelog.rst:151
+#: ../../changelog.rst:158
 msgid ""
 "The \"trek\" API filter on POI and SensitiveArea list views now provide "
 "the same treatment as \"near_trek\" and is marked as deprecated."
 msgstr ""
 
-#: ../../changelog.rst:152
+#: ../../changelog.rst:159
 msgid ""
 "`/api/v2/sensitive_area/?trek=123` now returns an empty list when trek "
 "does not exist instead of 404 - Not Found."
 msgstr ""
 
-#: ../../changelog.rst:153
+#: ../../changelog.rst:160
 msgid ""
 "`/api/v2/sensitive_area/` results are no longer sorted by ID when the "
 "\"trek\" filter is used."
 msgstr ""
 
-#: ../../changelog.rst:154
+#: ../../changelog.rst:161
 msgid ""
 "`/api/v2/sensitive_area/?trek=123` now uses the configured intersection "
 "margin for sensitive areas (previously returned intersections w/o "
 "margin)."
 msgstr ""
 
-#: ../../changelog.rst:155
+#: ../../changelog.rst:162
 msgid ""
 "The \"near_trek\" API filter now removes from results the trek's excluded"
 " POIs."
 msgstr ""
 
-#: ../../changelog.rst:157 ../../changelog.rst:169 ../../changelog.rst:1058
-#: ../../changelog.rst:1102 ../../changelog.rst:1665 ../../changelog.rst:1716
-#: ../../changelog.rst:1760 ../../changelog.rst:1792 ../../changelog.rst:1807
-#: ../../changelog.rst:3016 ../../changelog.rst:3057 ../../changelog.rst:3112
-#: ../../changelog.rst:3634
+#: ../../changelog.rst:164 ../../changelog.rst:176 ../../changelog.rst:1065
+#: ../../changelog.rst:1109 ../../changelog.rst:1672 ../../changelog.rst:1723
+#: ../../changelog.rst:1767 ../../changelog.rst:1799 ../../changelog.rst:1814
+#: ../../changelog.rst:3023 ../../changelog.rst:3064 ../../changelog.rst:3119
+#: ../../changelog.rst:3641
 msgid "**Performances**"
 msgstr ""
 
-#: ../../changelog.rst:159
+#: ../../changelog.rst:166
 msgid "Improve performance zoning filter interventions"
 msgstr ""
 
-#: ../../changelog.rst:163
+#: ../../changelog.rst:170
 msgid "Update UML diagrams in documentation"
 msgstr ""
 
-#: ../../changelog.rst:167
+#: ../../changelog.rst:174
 msgid "2.97.4     (2023-03-09)"
 msgstr ""
 
-#: ../../changelog.rst:171
+#: ../../changelog.rst:178
 msgid "Fix interventions list loading"
 msgstr ""
 
-#: ../../changelog.rst:175
+#: ../../changelog.rst:182
 msgid "2.97.3 (2023-02-28)"
 msgstr ""
 
-#: ../../changelog.rst:179
+#: ../../changelog.rst:186
 msgid ""
 "Fix: nearby sensitive areas now appears in outdoor details pages (and the"
 " other way too) (`Issue #3494 <https://github.com/GeotrekCE/Geotrek-"
 "admin/issues/3494>`_)"
 msgstr ""
 
-#: ../../changelog.rst:180
+#: ../../changelog.rst:187
 msgid "Fix Interventions list datatable is empty"
 msgstr ""
 
-#: ../../changelog.rst:184
+#: ../../changelog.rst:191
 msgid "Set max zoom on HD Views depending on tiles depth"
 msgstr ""
 
-#: ../../changelog.rst:188
+#: ../../changelog.rst:195
 msgid "2.97.2 (2023-02-22)"
 msgstr ""
 
-#: ../../changelog.rst:192
+#: ../../changelog.rst:199
 msgid ""
 "Fix link between attachment and file is lost when updating old attachment"
 " without title and suffix"
 msgstr ""
 
-#: ../../changelog.rst:196
+#: ../../changelog.rst:203
 msgid "2.97.1 (2023-02-17)"
 msgstr ""
 
-#: ../../changelog.rst:200
+#: ../../changelog.rst:207
 msgid ""
 "Fix link between attachment and file is lost when updating old attachment"
 " without suffix"
 msgstr ""
 
-#: ../../changelog.rst:204
+#: ../../changelog.rst:211
 msgid "2.97.0 (2023-02-17)"
 msgstr ""
 
-#: ../../changelog.rst:206 ../../changelog.rst:252 ../../changelog.rst:344
-#: ../../changelog.rst:363 ../../changelog.rst:419
+#: ../../changelog.rst:213 ../../changelog.rst:259 ../../changelog.rst:351
+#: ../../changelog.rst:370 ../../changelog.rst:426
 msgid "**New feature**"
 msgstr ""
 
-#: ../../changelog.rst:208
+#: ../../changelog.rst:215
 msgid ""
 "Add rules (with pictograms, descriptions and url) on regulatory sensitive"
 " areas (#3386)"
 msgstr ""
 
-#: ../../changelog.rst:212
+#: ../../changelog.rst:219
 msgid "Fix intervention filter when outdoor or signage is not installed"
 msgstr ""
 
-#: ../../changelog.rst:213
+#: ../../changelog.rst:220
 msgid "Fix intervention's geojson"
 msgstr ""
 
-#: ../../changelog.rst:214
+#: ../../changelog.rst:221
 msgid "Fix pictogram's for interventions on lands"
 msgstr ""
 
-#: ../../changelog.rst:218
+#: ../../changelog.rst:225
 msgid "Update Suricate documentation"
 msgstr ""
 
-#: ../../changelog.rst:219
+#: ../../changelog.rst:226
 msgid "Add HD Views documentation"
 msgstr ""
 
-#: ../../changelog.rst:221 ../../changelog.rst:1556 ../../changelog.rst:1627
-#: ../../changelog.rst:1650 ../../changelog.rst:1720
+#: ../../changelog.rst:228 ../../changelog.rst:1563 ../../changelog.rst:1634
+#: ../../changelog.rst:1657 ../../changelog.rst:1727
 msgid "**Security**"
 msgstr ""
 
-#: ../../changelog.rst:223
+#: ../../changelog.rst:230
 msgid "Add safety checks on uploaded files"
 msgstr ""
 
-#: ../../changelog.rst:225 ../../changelog.rst:248 ../../changelog.rst:277
-#: ../../changelog.rst:293 ../../changelog.rst:408 ../../changelog.rst:490
-#: ../../changelog.rst:513 ../../changelog.rst:734
+#: ../../changelog.rst:232 ../../changelog.rst:255 ../../changelog.rst:284
+#: ../../changelog.rst:300 ../../changelog.rst:415 ../../changelog.rst:497
+#: ../../changelog.rst:520 ../../changelog.rst:741
 msgid "**Warning**"
 msgstr ""
 
-#: ../../changelog.rst:227
+#: ../../changelog.rst:234
 msgid ""
 "Attachment filenames are now suffixed with a random string. This might "
 "cause duplication of old attachment files that previously did not have a "
@@ -652,101 +663,101 @@ msgid ""
 "disk space."
 msgstr ""
 
-#: ../../changelog.rst:232
+#: ../../changelog.rst:239
 msgid "2.96.1 (2022-02-02)"
 msgstr ""
 
-#: ../../changelog.rst:236
+#: ../../changelog.rst:243
 msgid "Fix APIv2 filters deteriorated performances"
 msgstr ""
 
-#: ../../changelog.rst:240
+#: ../../changelog.rst:247
 msgid "Sensitivity: Add missing attachments list to sensitive areas API"
 msgstr ""
 
-#: ../../changelog.rst:244
+#: ../../changelog.rst:251
 msgid "2.96.0     (2023-02-01)"
 msgstr ""
 
-#: ../../changelog.rst:246 ../../changelog.rst:488 ../../changelog.rst:511
-#: ../../changelog.rst:982 ../../changelog.rst:1032 ../../changelog.rst:1283
-#: ../../changelog.rst:2424
+#: ../../changelog.rst:253 ../../changelog.rst:495 ../../changelog.rst:518
+#: ../../changelog.rst:989 ../../changelog.rst:1039 ../../changelog.rst:1290
+#: ../../changelog.rst:2431
 msgid "**DO NOT USE IT!**"
 msgstr ""
 
-#: ../../changelog.rst:250
+#: ../../changelog.rst:257
 msgid "APIv2 filters performances are deteriorated - Skip to 2.96.1 instead"
 msgstr ""
 
-#: ../../changelog.rst:254
+#: ../../changelog.rst:261
 msgid ""
 "Handle very high resolution images (HD Views) that will automatically be "
 "tiled, for ``Trek``, ``POI`` and ``Site`` (#3378)"
 msgstr ""
 
-#: ../../changelog.rst:255
+#: ../../changelog.rst:262
 msgid "Handle annotations on HD Views (points, lines, polygons and text)"
 msgstr ""
 
-#: ../../changelog.rst:259
+#: ../../changelog.rst:266
 msgid ""
 "APIDAE Trek Parser output now shows APIDAE IDs of entities triggering "
 "warnings during import"
 msgstr ""
 
-#: ../../changelog.rst:260
+#: ../../changelog.rst:267
 msgid ""
 "Update maximum request size in Nginx from 10M to 200M to allow uploading "
 "HD pictures (#3378)"
 msgstr ""
 
-#: ../../changelog.rst:264
+#: ../../changelog.rst:271
 msgid "Fix intervention datatable list if one intervention has no target"
 msgstr ""
 
-#: ../../changelog.rst:265
+#: ../../changelog.rst:272
 msgid "Fix intervention datatable list with interventions on lands"
 msgstr ""
 
-#: ../../changelog.rst:266
+#: ../../changelog.rst:273
 msgid "Fix signage's blade detail"
 msgstr ""
 
-#: ../../changelog.rst:267
+#: ../../changelog.rst:274
 msgid ""
 "APIDAE Trek parser now raises an import error on geometry with not "
 "continuous segments"
 msgstr ""
 
-#: ../../changelog.rst:269
+#: ../../changelog.rst:276
 msgid "**Development**"
 msgstr ""
 
-#: ../../changelog.rst:271
+#: ../../changelog.rst:278
 msgid "New contributing guide (docs/CONTRIBUTING.rst)."
 msgstr ""
 
-#: ../../changelog.rst:272
+#: ../../changelog.rst:279
 msgid "Development dependencies are now split in dedicated file."
 msgstr ""
 
-#: ../../changelog.rst:273
+#: ../../changelog.rst:280
 msgid "pip-tools and flake8 are now available in developer environment."
 msgstr ""
 
-#: ../../changelog.rst:274
+#: ../../changelog.rst:281
 msgid ""
 "Dependency graph is now checked in CI (see docs/contribute/development to"
 " how add a new dependency)."
 msgstr ""
 
-#: ../../changelog.rst:275
+#: ../../changelog.rst:282
 msgid ""
 "New git pre-commit hook to check all is alright before commit (see "
 "docs/contribute/development)."
 msgstr ""
 
-#: ../../changelog.rst:279
+#: ../../changelog.rst:286
 msgid ""
 "The default Nginx configuration template has been improved "
 "(https://github.com/GeotrekCE/Geotrek-"
@@ -756,740 +767,740 @@ msgid ""
 "admin/var/conf/nginx.conf.in)."
 msgstr ""
 
-#: ../../changelog.rst:283
+#: ../../changelog.rst:290
 msgid "2.95.0     (2023-01-24)"
 msgstr ""
 
-#: ../../changelog.rst:287
+#: ../../changelog.rst:294
 msgid "Add possibility to duplicate objects with geometries"
 msgstr ""
 
-#: ../../changelog.rst:289 ../../changelog.rst:446 ../../changelog.rst:537
-#: ../../changelog.rst:561 ../../changelog.rst:591 ../../changelog.rst:631
-#: ../../changelog.rst:710 ../../changelog.rst:773 ../../changelog.rst:818
-#: ../../changelog.rst:853 ../../changelog.rst:866 ../../changelog.rst:923
-#: ../../changelog.rst:935 ../../changelog.rst:957 ../../changelog.rst:968
-#: ../../changelog.rst:989 ../../changelog.rst:1007 ../../changelog.rst:1049
-#: ../../changelog.rst:1082 ../../changelog.rst:1128 ../../changelog.rst:1152
-#: ../../changelog.rst:1200 ../../changelog.rst:1218 ../../changelog.rst:1768
+#: ../../changelog.rst:296 ../../changelog.rst:453 ../../changelog.rst:544
+#: ../../changelog.rst:568 ../../changelog.rst:598 ../../changelog.rst:638
+#: ../../changelog.rst:717 ../../changelog.rst:780 ../../changelog.rst:825
+#: ../../changelog.rst:860 ../../changelog.rst:873 ../../changelog.rst:930
+#: ../../changelog.rst:942 ../../changelog.rst:964 ../../changelog.rst:975
+#: ../../changelog.rst:996 ../../changelog.rst:1014 ../../changelog.rst:1056
+#: ../../changelog.rst:1089 ../../changelog.rst:1135 ../../changelog.rst:1159
+#: ../../changelog.rst:1207 ../../changelog.rst:1225 ../../changelog.rst:1775
 msgid "**Minor improvements**"
 msgstr ""
 
-#: ../../changelog.rst:291
+#: ../../changelog.rst:298
 msgid "Add blade type on signage detail view (#3325)"
 msgstr ""
 
-#: ../../changelog.rst:295
+#: ../../changelog.rst:302
 msgid ""
 "Bionic (Ubuntu 18.04) instances need to install deadsnakes PPA to handle "
 "python3.8 updates:"
 msgstr ""
 
-#: ../../changelog.rst:297
+#: ../../changelog.rst:304
 msgid "``apt-get install software-properties-common``"
 msgstr ""
 
-#: ../../changelog.rst:299
+#: ../../changelog.rst:306
 msgid "``add-apt-repository --yes ppa:deadsnakes/ppa``"
 msgstr ""
 
-#: ../../changelog.rst:301
+#: ../../changelog.rst:308
 msgid "``apt-get install python3.8``"
 msgstr ""
 
-#: ../../changelog.rst:305
+#: ../../changelog.rst:312
 msgid "In preparation for HD Views developments (PR #3298)"
 msgstr ""
 
-#: ../../changelog.rst:307
+#: ../../changelog.rst:314
 msgid "Bump Python to 3.8"
 msgstr ""
 
-#: ../../changelog.rst:309
+#: ../../changelog.rst:316
 msgid "Bump MapEntity to 8.4.0"
 msgstr ""
 
-#: ../../changelog.rst:311
+#: ../../changelog.rst:318
 msgid "Bump Pillow to 9.3.0"
 msgstr ""
 
-#: ../../changelog.rst:313
+#: ../../changelog.rst:320
 msgid "Bump Celery to 5.2.1"
 msgstr ""
 
-#: ../../changelog.rst:315
+#: ../../changelog.rst:322
 msgid "Bump django-celery-results to 2.4.0"
 msgstr ""
 
-#: ../../changelog.rst:317
+#: ../../changelog.rst:324
 msgid "Bump django-clearcache to 1.2.1"
 msgstr ""
 
-#: ../../changelog.rst:319
+#: ../../changelog.rst:326
 msgid "Add libvips to dependencies"
 msgstr ""
 
-#: ../../changelog.rst:323
+#: ../../changelog.rst:330
 msgid "Apidae trek parser supports geometry import from kml or kmz attachment"
 msgstr ""
 
-#: ../../changelog.rst:324
+#: ../../changelog.rst:331
 msgid ""
 "More checks on Apidae trek parser in order not to import trek without a "
 "geometry"
 msgstr ""
 
-#: ../../changelog.rst:328
+#: ../../changelog.rst:335
 msgid "Fix loaddem command update other types of geometry"
 msgstr ""
 
-#: ../../changelog.rst:329
+#: ../../changelog.rst:336
 msgid "Recreate cache folders if missing. (#3384)"
 msgstr ""
 
-#: ../../changelog.rst:330
+#: ../../changelog.rst:337
 msgid ""
 "Modify site's geometry before saving to avoid edition and export of "
 "shapefiles (#3399)"
 msgstr ""
 
-#: ../../changelog.rst:331
+#: ../../changelog.rst:338
 msgid "Fix API V2 cache key with X-Forwarded-Proto header (#3404)"
 msgstr ""
 
-#: ../../changelog.rst:332
+#: ../../changelog.rst:339
 msgid "Check pictogram exist on categories during generation of pdfs"
 msgstr ""
 
-#: ../../changelog.rst:333
+#: ../../changelog.rst:340
 msgid ""
 "Prevent \"Internal Error\" on API v2 when wrong url parameter is provided"
 " on courses and sites filter for pois"
 msgstr ""
 
-#: ../../changelog.rst:334
+#: ../../changelog.rst:341
 msgid "Fix ApidaeParsers does not update every time"
 msgstr ""
 
-#: ../../changelog.rst:335
+#: ../../changelog.rst:342
 msgid "Add fixtures licenses initial install"
 msgstr ""
 
-#: ../../changelog.rst:336
+#: ../../changelog.rst:343
 msgid "Fix default conf nginx for mobile"
 msgstr ""
 
-#: ../../changelog.rst:337
+#: ../../changelog.rst:344
 msgid ""
 "Replace image's relative URLs with absolute URLs in API v2 trek "
 "descriptions (#3321)"
 msgstr ""
 
-#: ../../changelog.rst:338
+#: ../../changelog.rst:345
 msgid ""
 "Disable scroll propagation on layers list to avoid zoom changes on map "
 "(#2687)"
 msgstr ""
 
-#: ../../changelog.rst:342
+#: ../../changelog.rst:349
 msgid "2.94.0     (2022-12-12)"
 msgstr ""
 
-#: ../../changelog.rst:346
+#: ../../changelog.rst:353
 msgid ""
 "New ``LEIParser`` to import touristic content and event from LEI "
 "touristic data system"
 msgstr ""
 
-#: ../../changelog.rst:347
+#: ../../changelog.rst:354
 msgid "New ``XMLParser`` to import content from XML"
 msgstr ""
 
-#: ../../changelog.rst:348
+#: ../../changelog.rst:355
 msgid "ApidaeTrekParser: import trek's contact info into description"
 msgstr ""
 
-#: ../../changelog.rst:349
+#: ../../changelog.rst:356
 msgid ""
 "New ``Parser`` subclass to import POIs from the APIDAE touristic data "
 "system."
 msgstr ""
 
-#: ../../changelog.rst:350
+#: ../../changelog.rst:357
 msgid ""
 "New ``POIParser`` to import POIs from files (with and without dynamic "
 "segmentation)"
 msgstr ""
 
-#: ../../changelog.rst:351
+#: ../../changelog.rst:358
 msgid "Change default color of imported filelayer (#306)"
 msgstr ""
 
-#: ../../changelog.rst:355
+#: ../../changelog.rst:362
 msgid "Fix shp zipfile import"
 msgstr ""
 
-#: ../../changelog.rst:356
+#: ../../changelog.rst:363
 msgid "ApidaeTrekParser: round computed duration"
 msgstr ""
 
-#: ../../changelog.rst:357
+#: ../../changelog.rst:364
 msgid "ApidaeTrekParser: fix attached pictures import"
 msgstr ""
 
-#: ../../changelog.rst:361
+#: ../../changelog.rst:368
 msgid "2.93.0     (2022-12-06)"
 msgstr ""
 
-#: ../../changelog.rst:365
+#: ../../changelog.rst:372
 msgid ""
 "New ``Parser`` subclass to import treks from the APIDAE touristic data "
 "system."
 msgstr ""
 
-#: ../../changelog.rst:369
+#: ../../changelog.rst:376
 msgid ""
 "Use MapEntity widget for geometries even without setting "
 "``TREKKING_TOPOLOGY_ENABLED`` (to always display file layer leaflet "
 "plugin)"
 msgstr ""
 
-#: ../../changelog.rst:373
+#: ../../changelog.rst:380
 msgid "2.92.3     (2022-12-02)"
 msgstr ""
 
-#: ../../changelog.rst:377
+#: ../../changelog.rst:384
 msgid ""
 "API v2: - revert ``?trek filter`` by direct intersecting geometry on "
 "sensitive area endpoint. - improve ``?near_xxx`` filters by direct "
 "intersecting buffered geometry on sensitive area endpoint."
 msgstr ""
 
-#: ../../changelog.rst:383
+#: ../../changelog.rst:390
 msgid "2.92.2     (2022-12-01)"
 msgstr ""
 
-#: ../../changelog.rst:387 ../../changelog.rst:402
+#: ../../changelog.rst:394 ../../changelog.rst:409
 msgid "Fix cache management in API v2"
 msgstr ""
 
-#: ../../changelog.rst:391
+#: ../../changelog.rst:398
 msgid "2.92.1     (2022-12-01)"
 msgstr ""
 
-#: ../../changelog.rst:395
+#: ../../changelog.rst:402
 msgid ""
 "Show direction on lines with setting ``DIRECTION_ON_LINES_ENABLED`` in "
 "signage detail"
 msgstr ""
 
-#: ../../changelog.rst:396
+#: ../../changelog.rst:403
 msgid "Add mobile nginx configuration directly on Geotrek-admin"
 msgstr ""
 
-#: ../../changelog.rst:400
+#: ../../changelog.rst:407
 msgid "Fix display lines on signage with setting ``DIRECTION_ON_LINES_ENABLED``"
 msgstr ""
 
-#: ../../changelog.rst:401
+#: ../../changelog.rst:408
 msgid "Show required's style for lines in blade form"
 msgstr ""
 
-#: ../../changelog.rst:406
+#: ../../changelog.rst:413
 msgid "2.92.0     (2022-11-29)"
 msgstr ""
 
-#: ../../changelog.rst:410
+#: ../../changelog.rst:417
 msgid ""
 "!!!! Clear cache after update. You can do this by going to admin panel, "
 "\"clearcache\" section, then delete default / fat and api_v2 !!!!"
 msgstr ""
 
-#: ../../changelog.rst:414
+#: ../../changelog.rst:421
 msgid "Cache API v2 Detail endpoints and themes list endpoint"
 msgstr ""
 
-#: ../../changelog.rst:415
+#: ../../changelog.rst:422
 msgid ""
 "Sensitive areas are now computed with buffered geometries with settings "
 "SENSITIVE_AREA_INTERSECTION_MARGIN. Use ST_INTERSECTS on it is faster."
 msgstr ""
 
-#: ../../changelog.rst:416
+#: ../../changelog.rst:423
 msgid "Zoning informations are now cached until instance or zoning is updated."
 msgstr ""
 
-#: ../../changelog.rst:417
+#: ../../changelog.rst:424
 msgid "Show more decimal for coordinates in signage sql view"
 msgstr ""
 
-#: ../../changelog.rst:421
+#: ../../changelog.rst:428
 msgid ""
 "Separate application and API v2 cache, ability to purge them with command"
 " or via admin"
 msgstr ""
 
-#: ../../changelog.rst:425
+#: ../../changelog.rst:432
 msgid "Check geom is valid before save"
 msgstr ""
 
-#: ../../changelog.rst:426
+#: ../../changelog.rst:433
 msgid ""
 "Fix old migration script of Topology.geom (actually causes Django to "
 "falsely detect model changes not yet with a migration in NDS mode)"
 msgstr ""
 
-#: ../../changelog.rst:427
+#: ../../changelog.rst:434
 msgid ""
 "Check that the Spatial Reference Identifier (SRID) unit is in meters "
 "before launching application (was during migration)"
 msgstr ""
 
-#: ../../changelog.rst:428
+#: ../../changelog.rst:435
 msgid "Fix filter_type1 and filter_type2 for EspritParcParser when val is a list"
 msgstr ""
 
-#: ../../changelog.rst:429
+#: ../../changelog.rst:436
 msgid ""
 "Fix \"'NoneType' object is not iterable\" when responseData is null for "
 "EspritParcParser"
 msgstr ""
 
-#: ../../changelog.rst:433
+#: ../../changelog.rst:440
 msgid "Fix parameter name ``MAIL_MANAGERS`` in documentation"
 msgstr ""
 
-#: ../../changelog.rst:437
+#: ../../changelog.rst:444
 msgid "2.91.1     (2022-11-18)"
 msgstr ""
 
-#: ../../changelog.rst:441 ../../changelog.rst:454
+#: ../../changelog.rst:448 ../../changelog.rst:461
 msgid "Fix flatpages can't be saved"
 msgstr ""
 
-#: ../../changelog.rst:444
+#: ../../changelog.rst:451
 msgid "2.91.0     (2022-11-17)"
 msgstr ""
 
-#: ../../changelog.rst:448
+#: ../../changelog.rst:455
 msgid "Add paths in overlays for elements which are not topologies"
 msgstr ""
 
-#: ../../changelog.rst:452
+#: ../../changelog.rst:459
 msgid "Add missing file field in Imports form layout"
 msgstr ""
 
-#: ../../changelog.rst:453
+#: ../../changelog.rst:460
 msgid ""
 "Add missing help texts and validators on ``TouristicEvent`` "
 "``intervention_duration`` and ``preparation_duration``"
 msgstr ""
 
-#: ../../changelog.rst:458
+#: ../../changelog.rst:465
 msgid "2.90.1 (2022-11-04)"
 msgstr ""
 
-#: ../../changelog.rst:462
+#: ../../changelog.rst:469
 msgid ""
 "Prevent providers from APIv2 from overriding local providers when using "
 "``GeotrekParser``"
 msgstr ""
 
-#: ../../changelog.rst:463
+#: ../../changelog.rst:470
 msgid ""
 "Add missing sources parsing to ``GeotrekParser`` (for ``Trek``, "
 "``Touristic Content``, ``Touristic Event``)"
 msgstr ""
 
-#: ../../changelog.rst:466
+#: ../../changelog.rst:473
 msgid "2.90.0     (2022-11-03)"
 msgstr ""
 
-#: ../../changelog.rst:470
+#: ../../changelog.rst:477
 msgid "Add new command to reorder pathaggregations of topologies"
 msgstr ""
 
-#: ../../changelog.rst:474
+#: ../../changelog.rst:481
 msgid "Fix APIv2 does not return sources related to published sites"
 msgstr ""
 
-#: ../../changelog.rst:478
+#: ../../changelog.rst:485
 msgid "2.89.1 (2022-10-20)"
 msgstr ""
 
-#: ../../changelog.rst:482
+#: ../../changelog.rst:489
 msgid ""
 "Prevent migration ``0033_auto_20220929_0840`` from failing by escaping "
 "Touristic Events ``participant_number``"
 msgstr ""
 
-#: ../../changelog.rst:483
+#: ../../changelog.rst:490
 msgid ""
 "Fix signage details page with DIRECTION_ON_LINES enabled (hide "
 "\"Direction\" column header)"
 msgstr ""
 
-#: ../../changelog.rst:486
+#: ../../changelog.rst:493
 msgid "2.89.0 (2022-10-20)"
 msgstr ""
 
-#: ../../changelog.rst:492 ../../changelog.rst:515
+#: ../../changelog.rst:499 ../../changelog.rst:522
 msgid ""
 "Migrations for Touristic Events can fail depending on data for "
 "``participant_number`` - Skip to 2.89.1 instead"
 msgstr ""
 
-#: ../../changelog.rst:496
+#: ../../changelog.rst:503
 msgid ""
 "Add fields ``preparation_duration``, ``intervention_duration``  to "
 "TouristicEvents"
 msgstr ""
 
-#: ../../changelog.rst:497
+#: ../../changelog.rst:504
 msgid ""
 "Add new setting ``DIRECTION_ON_LINES_ENABLED`` to have the ``direction`` "
 "field on lines instead of blades"
 msgstr ""
 
-#: ../../changelog.rst:498
+#: ../../changelog.rst:505
 msgid ""
 "Partially handle translated fields: when setting "
 "``fill_empty_translated_fields`` to True, all empty translation fields "
 "for all languages will be set with the parsed value"
 msgstr ""
 
-#: ../../changelog.rst:503
+#: ../../changelog.rst:510
 msgid ""
 "Blade list view now takes into account custom columns from "
 "``COLUMNS_LISTS`` setting"
 msgstr ""
 
-#: ../../changelog.rst:504
+#: ../../changelog.rst:511
 msgid "Fix Suricate Workflow : do not unlock reports when resolving them"
 msgstr ""
 
-#: ../../changelog.rst:505
+#: ../../changelog.rst:512
 msgid "Fix Suricate Workflow : display clickable links in report related emails"
 msgstr ""
 
-#: ../../changelog.rst:509
+#: ../../changelog.rst:516
 msgid "2.88.0 (2022-10-11)"
 msgstr ""
 
-#: ../../changelog.rst:519
+#: ../../changelog.rst:526
 msgid ""
 "Add optional places to TouristicEvents, using place selector to locate "
 "TouristicEvent on form map (#3266)"
 msgstr ""
 
-#: ../../changelog.rst:520
+#: ../../changelog.rst:527
 msgid ""
 "Add fields ``end_time``, ``cancelled``, ``cancellation_reason``, "
 "``bookable`` and ``place`` to TouristicEvents (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:521
+#: ../../changelog.rst:528
 msgid ""
 "``cancellation_reason`` selector is displayed in Event form if "
 "``bookable`` is checked (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:522
+#: ../../changelog.rst:529
 msgid ""
 "``booking`` text box is displayed in Event form if ``bookable`` is "
 "checked (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:523
+#: ../../changelog.rst:530
 msgid ""
 "Create ``Assessment`` tab in Event form to input retrospective "
 "information such as number of attendees per category (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:524
+#: ../../changelog.rst:531
 msgid ""
 "Create ``TouristicEventParticipantCategory`` model to define types of "
 "attendees for Events (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:526 ../../changelog.rst:1253 ../../changelog.rst:2495
-#: ../../changelog.rst:3217 ../../changelog.rst:3376 ../../changelog.rst:3670
-#: ../../changelog.rst:3736 ../../changelog.rst:3992 ../../changelog.rst:4027
-#: ../../changelog.rst:4133 ../../changelog.rst:4213 ../../changelog.rst:4379
-#: ../../changelog.rst:4467
+#: ../../changelog.rst:533 ../../changelog.rst:1260 ../../changelog.rst:2502
+#: ../../changelog.rst:3224 ../../changelog.rst:3383 ../../changelog.rst:3677
+#: ../../changelog.rst:3743 ../../changelog.rst:3999 ../../changelog.rst:4034
+#: ../../changelog.rst:4140 ../../changelog.rst:4220 ../../changelog.rst:4386
+#: ../../changelog.rst:4474
 msgid "**Breaking changes**"
 msgstr ""
 
-#: ../../changelog.rst:528
+#: ../../changelog.rst:535
 msgid ""
 "Rename ``meeting_time`` to ``start_time`` for TouristicEvent. APIv2 "
 "serialisation for TouristicEvent now exposes ``start_time`` instead of "
 "``meeting_time`` (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:529
+#: ../../changelog.rst:536
 msgid ""
 "Rename ``participant_number`` to ``capacity`` for TouristicEvent. APIv2 "
 "serialisation for TouristicEvent now exposes ``capacity`` instead of "
 "``participant_number`` (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:530
+#: ../../changelog.rst:537
 msgid ""
 "These fields are still available in API v2 for retrocompatibility but "
 "should not be used by default (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:531
+#: ../../changelog.rst:538
 msgid ""
 "If you have specific parsers importing into TouristicEvents, you should "
 "rename ``meeting_time`` to ``start_time`` and ``participant_number`` to "
 "``capacity`` (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:535
+#: ../../changelog.rst:542
 msgid "Fix TouristicEvent with no end dates are not returned in APIv2 (#3127)"
 msgstr ""
 
-#: ../../changelog.rst:539
+#: ../../changelog.rst:546
 msgid ""
 "Check ``begin_date`` is before ``end_date`` in TouristicEvent forms "
 "(#3237)"
 msgstr ""
 
-#: ../../changelog.rst:540
+#: ../../changelog.rst:547
 msgid "Set ``begin_date`` not null for TouristicEvents (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:541
+#: ../../changelog.rst:548
 msgid "Change order of attributes in Event forms and detail view (#3237)"
 msgstr ""
 
-#: ../../changelog.rst:542
+#: ../../changelog.rst:549
 msgid ""
 "Update Event SQL view ``v_touristicevents`` according to above changes "
 "(#3237)"
 msgstr ""
 
-#: ../../changelog.rst:544 ../../changelog.rst:611 ../../changelog.rst:685
-#: ../../changelog.rst:833
+#: ../../changelog.rst:551 ../../changelog.rst:618 ../../changelog.rst:692
+#: ../../changelog.rst:840
 msgid "**Suricate Workflow**  (#2366)"
 msgstr ""
 
-#: ../../changelog.rst:546
+#: ../../changelog.rst:553
 msgid "Show sentinel email addresses only to workflow manager"
 msgstr ""
 
-#: ../../changelog.rst:551
+#: ../../changelog.rst:558
 msgid ""
 "Add new setting `DIRECTION_ON_LINES_ENABLED` to have the `direction` "
 "field on lines instead of blades"
 msgstr ""
 
-#: ../../changelog.rst:555
+#: ../../changelog.rst:562
 msgid "2.87.2 (2022-09-23)"
 msgstr ""
 
-#: ../../changelog.rst:559
+#: ../../changelog.rst:566
 msgid ""
 "Add `default_language` attribute to Parsers to specify which language to "
 "update"
 msgstr ""
 
-#: ../../changelog.rst:563
+#: ../../changelog.rst:570
 msgid "Ensure attachments from parsers have generated thumbnails"
 msgstr ""
 
-#: ../../changelog.rst:567
+#: ../../changelog.rst:574
 msgid "Fix `provider` is not used properly when parsing TouristicContents"
 msgstr ""
 
-#: ../../changelog.rst:568
+#: ../../changelog.rst:575
 msgid "Improve Aggregator translation management"
 msgstr ""
 
-#: ../../changelog.rst:569
+#: ../../changelog.rst:576
 msgid "Fix PermissionError during sync-rando on fresh install from .deb package"
 msgstr ""
 
-#: ../../changelog.rst:573
+#: ../../changelog.rst:580
 msgid "2.87.1 (2022-09-20)"
 msgstr ""
 
-#: ../../changelog.rst:577
+#: ../../changelog.rst:584
 msgid "Fix acces rights on files after synchronization"
 msgstr ""
 
-#: ../../changelog.rst:581
+#: ../../changelog.rst:588
 msgid "2.87.0 (2022-09-20)"
 msgstr ""
 
-#: ../../changelog.rst:585
+#: ../../changelog.rst:592
 msgid ""
 "Add `provider` field to Trek, POI, Service, Signage, Infrastructure, "
 "TouristicContent, TouristicEvent, InformationDesk, Path, Trail, Course, "
 "Site, SensitiveArea (#3189)"
 msgstr ""
 
-#: ../../changelog.rst:587
+#: ../../changelog.rst:594
 msgid ""
 "Add parser using api v2 (InformationDesk, TouristicContent, "
 "TouristicEvent, POI, Trek, Service, Signage, Infrastructure)"
 msgstr ""
 
-#: ../../changelog.rst:588
+#: ../../changelog.rst:595
 msgid "Add aggregator parser with a conductor using json file"
 msgstr ""
 
-#: ../../changelog.rst:593
+#: ../../changelog.rst:600
 msgid "Disable debug log in debian package post installation script."
 msgstr ""
 
-#: ../../changelog.rst:594
+#: ../../changelog.rst:601
 msgid ""
 "Improve and fix error logging, now errors and warnings are logged to "
 "var/geotrek.log and console."
 msgstr ""
 
-#: ../../changelog.rst:595
+#: ../../changelog.rst:602
 msgid ""
 "Allow configuring email alerts for late reports (generalized from "
 "Suricate Workflow #2366)"
 msgstr ""
 
-#: ../../changelog.rst:599
+#: ../../changelog.rst:606
 msgid "Fix filtering on Services List does not filter"
 msgstr ""
 
-#: ../../changelog.rst:600
+#: ../../changelog.rst:607
 msgid "Fix Site creation form is initialized with parent Site"
 msgstr ""
 
-#: ../../changelog.rst:601
+#: ../../changelog.rst:608
 msgid "Fix memory leak and optimize SQL queries on zoning intersections"
 msgstr ""
 
-#: ../../changelog.rst:602
+#: ../../changelog.rst:609
 msgid ""
 "Fix error message should not be displayed on attachments from the same "
 "structure as user"
 msgstr ""
 
-#: ../../changelog.rst:606
+#: ../../changelog.rst:613
 msgid "Upgrade dependencies. The detail for the main dependencies:"
 msgstr ""
 
-#: ../../changelog.rst:608
+#: ../../changelog.rst:615
 msgid "django to 3.2.15"
 msgstr ""
 
-#: ../../changelog.rst:609
+#: ../../changelog.rst:616
 msgid "celery[redis] to 5.1.2"
 msgstr ""
 
-#: ../../changelog.rst:613
+#: ../../changelog.rst:620
 msgid "Do not unlock reports when resolving them"
 msgstr ""
 
-#: ../../changelog.rst:614 ../../changelog.rst:688
+#: ../../changelog.rst:621 ../../changelog.rst:695
 msgid "Improve Suricate workflow alert emails"
 msgstr ""
 
-#: ../../changelog.rst:618
+#: ../../changelog.rst:625
 msgid "2.86.0 (2022-09-05)"
 msgstr ""
 
-#: ../../changelog.rst:622
+#: ../../changelog.rst:629
 msgid ""
 "Add sync_rando / sync_mobile option `empty_tmp_folder` which will force "
 "deletion of all directories / files in tmp directory"
 msgstr ""
 
-#: ../../changelog.rst:623
+#: ../../changelog.rst:630
 msgid "Add information desk uuid (#3189)"
 msgstr ""
 
-#: ../../changelog.rst:624
+#: ../../changelog.rst:631
 msgid ""
 "Add setting ``ALERT_DRAFT`` which send mail whenever a path has been "
 "changed to draft (#2904)"
 msgstr ""
 
-#: ../../changelog.rst:625
+#: ../../changelog.rst:632
 msgid "Add file type to attachments in API v2 (#3189)"
 msgstr ""
 
-#: ../../changelog.rst:626
+#: ../../changelog.rst:633
 msgid "Add possibility to use different type of file with import form"
 msgstr ""
 
-#: ../../changelog.rst:627
+#: ../../changelog.rst:634
 msgid ""
 "Add setting MAX_CHARACTERS for rich text fields with Mapentity 8.2.1 "
 "(#2901)"
 msgstr ""
 
-#: ../../changelog.rst:628
+#: ../../changelog.rst:635
 msgid "Set map resizable with Mapentity 8.2.1 (#3162)"
 msgstr ""
 
-#: ../../changelog.rst:629
+#: ../../changelog.rst:636
 msgid ""
 "Add Category, certification label and status fields on trails (#2900 & "
 "#3152)"
 msgstr ""
 
-#: ../../changelog.rst:633
+#: ../../changelog.rst:640
 msgid ""
 "Remove problems of tmp_sync_rando / tmp_sync_mobile which are not removed"
 " before new sync_rando / sync_mobile"
 msgstr ""
 
-#: ../../changelog.rst:634
+#: ../../changelog.rst:641
 msgid "Change translation for Tag in Feedback module"
 msgstr ""
 
-#: ../../changelog.rst:635
+#: ../../changelog.rst:642
 msgid ""
 "Change concatenation of null value for multiples values from '*' to '_' "
 "on sql views"
 msgstr ""
 
-#: ../../changelog.rst:636
+#: ../../changelog.rst:643
 msgid "Prevent \"Internal Error\" on API v2 when wrong url parameter is provided"
 msgstr ""
 
-#: ../../changelog.rst:637
+#: ../../changelog.rst:644
 msgid ""
 "Add 'source', 'portal', 'labels' and 'structure' to Cirkwi trek exports "
 "(#3220, #3164)"
 msgstr ""
 
-#: ../../changelog.rst:639
+#: ../../changelog.rst:646
 msgid "**New ci**"
 msgstr ""
 
-#: ../../changelog.rst:641
+#: ../../changelog.rst:648
 msgid "New common interface github actions"
 msgstr ""
 
-#: ../../changelog.rst:645
+#: ../../changelog.rst:652
 msgid "Set relevant max zoom level for OpenTopoMap in the default config"
 msgstr ""
 
-#: ../../changelog.rst:646
+#: ../../changelog.rst:653
 msgid "Fix fields filter for infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:650
+#: ../../changelog.rst:657
 msgid "Upgrade mapentity to 8.2.1"
 msgstr ""
 
-#: ../../changelog.rst:652
+#: ../../changelog.rst:659
 msgid "**! Regression !**"
 msgstr ""
 
-#: ../../changelog.rst:654
+#: ../../changelog.rst:661
 msgid ""
 "System permissions on files output by `sync_rando` and `sync_mobile` "
 "commands were inadvertently changed to more restricted with no reading "
@@ -1498,185 +1509,185 @@ msgid ""
 "restored with `v2.87.1`."
 msgstr ""
 
-#: ../../changelog.rst:660
+#: ../../changelog.rst:667
 msgid "2.85.0     (2022-07-26)"
 msgstr ""
 
-#: ../../changelog.rst:664
+#: ../../changelog.rst:671
 msgid ""
 "Fix downgrade user permissions (is_staff, is_superuser) for external "
 "authent (#3156)"
 msgstr ""
 
-#: ../../changelog.rst:665
+#: ../../changelog.rst:672
 msgid ""
 "Use permission bypass_structure on attachments and accessibility "
 "attachments (#2899)"
 msgstr ""
 
-#: ../../changelog.rst:666
+#: ../../changelog.rst:673
 msgid "Add boolean field 'display_in_legend' to Report Status model"
 msgstr ""
 
-#: ../../changelog.rst:667
+#: ../../changelog.rst:674
 msgid ""
 "Add setting ``ALERT_REVIEW`` which send mail whenever an object has been "
 "changed to review (#2903)"
 msgstr ""
 
-#: ../../changelog.rst:668
+#: ../../changelog.rst:675
 msgid ""
 "Add setting ``PAPERCLIP_MAX_BYTES_SIZE_IMAGE`` unallow usage of huge "
 "image (#2902)"
 msgstr ""
 
-#: ../../changelog.rst:669
+#: ../../changelog.rst:676
 msgid ""
 "Add setting ``PAPERCLIP_MIN_IMAGE_UPLOAD_WIDTH`` unallow usage of images "
 "with small width (#2902)"
 msgstr ""
 
-#: ../../changelog.rst:670
+#: ../../changelog.rst:677
 msgid ""
 "Add setting ``PAPERCLIP_MIN_IMAGE_UPLOAD_HEIGHT`` unallow usage of images"
 " with small height (#2902) These settings will influence the attachments "
 "downloaded in parsers"
 msgstr ""
 
-#: ../../changelog.rst:675
+#: ../../changelog.rst:682
 msgid "Add tutorial to visualize sql views in Qgis"
 msgstr ""
 
-#: ../../changelog.rst:676
+#: ../../changelog.rst:683
 msgid "Add sql views for Qgis"
 msgstr ""
 
-#: ../../changelog.rst:680
+#: ../../changelog.rst:687
 msgid "Fix api v2 services are published by type"
 msgstr ""
 
-#: ../../changelog.rst:681
+#: ../../changelog.rst:688
 msgid ""
 "Fix form outdoor/trekking when rating scale is used with modification of "
 "practice"
 msgstr ""
 
-#: ../../changelog.rst:682
+#: ../../changelog.rst:689
 msgid "Fix initial value of rating was not shown in trekking form (#3121)"
 msgstr ""
 
-#: ../../changelog.rst:687
+#: ../../changelog.rst:694
 msgid ""
 "Add form field to enter messages for administrators in Report Workflow "
 "Mode"
 msgstr ""
 
-#: ../../changelog.rst:692
+#: ../../changelog.rst:699
 msgid "2.84.1     (2022-06-21)"
 msgstr ""
 
-#: ../../changelog.rst:696
+#: ../../changelog.rst:703
 msgid "Fix length_2d or land's app for exports and lists"
 msgstr ""
 
-#: ../../changelog.rst:700
+#: ../../changelog.rst:707
 msgid "2.84.0     (2022-06-20)"
 msgstr ""
 
-#: ../../changelog.rst:704
+#: ../../changelog.rst:711
 msgid "Add filter valid geometries on topologies (#2515)[3.1]"
 msgstr ""
 
-#: ../../changelog.rst:705
+#: ../../changelog.rst:712
 msgid ""
 "Add setting ``ALLOW_PATH_DELETION_TOPOLOGY`` which protect or not against"
 " deletion of path with topologies linked to it (#2515)[3.3.1]"
 msgstr ""
 
-#: ../../changelog.rst:706
+#: ../../changelog.rst:713
 msgid "Add eid on InformationDesk"
 msgstr ""
 
-#: ../../changelog.rst:707
+#: ../../changelog.rst:714
 msgid "Add parser InformationDesk for Apidae"
 msgstr ""
 
-#: ../../changelog.rst:708
+#: ../../changelog.rst:715
 msgid "Add accessibility on Infrastructure in api v2"
 msgstr ""
 
-#: ../../changelog.rst:712
+#: ../../changelog.rst:719
 msgid "Add length 2d for land's app for exports and lists (#2976)"
 msgstr ""
 
-#: ../../changelog.rst:713
+#: ../../changelog.rst:720
 msgid "Add option to recalculate altimetry with ``loaddem`` command"
 msgstr ""
 
-#: ../../changelog.rst:717
+#: ../../changelog.rst:724
 msgid "Log entry menu is now only displayed if user has permission (#3130)"
 msgstr ""
 
-#: ../../changelog.rst:718
+#: ../../changelog.rst:725
 msgid "Admin menu is now only displayed if user has permission (#3130)"
 msgstr ""
 
-#: ../../changelog.rst:719
+#: ../../changelog.rst:726
 msgid ""
 "Object 'All history' button is now only displayed if user has permission "
 "(#3130)"
 msgstr ""
 
-#: ../../changelog.rst:720
+#: ../../changelog.rst:727
 msgid "Error 404 default template now display a visible message"
 msgstr ""
 
-#: ../../changelog.rst:721
+#: ../../changelog.rst:728
 msgid "Error 500 default template doesn't make recursive exceptions anymore"
 msgstr ""
 
-#: ../../changelog.rst:722
+#: ../../changelog.rst:729
 msgid ""
 "Log entry permissions are now managed by \"mapentity - xxx log entries\" "
 "instead of \"admin - xxx log entries\""
 msgstr ""
 
-#: ../../changelog.rst:723
+#: ../../changelog.rst:730
 msgid "Fix information desk filter when outdoor module is not available (#3135)"
 msgstr ""
 
-#: ../../changelog.rst:724
+#: ../../changelog.rst:731
 msgid "Fix APIv2 does not return labels and themes on published outdoor sites"
 msgstr ""
 
-#: ../../changelog.rst:726
+#: ../../changelog.rst:733
 msgid "**Breaking Changes**"
 msgstr ""
 
-#: ../../changelog.rst:728
+#: ../../changelog.rst:735
 msgid "This release requires PostGIS 2.5 or later."
 msgstr ""
 
-#: ../../changelog.rst:730
+#: ../../changelog.rst:737
 msgid ""
 "Ubuntu bionic 18.04 users, take care, PostGIS default is 2.4. You need to"
 " upgrade your PostGIS version."
 msgstr ""
 
-#: ../../changelog.rst:732
+#: ../../changelog.rst:739
 msgid ""
 "See documentation "
 "https://geotrek.readthedocs.io/en/latest/install/installation.html"
 "#ubuntu-bionic-postgis-2.5-upgrade)"
 msgstr ""
 
-#: ../../changelog.rst:736
+#: ../../changelog.rst:743
 msgid ""
 "From now, Geotrek-admin is not installable on Ubuntu 18.04 bionic "
 "anymore. But upgrade are still available."
 msgstr ""
 
-#: ../../changelog.rst:737
+#: ../../changelog.rst:744
 msgid ""
 "The default Nginx configuration template `has been improved "
 "<https://github.com/GeotrekCE/Geotrek-"
@@ -1686,860 +1697,860 @@ msgid ""
 "admin/var/conf/nginx.conf.in``)."
 msgstr ""
 
-#: ../../changelog.rst:739
+#: ../../changelog.rst:746
 msgid "**Improvments**"
 msgstr ""
 
-#: ../../changelog.rst:741
+#: ../../changelog.rst:748
 msgid ""
 "New GeoJSON generation system, using Django Rest Framework and PostGIS "
 "functions (#2967)"
 msgstr ""
 
-#: ../../changelog.rst:742
+#: ../../changelog.rst:749
 msgid "Enable GZIP compression on JSON / GeoJSON by Nginx"
 msgstr ""
 
-#: ../../changelog.rst:746
+#: ../../changelog.rst:753
 msgid "Upgrade mapentity to 8.1.2"
 msgstr ""
 
-#: ../../changelog.rst:750
+#: ../../changelog.rst:757
 msgid "2.83.0     (2022-06-01)"
 msgstr ""
 
-#: ../../changelog.rst:754
+#: ../../changelog.rst:761
 msgid "Display link to attachment in admin site for attachments"
 msgstr ""
 
-#: ../../changelog.rst:755
+#: ../../changelog.rst:762
 msgid "Add license field on attachments (#3089) [thanks to Paul Florence]"
 msgstr ""
 
-#: ../../changelog.rst:756
+#: ../../changelog.rst:763
 msgid ""
 "If ``COMPLETENESS_FIELDS`` is set for a model an object is published, "
 "display completeness fields if missing on page detail (#2898)"
 msgstr ""
 
-#: ../../changelog.rst:758
+#: ../../changelog.rst:765
 msgid ""
 "Avoid publication or review if ``COMPLETENESS_FIELDS`` is set for a "
 "model, and ``COMPLETENESS_LEVEL`` is one of 'error_on_publication' and "
 "'error_on_review' (#2898)"
 msgstr ""
 
-#: ../../changelog.rst:763
+#: ../../changelog.rst:770
 msgid ""
 "Fix APIv2 does not return information desks on published outdoor "
 "sites(#3095)"
 msgstr ""
 
-#: ../../changelog.rst:764
+#: ../../changelog.rst:771
 msgid "Fix trail detail link in list view"
 msgstr ""
 
-#: ../../changelog.rst:765
+#: ../../changelog.rst:772
 msgid "Fix infrastructure detail link in list view"
 msgstr ""
 
-#: ../../changelog.rst:766
+#: ../../changelog.rst:773
 msgid "Fix dive detail link in list view"
 msgstr ""
 
-#: ../../changelog.rst:767
+#: ../../changelog.rst:774
 msgid "Fix signage and infrastructure attachment access if published"
 msgstr ""
 
-#: ../../changelog.rst:771
+#: ../../changelog.rst:778
 msgid "Improve import from file section"
 msgstr ""
 
-#: ../../changelog.rst:775
+#: ../../changelog.rst:782
 msgid "Add image widget to tinymce editors by default"
 msgstr ""
 
-#: ../../changelog.rst:776
+#: ../../changelog.rst:783
 msgid ""
 "Delete filenames in captions of attachments when importing from Apidae "
 "(#2698)"
 msgstr ""
 
-#: ../../changelog.rst:777
+#: ../../changelog.rst:784
 msgid "Add copyright when importing from Apidae on attachments (#2698)"
 msgstr ""
 
-#: ../../changelog.rst:778
+#: ../../changelog.rst:785
 msgid ""
 "Improve basic fixture for Feedback app allowing to initialize Report form"
 " in one go"
 msgstr ""
 
-#: ../../changelog.rst:782
+#: ../../changelog.rst:789
 msgid "Add a git hook to prevent pushing to master."
 msgstr ""
 
-#: ../../changelog.rst:783
+#: ../../changelog.rst:790
 msgid "Update to paperclip 2.5.0"
 msgstr ""
 
-#: ../../changelog.rst:787
+#: ../../changelog.rst:794
 msgid "2.82.2  (2022-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:791
+#: ../../changelog.rst:798
 msgid ""
 "Prevent exceptions on malformed images when launching ``sync_suricate`` "
 "command"
 msgstr ""
 
-#: ../../changelog.rst:792
+#: ../../changelog.rst:799
 msgid "Fix alert on Project list view"
 msgstr ""
 
-#: ../../changelog.rst:796
+#: ../../changelog.rst:803
 msgid "2.82.1  (2022-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:798
+#: ../../changelog.rst:805
 msgid "**WARNING!** Do not use, list view for Projects raises Datatable alert"
 msgstr ""
 
-#: ../../changelog.rst:803
+#: ../../changelog.rst:810
 msgid ""
 "Fix display objects with wrong colors when "
 "``ENABLE_REPORT_COLORS_PER_STATUS`` is True"
 msgstr ""
 
-#: ../../changelog.rst:807
+#: ../../changelog.rst:814
 msgid "2.82.0     (2022-04-27)"
 msgstr ""
 
-#: ../../changelog.rst:809 ../../changelog.rst:893 ../../changelog.rst:906
-#: ../../changelog.rst:1257 ../../changelog.rst:1920 ../../changelog.rst:3544
+#: ../../changelog.rst:816 ../../changelog.rst:900 ../../changelog.rst:913
+#: ../../changelog.rst:1264 ../../changelog.rst:1927 ../../changelog.rst:3551
 msgid "**WARNING!**"
 msgstr ""
 
-#: ../../changelog.rst:811
+#: ../../changelog.rst:818
 msgid ""
 "Do not use, or set ``ENABLE_REPORT_COLORS_PER_STATUS`` to False, else "
 "objects will not be displayed properly on map - Release 2.82.1 should be "
 "used instead"
 msgstr ""
 
-#: ../../changelog.rst:815
+#: ../../changelog.rst:822
 msgid "Server-side list pagination. Better performance for large lists (#2967)"
 msgstr ""
 
-#: ../../changelog.rst:816
+#: ../../changelog.rst:823
 msgid ""
 "Add overlays for objects from Trekking, Maintenance, Infrastructure and "
 "Feedback modules (#1300)"
 msgstr ""
 
-#: ../../changelog.rst:820
+#: ../../changelog.rst:827
 msgid "Refer to Reports by a label instead of email addresses"
 msgstr ""
 
-#: ../../changelog.rst:821
+#: ../../changelog.rst:828
 msgid "Increase default cache expiration from 8hours to 30days (#2967)"
 msgstr ""
 
-#: ../../changelog.rst:822
+#: ../../changelog.rst:829
 msgid ""
 "Use distance from setting ``SENSITIVE_AREA_INTERSECTION_MARGIN`` in "
 "sensitive area filter `trek` in api v2"
 msgstr ""
 
-#: ../../changelog.rst:826
+#: ../../changelog.rst:833
 msgid "Fix filter ``trek`` in api v2 for information desks"
 msgstr ""
 
-#: ../../changelog.rst:827
+#: ../../changelog.rst:834
 msgid ""
 "Fix filter ``trek`` in api v2 for pois with setting "
 "``TREKKING_TOPOLOGY_ENABLED`` (#3054)"
 msgstr ""
 
-#: ../../changelog.rst:831
+#: ../../changelog.rst:838
 msgid "Update to mapentity 8.0.1"
 msgstr ""
 
-#: ../../changelog.rst:835
+#: ../../changelog.rst:842
 msgid "Add ``assigned_user`` field to Report model"
 msgstr ""
 
-#: ../../changelog.rst:836
+#: ../../changelog.rst:843
 msgid "Add ``color`` field to Report Status model"
 msgstr ""
 
-#: ../../changelog.rst:837
+#: ../../changelog.rst:844
 msgid ""
 "Add TimerEvent class, used to alert Report supervisors when timer "
 "expires, with ``check_timers`` command"
 msgstr ""
 
-#: ../../changelog.rst:838
+#: ../../changelog.rst:845
 msgid "Force workflow when ``SURICATE_WORKFLOW_ENABLED`` setting is enabled"
 msgstr ""
 
-#: ../../changelog.rst:839
+#: ../../changelog.rst:846
 msgid ""
 "Add setting ``ENABLE_REPORT_COLORS_PER_STATUS`` to display different "
 "colors in status list view"
 msgstr ""
 
-#: ../../changelog.rst:840
+#: ../../changelog.rst:847
 msgid "Add editable predefined emails"
 msgstr ""
 
-#: ../../changelog.rst:841
+#: ../../changelog.rst:848
 msgid "Display only some reports depending on which user is logged in"
 msgstr ""
 
-#: ../../changelog.rst:842
+#: ../../changelog.rst:849
 msgid "Add City and District information to Report detail page"
 msgstr ""
 
-#: ../../changelog.rst:843
+#: ../../changelog.rst:850
 msgid "Alert user about synchronization problems in Suricate Workflow mode"
 msgstr ""
 
-#: ../../changelog.rst:847
+#: ../../changelog.rst:854
 msgid "2.81.0     (2022-04-11)"
 msgstr ""
 
-#: ../../changelog.rst:851
+#: ../../changelog.rst:858
 msgid "Add SQL default values directly on most tables of the database (#3008)"
 msgstr ""
 
-#: ../../changelog.rst:855
+#: ../../changelog.rst:862
 msgid ""
 "Rename French field names of attachment and accessibility attachment "
 "tables (author, legend, title)"
 msgstr ""
 
-#: ../../changelog.rst:856 ../../changelog.rst:868
+#: ../../changelog.rst:863 ../../changelog.rst:875
 msgid "Improve pdf for sites, courses"
 msgstr ""
 
-#: ../../changelog.rst:860
+#: ../../changelog.rst:867
 msgid "Update to paperclip 2.4.3"
 msgstr ""
 
-#: ../../changelog.rst:864
+#: ../../changelog.rst:871
 msgid "2.80.0     (2022-04-05)"
 msgstr ""
 
-#: ../../changelog.rst:869
+#: ../../changelog.rst:876
 msgid ""
 "Add a new parameter in parsers, allowing to add multiple values to fields"
 " from multiple parsers (#2091)"
 msgstr ""
 
-#: ../../changelog.rst:870
+#: ../../changelog.rst:877
 msgid "Add locale altimetry filters"
 msgstr ""
 
-#: ../../changelog.rst:871
+#: ../../changelog.rst:878
 msgid "Change order list actions and add new signage in signage module (#2852)"
 msgstr ""
 
-#: ../../changelog.rst:875
+#: ../../changelog.rst:882
 msgid "Fix templates map and image"
 msgstr ""
 
-#: ../../changelog.rst:876
+#: ../../changelog.rst:883
 msgid "Fix trekking's template elevation was not on the right"
 msgstr ""
 
-#: ../../changelog.rst:877
+#: ../../changelog.rst:884
 msgid "Show accessibility block only with datas in accessibility"
 msgstr ""
 
-#: ../../changelog.rst:878
+#: ../../changelog.rst:885
 msgid "Compile messages of every apps"
 msgstr ""
 
-#: ../../changelog.rst:879 ../../changelog.rst:889
+#: ../../changelog.rst:886 ../../changelog.rst:896
 msgid "Fix required language in form is ignored from configuration"
 msgstr ""
 
-#: ../../changelog.rst:880
+#: ../../changelog.rst:887
 msgid "Fix link initial mode is now File (#3001)"
 msgstr ""
 
-#: ../../changelog.rst:881
+#: ../../changelog.rst:888
 msgid "Fix line topologies drawing sometimes fails on some paths"
 msgstr ""
 
-#: ../../changelog.rst:882
+#: ../../changelog.rst:889
 msgid "Fix poi's csv generation of elements from other modules (#2286)"
 msgstr ""
 
-#: ../../changelog.rst:883
+#: ../../changelog.rst:890
 msgid "Fix pdfs booklet outdoor"
 msgstr ""
 
-#: ../../changelog.rst:884
+#: ../../changelog.rst:891
 msgid "Fix api v2 schema targets (GTRV3#607)"
 msgstr ""
 
-#: ../../changelog.rst:885
+#: ../../changelog.rst:892
 msgid "Fix api v2 translation schema targets (values should not be in french)"
 msgstr ""
 
-#: ../../changelog.rst:890
+#: ../../changelog.rst:897
 msgid "Allow configuring scheme forwarding though proxy"
 msgstr ""
 
-#: ../../changelog.rst:891
+#: ../../changelog.rst:898
 msgid "Update to paperclip 2.4.2"
 msgstr ""
 
-#: ../../changelog.rst:895
+#: ../../changelog.rst:902
 msgid ""
 "If an error occurred while checking the signature for debian packaging "
 "check troubleshooting section for additional informations"
 msgstr ""
 
-#: ../../changelog.rst:899
+#: ../../changelog.rst:906
 msgid "2.79.0     (2022-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:903
+#: ../../changelog.rst:910
 msgid "Add public booklet pdf for courses, sites, events, contents, dives"
 msgstr ""
 
-#: ../../changelog.rst:904
+#: ../../changelog.rst:911
 msgid "Improve treks pdf templates and add new accessibility fields (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:908
+#: ../../changelog.rst:915
 msgid ""
 "Check your custom trekking's templates, blocks order changed. There is a "
 "huge new block accessibility. Disabled infrastructure's block have been "
 "removed"
 msgstr ""
 
-#: ../../changelog.rst:913
+#: ../../changelog.rst:920
 msgid "Fix maps height when height is bigger than width in treks pdf (#2746)"
 msgstr ""
 
-#: ../../changelog.rst:917
+#: ../../changelog.rst:924
 msgid "2.78.0     (2022-03-22)"
 msgstr ""
 
-#: ../../changelog.rst:921
+#: ../../changelog.rst:928
 msgid "Ability to customize public PDF by portal  (#2691)"
 msgstr ""
 
-#: ../../changelog.rst:925
+#: ../../changelog.rst:932
 msgid "Add block logo in public PDF templates"
 msgstr ""
 
-#: ../../changelog.rst:929
+#: ../../changelog.rst:936
 msgid "Fix pdf booklet use the right template"
 msgstr ""
 
-#: ../../changelog.rst:933
+#: ../../changelog.rst:940
 msgid "2.77.3     (2022-03-18)"
 msgstr ""
 
-#: ../../changelog.rst:937
+#: ../../changelog.rst:944
 msgid "Add `only_filters` filter api v2 for labels (#3002)"
 msgstr ""
 
-#: ../../changelog.rst:938
+#: ../../changelog.rst:945
 msgid ""
 "Add filter labels_exclude for api v2 allowing to exclude particular label"
 " on treks, sites"
 msgstr ""
 
-#: ../../changelog.rst:942
+#: ../../changelog.rst:949
 msgid "Fix parser biodiv didn't collect all sensitive areas (#2966)"
 msgstr ""
 
-#: ../../changelog.rst:943
+#: ../../changelog.rst:950
 msgid "Fix attachments external links (#3001)"
 msgstr ""
 
-#: ../../changelog.rst:947
+#: ../../changelog.rst:954
 msgid "Update to paperclip 2.4.1"
 msgstr ""
 
-#: ../../changelog.rst:951
+#: ../../changelog.rst:958
 msgid "2.77.2     (2022-03-15)"
 msgstr ""
 
-#: ../../changelog.rst:955
+#: ../../changelog.rst:962
 msgid "Fix migration 2.77.1 publication"
 msgstr ""
 
-#: ../../changelog.rst:959
+#: ../../changelog.rst:966
 msgid "Add publication informations by lang on infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:960
+#: ../../changelog.rst:967
 msgid "Remove table Infrastructure on infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:961
+#: ../../changelog.rst:968
 msgid "Fix Intervention detail page breaks when target is a Report"
 msgstr ""
 
-#: ../../changelog.rst:962
+#: ../../changelog.rst:969
 msgid "Add translation signage"
 msgstr ""
 
-#: ../../changelog.rst:966
+#: ../../changelog.rst:973
 msgid "2.77.1     (2022-03-11)"
 msgstr ""
 
-#: ../../changelog.rst:970
+#: ../../changelog.rst:977
 msgid "Show all infrastructures and signages on interventions (#2851)"
 msgstr ""
 
-#: ../../changelog.rst:974
+#: ../../changelog.rst:981
 msgid "Show trail and path on intervention (#2851)"
 msgstr ""
 
-#: ../../changelog.rst:975
+#: ../../changelog.rst:982
 msgid "Remove duplicate id POI export (#2893)"
 msgstr ""
 
-#: ../../changelog.rst:976
+#: ../../changelog.rst:983
 msgid "Fix migration 2.77.0 publication"
 msgstr ""
 
-#: ../../changelog.rst:980
+#: ../../changelog.rst:987
 msgid "2.77.0     (2022-03-09)"
 msgstr ""
 
-#: ../../changelog.rst:986
+#: ../../changelog.rst:993
 msgid "Add filter label sites outdoor api v2"
 msgstr ""
 
-#: ../../changelog.rst:987
+#: ../../changelog.rst:994
 msgid "Add accessibility field on Infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:991
+#: ../../changelog.rst:998
 msgid "Add ratings_description field in export (#2755)"
 msgstr ""
 
-#: ../../changelog.rst:995
+#: ../../changelog.rst:1002
 msgid ""
 "Remove width and height in SVG generating problems in Geotrek-rando V3 by"
 " Camille Monchicourt"
 msgstr ""
 
-#: ../../changelog.rst:996
+#: ../../changelog.rst:1003
 msgid "Fix labels filter api v2 (#2764)"
 msgstr ""
 
-#: ../../changelog.rst:997
+#: ../../changelog.rst:1004
 msgid "Fix linebreaks template detail"
 msgstr ""
 
-#: ../../changelog.rst:1001
+#: ../../changelog.rst:1008
 msgid "Update to mapentity 7.1.3"
 msgstr ""
 
-#: ../../changelog.rst:1005
+#: ../../changelog.rst:1012
 msgid "2.76.4     (2022-03-07)"
 msgstr ""
 
-#: ../../changelog.rst:1009
+#: ../../changelog.rst:1016
 msgid "Move fields in forms and details (#2755)"
 msgstr ""
 
-#: ../../changelog.rst:1010
+#: ../../changelog.rst:1017
 msgid "Add information rating scale in csv for treks (#2755)"
 msgstr ""
 
-#: ../../changelog.rst:1014
+#: ../../changelog.rst:1021
 msgid "2.76.3     (2022-02-09)"
 msgstr ""
 
-#: ../../changelog.rst:1018
+#: ../../changelog.rst:1025
 msgid "Fix documentation trek with gear and not equipments"
 msgstr ""
 
-#: ../../changelog.rst:1022
+#: ../../changelog.rst:1029
 msgid "Fix css caption detail"
 msgstr ""
 
-#: ../../changelog.rst:1023
+#: ../../changelog.rst:1030
 msgid "Fix ACCESSIBILITY_ATTACHMENTS_ENABLED setting work as intended"
 msgstr ""
 
-#: ../../changelog.rst:1024
+#: ../../changelog.rst:1031
 msgid "Fix attachment translations"
 msgstr ""
 
-#: ../../changelog.rst:1025
+#: ../../changelog.rst:1032
 msgid ""
 "Facilitate the comprehension of the difference between fields "
 "label_accessibility and approved in touristic content detail"
 msgstr ""
 
-#: ../../changelog.rst:1026
+#: ../../changelog.rst:1033
 msgid "Fix migration translations equipment and disabled_infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:1030
+#: ../../changelog.rst:1037
 msgid "2.76.2     (2022-02-08)"
 msgstr ""
 
-#: ../../changelog.rst:1036
+#: ../../changelog.rst:1043
 msgid "Remove multiple choice ratings by rating scale for treks"
 msgstr ""
 
-#: ../../changelog.rst:1037
+#: ../../changelog.rst:1044
 msgid ""
 "Fix translations equipment and disabled_infrastructure are recovered for "
 "gear and accessibility_infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:1041
+#: ../../changelog.rst:1048
 msgid "2.76.1     (2022-02-07)"
 msgstr ""
 
-#: ../../changelog.rst:1045
+#: ../../changelog.rst:1052
 msgid ""
 "Add ACCESSIBILITY_ATTACHMENTS_ENABLED setting allowing to disable/enable "
 "menu attachments for accessibility"
 msgstr ""
 
-#: ../../changelog.rst:1046
+#: ../../changelog.rst:1053
 msgid "Add accessibility field on sites (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1047
+#: ../../changelog.rst:1054
 msgid ""
 "Change field disabled_infrastructure for accessibility_infrastructure "
 "(#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1051
+#: ../../changelog.rst:1058
 msgid "Text pasted in rich text fields (TinyMCE) are now cleaned up."
 msgstr ""
 
-#: ../../changelog.rst:1052
+#: ../../changelog.rst:1059
 msgid ""
 "Facilitate the comprehension of the difference between fields "
 "label_accessibility and approved in tourism (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1053
+#: ../../changelog.rst:1060
 msgid "Move trek DEM serialization to APIv2 (for 3D view)"
 msgstr ""
 
-#: ../../changelog.rst:1054
+#: ../../changelog.rst:1061
 msgid "Move trek altimetry profile serialization to APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1055
+#: ../../changelog.rst:1062
 msgid "Change fixture rating trekking"
 msgstr ""
 
-#: ../../changelog.rst:1056
+#: ../../changelog.rst:1063
 msgid "Move gear field form and detail (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1060
+#: ../../changelog.rst:1067
 msgid "Fix DEM cache does not invalidate on trek update"
 msgstr ""
 
-#: ../../changelog.rst:1064
+#: ../../changelog.rst:1071
 msgid "Fix translation equipment api v2 courses"
 msgstr ""
 
-#: ../../changelog.rst:1068
+#: ../../changelog.rst:1075
 msgid "2.76.0     (2022-02-02)"
 msgstr ""
 
-#: ../../changelog.rst:1072
+#: ../../changelog.rst:1079
 msgid "Add ratings, rating scales fields on trekking (#2755)"
 msgstr ""
 
-#: ../../changelog.rst:1073
+#: ../../changelog.rst:1080
 msgid "Add equipments field on trekking (#2845)"
 msgstr ""
 
-#: ../../changelog.rst:1074
+#: ../../changelog.rst:1081
 msgid "Add filters altimetry on all apps"
 msgstr ""
 
-#: ../../changelog.rst:1075
+#: ../../changelog.rst:1082
 msgid "Add accessibility attachments on trekking (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1076
+#: ../../changelog.rst:1083
 msgid "Add accessibility field on courses (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1077
+#: ../../changelog.rst:1084
 msgid "Add accessibility field on touristic content (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1078
+#: ../../changelog.rst:1085
 msgid "Add accessibility field on information desks (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1079
+#: ../../changelog.rst:1086
 msgid ""
 "Add label accessibility field on touristic content and informations desks"
 " (#2838)"
 msgstr ""
 
-#: ../../changelog.rst:1080
+#: ../../changelog.rst:1087
 msgid "Add information desk type api v2"
 msgstr ""
 
-#: ../../changelog.rst:1084
+#: ../../changelog.rst:1091
 msgid "Add translations NL, ES, DE, IT, EN for all apps"
 msgstr ""
 
-#: ../../changelog.rst:1085
+#: ../../changelog.rst:1092
 msgid "Change admin translations fields, add tab (#2892)"
 msgstr ""
 
-#: ../../changelog.rst:1086
+#: ../../changelog.rst:1093
 msgid "All rich text fields are updated according new TinyMCE theme."
 msgstr ""
 
-#: ../../changelog.rst:1087
+#: ../../changelog.rst:1094
 msgid "Improve API v2 POI serializer to include type labels and pictograms"
 msgstr ""
 
-#: ../../changelog.rst:1091
+#: ../../changelog.rst:1098
 msgid "Update to mapentity 7.1.0"
 msgstr ""
 
-#: ../../changelog.rst:1092
+#: ../../changelog.rst:1099
 msgid "Update to django-tinymce 3.4.0 and TinyMCE 5.10.1"
 msgstr ""
 
-#: ../../changelog.rst:1096
+#: ../../changelog.rst:1103
 msgid "Fix missing trademark (#2921)"
 msgstr ""
 
-#: ../../changelog.rst:1097
+#: ../../changelog.rst:1104
 msgid "Fix bootstrap theme in warning and error messages or alerts (#2872)"
 msgstr ""
 
-#: ../../changelog.rst:1098
+#: ../../changelog.rst:1105
 msgid "Fix search in infrastructure admin panels (#2924)"
 msgstr ""
 
-#: ../../changelog.rst:1099
+#: ../../changelog.rst:1106
 msgid ""
 "Fix APIv2 nearby content filter throws exceptions when queried for "
 "missing data (#2926)"
 msgstr ""
 
-#: ../../changelog.rst:1100
+#: ../../changelog.rst:1107
 msgid "Prevent exceptions when parsers receive integers instead of strings"
 msgstr ""
 
-#: ../../changelog.rst:1104
+#: ../../changelog.rst:1111
 msgid ""
 "Add missing indexes on geometry fields (WARNING, if you add indexes "
 "manually you should delete them before applying migrations) (#2933)"
 msgstr ""
 
-#: ../../changelog.rst:1108
+#: ../../changelog.rst:1115
 msgid "2.75.0     (2022-01-07)"
 msgstr ""
 
-#: ../../changelog.rst:1110
+#: ../../changelog.rst:1117
 msgid "**Tools**"
 msgstr ""
 
-#: ../../changelog.rst:1112
+#: ../../changelog.rst:1119
 msgid "Update check_ign_key tool"
 msgstr ""
 
-#: ../../changelog.rst:1116
+#: ../../changelog.rst:1123
 msgid "Add new group external authent `EDITOR_TREKKING_MANAGEMENT` (#2842)"
 msgstr ""
 
-#: ../../changelog.rst:1120
+#: ../../changelog.rst:1127
 msgid "Fix bootstrap theme in warning and error messages or alerts"
 msgstr ""
 
-#: ../../changelog.rst:1121
+#: ../../changelog.rst:1128
 msgid "Fix Services external IDs were not displayed in detail pages"
 msgstr ""
 
-#: ../../changelog.rst:1122
+#: ../../changelog.rst:1129
 msgid "Fix interventions filtering on zonings (#2766)"
 msgstr ""
 
-#: ../../changelog.rst:1123
+#: ../../changelog.rst:1130
 msgid ""
 "Fix interventions shapefiles with `ENABLE_JOBS_COSTS_DETAILED_EXPORT` "
 "setting (#1798)"
 msgstr ""
 
-#: ../../changelog.rst:1124
+#: ../../changelog.rst:1131
 msgid "Fix projects on interventions with GeometryCollection's geometry"
 msgstr ""
 
-#: ../../changelog.rst:1125
+#: ../../changelog.rst:1132
 msgid "Fix parser when DatabaseError occurs"
 msgstr ""
 
-#: ../../changelog.rst:1126
+#: ../../changelog.rst:1133
 msgid ""
 "Add customization columns `COLUMNS_LISTS` on every models listed in "
 "documentation (#2688)"
 msgstr ""
 
-#: ../../changelog.rst:1130
+#: ../../changelog.rst:1137
 msgid ""
 "Add filtering portals sync_mobile for touristic contents and events "
 "(#1941)"
 msgstr ""
 
-#: ../../changelog.rst:1134
+#: ../../changelog.rst:1141
 msgid "Update to mapentity 7.0.6"
 msgstr ""
 
-#: ../../changelog.rst:1138
+#: ../../changelog.rst:1145
 msgid "2.74.1     (2021-12-21)"
 msgstr ""
 
-#: ../../changelog.rst:1142
+#: ../../changelog.rst:1149
 msgid "Fix blank line due to mapentity template error"
 msgstr ""
 
-#: ../../changelog.rst:1146
+#: ../../changelog.rst:1153
 msgid "Update to mapentity 7.0.5"
 msgstr ""
 
-#: ../../changelog.rst:1150
+#: ../../changelog.rst:1157
 msgid "2.74.0     (2021-12-17)"
 msgstr ""
 
-#: ../../changelog.rst:1154
+#: ../../changelog.rst:1161
 msgid "Show every paths in intervention csv (#2711)"
 msgstr ""
 
-#: ../../changelog.rst:1155
+#: ../../changelog.rst:1162
 msgid ""
 "Hide signage/blade dropdown-toggle with settings ``BLADE_ENABLED=False`` "
 "(#2852)"
 msgstr ""
 
-#: ../../changelog.rst:1156
+#: ../../changelog.rst:1163
 msgid "Remove urls blade with settings ``BLADE_ENABLED=False`` (#2852)"
 msgstr ""
 
-#: ../../changelog.rst:1160
+#: ../../changelog.rst:1167
 msgid "Fix multiple forms in formsets deletion (#2693)"
 msgstr ""
 
-#: ../../changelog.rst:1161
+#: ../../changelog.rst:1168
 msgid "Fix access to pictures generated with watermark (#2840)"
 msgstr ""
 
-#: ../../changelog.rst:1162
+#: ../../changelog.rst:1169
 msgid ""
 "Fix intervention creation and update is now scrollable after merging tabs"
 " (#2712)"
 msgstr ""
 
-#: ../../changelog.rst:1163
+#: ../../changelog.rst:1170
 msgid ""
 "Fix restricted area and restricted area type filters on intervention "
 "(#2766)"
 msgstr ""
 
-#: ../../changelog.rst:1167
+#: ../../changelog.rst:1174
 msgid ""
 "Allow to filter Cirkwi ``circuits.xml`` and ``pois.xml`` API with portals"
 " and structures (#2822)"
 msgstr ""
 
-#: ../../changelog.rst:1168
+#: ../../changelog.rst:1175
 msgid "Add restricted area and restricted area type filters on projects (#2766)"
 msgstr ""
 
-#: ../../changelog.rst:1169
+#: ../../changelog.rst:1176
 msgid "Add ``reservation_id`` in ``/trek`` API v2 (#2817)"
 msgstr ""
 
-#: ../../changelog.rst:1173
+#: ../../changelog.rst:1180
 msgid "2.73.0 (2021-12-13)"
 msgstr ""
 
-#: ../../changelog.rst:1177
+#: ../../changelog.rst:1184
 msgid "Fix formset item deletion raises error in forms (#2693)"
 msgstr ""
 
-#: ../../changelog.rst:1179 ../../changelog.rst:1764
+#: ../../changelog.rst:1186 ../../changelog.rst:1771
 msgid "**Refactoring**"
 msgstr ""
 
-#: ../../changelog.rst:1181
+#: ../../changelog.rst:1188
 msgid ""
 "MapEntity is now a separate dependency (https://github.com/makinacorpus"
 "/django-mapentity)"
 msgstr ""
 
-#: ../../changelog.rst:1185
+#: ../../changelog.rst:1192
 msgid "Optimize Path caching in edition views (#2847)"
 msgstr ""
 
-#: ../../changelog.rst:1186
+#: ../../changelog.rst:1193
 msgid ""
 "Filter list views by Restricted Area as well as by Restricted Area Type "
 "(#2766)"
 msgstr ""
 
-#: ../../changelog.rst:1187
+#: ../../changelog.rst:1194
 msgid ""
 "Add ``BLADE_ENABLED`` setting to hide Blade in Signage forms and in "
 "Signage detail page (#2852)"
 msgstr ""
 
-#: ../../changelog.rst:1188
+#: ../../changelog.rst:1195
 msgid ""
 "Add ``LINE_ENABLED`` setting to hide Line in Blade forms and in Blade "
 "detail page (#2852)"
 msgstr ""
 
-#: ../../changelog.rst:1189
+#: ../../changelog.rst:1196
 msgid ""
 "Add ``PAPERCLIP_RESIZE_ATTACHMENTS_ON_UPLOAD`` setting to enable resize "
 "attachments on upload (#2835)"
 msgstr ""
 
-#: ../../changelog.rst:1190
+#: ../../changelog.rst:1197
 msgid ""
 "Add ``PAPERCLIP_MAX_ATTACHMENT_WIDTH`` and "
 "``PAPERCLIP_MAX_ATTACHMENT_HEIGHT`` to configure attachment resizing "
 "(defaults 1280px) (#2835)"
 msgstr ""
 
-#: ../../changelog.rst:1191
+#: ../../changelog.rst:1198
 msgid ""
 "Use ``MAPENTITY_CONFIG`` setting to configure map style on list and "
 "detail views (#2554)"
 msgstr ""
 
-#: ../../changelog.rst:1193
+#: ../../changelog.rst:1200
 msgid "**User interface**"
 msgstr ""
 
-#: ../../changelog.rst:1195
+#: ../../changelog.rst:1202
 msgid "Clarify Land Edge module browsing (#1404)"
 msgstr ""
 
-#: ../../changelog.rst:1196
+#: ../../changelog.rst:1203
 msgid ""
 "Renamed \"Tronçons physique\" to \"Types de voie\", \"Tronçons de "
 "compétence\" to \"Compétence sentiers\", \"Tronçons de gestion de "
@@ -2547,82 +2558,82 @@ msgid ""
 "signalétique\" to \"Gestionnaire signalétique\" (#1301)"
 msgstr ""
 
-#: ../../changelog.rst:1198
+#: ../../changelog.rst:1205
 msgid "Renamed \"zonage réglementaire\" to \"zonage\" (#2766)"
 msgstr ""
 
-#: ../../changelog.rst:1202
+#: ../../changelog.rst:1209
 msgid "Merge tabs in Intervention forms (#2712)"
 msgstr ""
 
-#: ../../changelog.rst:1203
+#: ../../changelog.rst:1210
 msgid "Make targets display more specific in Interventions exports (#2711)"
 msgstr ""
 
-#: ../../changelog.rst:1204
+#: ../../changelog.rst:1211
 msgid "Improve support for Tourinsoft v3 with new medias management"
 msgstr ""
 
-#: ../../changelog.rst:1206
+#: ../../changelog.rst:1213
 msgid "**Bug fix**"
 msgstr ""
 
-#: ../../changelog.rst:1208
+#: ../../changelog.rst:1215
 msgid ""
 "Fix TopologyException when filtering objects by several "
 "RestrictedAreaTypes"
 msgstr ""
 
-#: ../../changelog.rst:1212
+#: ../../changelog.rst:1219
 msgid "2.72.0 (2021-11-16)"
 msgstr ""
 
-#: ../../changelog.rst:1216
+#: ../../changelog.rst:1223
 msgid "APIv2 : Add ``attachment`` field to Touristic Event serialization"
 msgstr ""
 
-#: ../../changelog.rst:1220
+#: ../../changelog.rst:1227
 msgid ""
 "Add possibility to fill ``code`` field in Signage model when using "
 "``loadsignage`` command. Two parameters added : ``code_field`` and "
 "``code_default``"
 msgstr ""
 
-#: ../../changelog.rst:1224
+#: ../../changelog.rst:1231
 msgid ""
 "Prevent Signages and Infrastructures from being displayed on PDFs when "
 "unpublished"
 msgstr ""
 
-#: ../../changelog.rst:1225
+#: ../../changelog.rst:1232
 msgid ""
 "Database: fix SQL cleanup that delete foreign key on "
 "``core_pathaggregation.path_id`` -> ``core_path.id`` (#2819)"
 msgstr ""
 
-#: ../../changelog.rst:1226
+#: ../../changelog.rst:1233
 msgid "Fix generation altimetry profile (``dem.json``)"
 msgstr ""
 
-#: ../../changelog.rst:1230
+#: ../../changelog.rst:1237
 msgid "2.71.0 (2021-11-03)"
 msgstr ""
 
-#: ../../changelog.rst:1234
+#: ../../changelog.rst:1241
 msgid "APIv2 : Add filter by portal on outdoor practices and ratings"
 msgstr ""
 
-#: ../../changelog.rst:1238
+#: ../../changelog.rst:1245
 msgid ""
 "APIv2 : Fix exceptions on filter by portals or themes in Outdoor Course "
 "route"
 msgstr ""
 
-#: ../../changelog.rst:1242
+#: ../../changelog.rst:1249
 msgid "2.70.0 (2021-11-02)"
 msgstr ""
 
-#: ../../changelog.rst:1246
+#: ../../changelog.rst:1253
 msgid ""
 "Add UUIDS to the following objects, and to APIv2 serialization for those "
 "included : Path, TouristicContent, TouristicEvent, Outdoor Site, Outdoor "
@@ -2630,475 +2641,475 @@ msgid ""
 " Signage, Infrastructure, PhysicalEdge, CompetenceEdge, LandEdge)"
 msgstr ""
 
-#: ../../changelog.rst:1248
+#: ../../changelog.rst:1255
 msgid "APIv2 : Add pictograms to outdoor practice routes"
 msgstr ""
 
-#: ../../changelog.rst:1249
+#: ../../changelog.rst:1256
 msgid "APIv2 : Add cities to outdoor sites and outdoor courses routes"
 msgstr ""
 
-#: ../../changelog.rst:1250
+#: ../../changelog.rst:1257
 msgid ""
 "APIv2 : Add filter by themes, cities, districts, types, and structures to"
 " outdoor sites and outdoor courses routes"
 msgstr ""
 
-#: ../../changelog.rst:1251
+#: ../../changelog.rst:1258
 msgid ""
 "APIv2 : Change Web Links serialization on outdoor sites routes, to "
 "detailed instead of just an id"
 msgstr ""
 
-#: ../../changelog.rst:1255
+#: ../../changelog.rst:1262
 msgid "Geotrek-admin now needs PostgreSQL extension 'pgrypto'."
 msgstr ""
 
-#: ../../changelog.rst:1259
+#: ../../changelog.rst:1266
 msgid ""
 "**Before** upgrading to this version make sure to run ``CREATE EXTENSION "
 "IF NOT EXISTS \"pgcrypto\";``  from ``postgres`` user in database."
 msgstr ""
 
-#: ../../changelog.rst:1261
+#: ../../changelog.rst:1268
 msgid ""
 "``su postgres -c \"psql -q -d $POSTGRES_DB -c 'CREATE EXTENSION "
 "pgcrypto;'\"``"
 msgstr ""
 
-#: ../../changelog.rst:1265
+#: ../../changelog.rst:1272
 msgid "2.69.0 (2021-10-22)"
 msgstr ""
 
-#: ../../changelog.rst:1269
+#: ../../changelog.rst:1276
 msgid "Add public PDFs to Outdoor Course and Outdoor Site, with templates"
 msgstr ""
 
-#: ../../changelog.rst:1273
+#: ../../changelog.rst:1280
 msgid "2.68.1 (2021-10-21)"
 msgstr ""
 
-#: ../../changelog.rst:1277
+#: ../../changelog.rst:1284
 msgid "Fix error 404 on CSS from 2.68.0"
 msgstr ""
 
-#: ../../changelog.rst:1281
+#: ../../changelog.rst:1288
 msgid "2.68.0 (2021-10-20)"
 msgstr ""
 
-#: ../../changelog.rst:1287
+#: ../../changelog.rst:1294
 msgid "Link an Outdoor Course to multiple parent Sites instead of one"
 msgstr ""
 
-#: ../../changelog.rst:1288
+#: ../../changelog.rst:1295
 msgid ""
 "Added notion of points of reference for Outdoor Courses. (Can be disabled"
 " with ``OUTDOOR_COURSE_POINTS_OF_REFERENCE_ENABLED = False``)"
 msgstr ""
 
-#: ../../changelog.rst:1290
+#: ../../changelog.rst:1297
 msgid "**Breaking change**"
 msgstr ""
 
-#: ../../changelog.rst:1292
+#: ../../changelog.rst:1299
 msgid "APIv2 serialisation for Courses now exposes ``sites`` instead of ``site``"
 msgstr ""
 
-#: ../../changelog.rst:1296
+#: ../../changelog.rst:1303
 msgid "Fix translations for Site and Course filters in Interventions list view"
 msgstr ""
 
-#: ../../changelog.rst:1297
+#: ../../changelog.rst:1304
 msgid ""
 "Fix bug that auto-confirms the modal when launching a synchronization "
 "(bug introduced with bootstrap migration)"
 msgstr ""
 
-#: ../../changelog.rst:1299 ../../changelog.rst:1313 ../../changelog.rst:1345
-#: ../../changelog.rst:1480
+#: ../../changelog.rst:1306 ../../changelog.rst:1320 ../../changelog.rst:1352
+#: ../../changelog.rst:1487
 msgid "**User Interface**"
 msgstr ""
 
-#: ../../changelog.rst:1301
+#: ../../changelog.rst:1308
 msgid "Display children Sites above parent Sites in Outdoor Sites list view"
 msgstr ""
 
-#: ../../changelog.rst:1305
+#: ../../changelog.rst:1312
 msgid "2.67.0 (2021-10-12)"
 msgstr ""
 
-#: ../../changelog.rst:1309
+#: ../../changelog.rst:1316
 msgid "APIv2 : Add 'children' and 'parent' fields to Outdoor Site serialization"
 msgstr ""
 
-#: ../../changelog.rst:1310
+#: ../../changelog.rst:1317
 msgid "APIv2 : Add filter by pratices on outdoor courses"
 msgstr ""
 
-#: ../../changelog.rst:1311
+#: ../../changelog.rst:1318
 msgid ""
 "Filter interventions by Outdoor model targets in Intervention module's "
 "list view"
 msgstr ""
 
-#: ../../changelog.rst:1315
+#: ../../changelog.rst:1322
 msgid "Distinguish Sites from Courses in Outdoor tree display thanks to bullets"
 msgstr ""
 
-#: ../../changelog.rst:1316
+#: ../../changelog.rst:1323
 msgid "Display full Sites hierarchy in Outdoor detail views"
 msgstr ""
 
-#: ../../changelog.rst:1320
+#: ../../changelog.rst:1327
 msgid "Fix nearby Courses and nearby Sites display in Outdoor detail pages"
 msgstr ""
 
-#: ../../changelog.rst:1321
+#: ../../changelog.rst:1328
 msgid "Fix Outdoor migrations fail on empty database"
 msgstr ""
 
-#: ../../changelog.rst:1322
+#: ../../changelog.rst:1329
 msgid "Fix sync_mobile does not check for published or unpublished treks"
 msgstr ""
 
-#: ../../changelog.rst:1326
+#: ../../changelog.rst:1333
 msgid "2.66.0 (2021-09-27)"
 msgstr ""
 
-#: ../../changelog.rst:1330
+#: ../../changelog.rst:1337
 msgid "APIv2 : Add filter by ratings on outdoor courses and sites"
 msgstr ""
 
-#: ../../changelog.rst:1331
+#: ../../changelog.rst:1338
 msgid "APIv2 : Add filter by pratices in hierarchy on outdoor courses and sites"
 msgstr ""
 
-#: ../../changelog.rst:1332
+#: ../../changelog.rst:1339
 msgid "APIv2 : Add filter by ratings in hierarchy on outdoor courses and sites"
 msgstr ""
 
-#: ../../changelog.rst:1333
+#: ../../changelog.rst:1340
 msgid "Display children sites' ratings in site page"
 msgstr ""
 
-#: ../../changelog.rst:1334
+#: ../../changelog.rst:1341
 msgid "APIv2 : Add 'sector' and 'attachment' fields to Outdoor Site serialization"
 msgstr ""
 
-#: ../../changelog.rst:1335
+#: ../../changelog.rst:1342
 msgid ""
 "Add DISPLAY_COORDS_AS_DECIMALS setting to format coordinates as decimal "
 "degrees instead of degrees minutes seconds"
 msgstr ""
 
-#: ../../changelog.rst:1336
+#: ../../changelog.rst:1343
 msgid "Enable translations on 'equipment' field on Outdoor Course"
 msgstr ""
 
-#: ../../changelog.rst:1341
+#: ../../changelog.rst:1348
 msgid ""
 "Fix dynamic forms on outdoor cotations display all cotations when "
 "selector empty"
 msgstr ""
 
-#: ../../changelog.rst:1342
+#: ../../changelog.rst:1349
 msgid "Hide excluded POIs on Outdoor Site and Course detail pages"
 msgstr ""
 
-#: ../../changelog.rst:1347
+#: ../../changelog.rst:1354
 msgid "Sort sites by alphabetical order in outdoor course forms"
 msgstr ""
 
-#: ../../changelog.rst:1351
+#: ../../changelog.rst:1358
 msgid "2.65.0 (2021-09-21)"
 msgstr ""
 
-#: ../../changelog.rst:1355
+#: ../../changelog.rst:1362
 msgid ""
 "APIv2 : Add filter on Outdoor Site route to only retrieve root sites from"
 " hierarchy"
 msgstr ""
 
-#: ../../changelog.rst:1356
+#: ../../changelog.rst:1363
 msgid ""
 "Add fields 'duration', 'type', 'gear', 'ratings_description' to Outdoor "
 "Course"
 msgstr ""
 
-#: ../../changelog.rst:1357
+#: ../../changelog.rst:1364
 msgid ""
 "Add fields on APIv2 for Course model : 'min_elevation', 'max_elevation', "
 "'children', 'parents', 'attachments'"
 msgstr ""
 
-#: ../../changelog.rst:1358
+#: ../../changelog.rst:1365
 msgid "Add excluded_pois on Course and Site models."
 msgstr ""
 
-#: ../../changelog.rst:1359
+#: ../../changelog.rst:1366
 msgid ""
 "Add filter on APIVv2 POI endpoint to retrieve pois related to Course or "
 "Site"
 msgstr ""
 
-#: ../../changelog.rst:1360
+#: ../../changelog.rst:1367
 msgid "Replace Outdoor Site 'ratings_min' and 'ratings_max' fields with 'ratings'"
 msgstr ""
 
-#: ../../changelog.rst:1361
+#: ../../changelog.rst:1368
 msgid ""
 "Make Outdoor Site and Course 'ratings' form fields dynamically change on "
 "practice selection"
 msgstr ""
 
-#: ../../changelog.rst:1362
+#: ../../changelog.rst:1369
 msgid "APIv2 : Add children courses to sites' serialization"
 msgstr ""
 
-#: ../../changelog.rst:1363
+#: ../../changelog.rst:1370
 msgid "Add Course Type management to admin site"
 msgstr ""
 
-#: ../../changelog.rst:1367
+#: ../../changelog.rst:1374
 msgid "2.64.0 (2021-09-14)"
 msgstr ""
 
-#: ../../changelog.rst:1371
+#: ../../changelog.rst:1378
 msgid "Add endpoints for infrastructure and related types in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1372
+#: ../../changelog.rst:1379
 msgid "Add endpoints for signage and related types in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1373
+#: ../../changelog.rst:1380
 msgid "Filter TouristicContentTypes according to published content in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1377
+#: ../../changelog.rst:1384
 msgid "Fix missing translations for infrastructure difficulty levels in admin"
 msgstr ""
 
-#: ../../changelog.rst:1378
+#: ../../changelog.rst:1385
 msgid "Fix impossible import of uninstalled module 'sensitivity' in 'dive'"
 msgstr ""
 
-#: ../../changelog.rst:1382
+#: ../../changelog.rst:1389
 msgid "2.63.0 (2021-09-03)"
 msgstr ""
 
-#: ../../changelog.rst:1386
+#: ../../changelog.rst:1393
 msgid "Add difficulty level fields (usage and maintenance) to infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:1387
+#: ../../changelog.rst:1394
 msgid "Add 'active' field to job model, and hide inactive jobs in forms"
 msgstr ""
 
-#: ../../changelog.rst:1388
+#: ../../changelog.rst:1395
 msgid ""
 "Add detailed jobs costs to interventions exports, with a new column for "
 "each job"
 msgstr ""
 
-#: ../../changelog.rst:1389
+#: ../../changelog.rst:1396
 msgid "Add SURICATE_MANAGEMENT_ENABLED setting"
 msgstr ""
 
-#: ../../changelog.rst:1390
+#: ../../changelog.rst:1397
 msgid "Add SURICATE_MANAGEMENT_SETTINGS setting to configure second Suricate API"
 msgstr ""
 
-#: ../../changelog.rst:1391
+#: ../../changelog.rst:1398
 msgid "Add helper to make requests to Suricate"
 msgstr ""
 
-#: ../../changelog.rst:1392
+#: ../../changelog.rst:1399
 msgid ""
 "Add parser to retrieve statuses, activities, and reports (in bounding "
 "box) from Suricate"
 msgstr ""
 
-#: ../../changelog.rst:1393
+#: ../../changelog.rst:1400
 msgid "Add sync_suricate command to retrieve Suricate data"
 msgstr ""
 
-#: ../../changelog.rst:1394
+#: ../../changelog.rst:1401
 msgid ""
 "Change Report model to use one of 3 modes : No Suricate, Suricate Report "
 "or Suricate Management (SURICATE_REPORT_ENABLED and "
 "SURICATE_MANAGEMENT_ENABLED settings)"
 msgstr ""
 
-#: ../../changelog.rst:1395
+#: ../../changelog.rst:1402
 msgid "Generalize existing filters in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1396
+#: ../../changelog.rst:1403
 msgid "Add 'near_outdoorsite' and 'near_outdoorcourse' filters in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1397
+#: ../../changelog.rst:1404
 msgid ""
 "Add 'created_before', 'updated_before', 'created_after' and "
 "'updated_after' filters in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1398
+#: ../../changelog.rst:1405
 msgid "Add route to APIv2 to retrieve Geotrek version"
 msgstr ""
 
-#: ../../changelog.rst:1399
+#: ../../changelog.rst:1406
 msgid ""
 "Add API_V2_DESCRIPTION setting to change description text in API v2 "
 "Swagger page"
 msgstr ""
 
-#: ../../changelog.rst:1400
+#: ../../changelog.rst:1407
 msgid "Add endpoints for services in APIv2 : service, service type"
 msgstr ""
 
-#: ../../changelog.rst:1401
+#: ../../changelog.rst:1408
 msgid "Add link between reports and interventions"
 msgstr ""
 
-#: ../../changelog.rst:1406
+#: ../../changelog.rst:1413
 msgid "Fix length_kilometer attribute computation in treks"
 msgstr ""
 
-#: ../../changelog.rst:1407
+#: ../../changelog.rst:1414
 msgid "Fix date update format in lists"
 msgstr ""
 
-#: ../../changelog.rst:1408
+#: ../../changelog.rst:1415
 msgid "Add CORS header to access medias"
 msgstr ""
 
-#: ../../changelog.rst:1409
+#: ../../changelog.rst:1416
 msgid ""
 "Change geographic intersection calculation from annoted queries to "
 "optimized build-in method"
 msgstr ""
 
-#: ../../changelog.rst:1413
+#: ../../changelog.rst:1420
 msgid "2.62.0 (2021-07-06)"
 msgstr ""
 
-#: ../../changelog.rst:1417
+#: ../../changelog.rst:1424
 msgid "Add custom columns configuration to list views"
 msgstr ""
 
-#: ../../changelog.rst:1418
+#: ../../changelog.rst:1425
 msgid "Add custom columns configuration to list CSV exports"
 msgstr ""
 
-#: ../../changelog.rst:1419
+#: ../../changelog.rst:1426
 msgid "Add custom form fields configuration to creation views"
 msgstr ""
 
-#: ../../changelog.rst:1423
+#: ../../changelog.rst:1430
 msgid "Fix filter difficulty in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1427
+#: ../../changelog.rst:1434
 msgid "2.61.1 (2021-06-28)"
 msgstr ""
 
-#: ../../changelog.rst:1431
+#: ../../changelog.rst:1438
 msgid "Fix filter in_bbox in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1435
+#: ../../changelog.rst:1442
 msgid "2.61.0 (2021-06-25)"
 msgstr ""
 
-#: ../../changelog.rst:1439
+#: ../../changelog.rst:1446
 msgid "Add Web Links to Trek endpoints in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1440
+#: ../../changelog.rst:1447
 msgid "Add endpoints for Web Links categories in APIv2"
 msgstr ""
 
-#: ../../changelog.rst:1441
+#: ../../changelog.rst:1448
 msgid ""
 "Ensure APIv2 returns outdoor sites list and outdoor courses list as "
 "ordered by localized name"
 msgstr ""
 
-#: ../../changelog.rst:1445
+#: ../../changelog.rst:1452
 msgid "2.60.0 (2021-06-25)"
 msgstr ""
 
-#: ../../changelog.rst:1449
+#: ../../changelog.rst:1456
 msgid ""
 "Add endpoints for user feedback in APIv2 : report category, report "
 "activity, report problem magnitude, and report status"
 msgstr ""
 
-#: ../../changelog.rst:1450
+#: ../../changelog.rst:1457
 msgid ""
 "Ensure APIv2 returns treks list and touristic contents list as ordered by"
 " localized name"
 msgstr ""
 
-#: ../../changelog.rst:1454
+#: ../../changelog.rst:1461
 msgid "Fix confirm delete attachment modal not visible"
 msgstr ""
 
-#: ../../changelog.rst:1455
+#: ../../changelog.rst:1462
 msgid "Fix required '\\*geom' position"
 msgstr ""
 
-#: ../../changelog.rst:1456
+#: ../../changelog.rst:1463
 msgid "Fix scroll unwanted when list is full"
 msgstr ""
 
-#: ../../changelog.rst:1457
+#: ../../changelog.rst:1464
 msgid "Fix responsive on dataTables"
 msgstr ""
 
-#: ../../changelog.rst:1458
+#: ../../changelog.rst:1465
 msgid ""
 "Remove excluded POIs from results in POI endpoint on api v2 when "
 "filtering by trek id"
 msgstr ""
 
-#: ../../changelog.rst:1459
+#: ../../changelog.rst:1466
 msgid ""
 "Sort attachments listed in api v2 endpoints for Trek, TouristicContent, "
 "POI"
 msgstr ""
 
-#: ../../changelog.rst:1460
+#: ../../changelog.rst:1467
 msgid ""
 "Ensure content is displayed only when a related object is published on "
 "api v2"
 msgstr ""
 
-#: ../../changelog.rst:1461
+#: ../../changelog.rst:1468
 msgid "Exclude deleted content of portal filters in api v2"
 msgstr ""
 
-#: ../../changelog.rst:1465
+#: ../../changelog.rst:1472
 msgid "Update to paperclip 2.3.2"
 msgstr ""
 
-#: ../../changelog.rst:1469
+#: ../../changelog.rst:1476
 msgid "2.59.0 (2021-06-07)"
 msgstr ""
 
-#: ../../changelog.rst:1471
+#: ../../changelog.rst:1478
 msgid "**Breaking Change**"
 msgstr ""
 
-#: ../../changelog.rst:1473
+#: ../../changelog.rst:1480
 msgid ""
 "Template nginx.conf.in was changed to work with multiple rando portals "
 "(#2670)."
 msgstr ""
 
-#: ../../changelog.rst:1475
+#: ../../changelog.rst:1482
 msgid ""
 "First, if you changed file `/opt/geotrek-admin/var/conf/nginx.conf.in`, "
 "back it up somewhere. 1 - While installing, choose 'Y' to get the new "
@@ -3107,754 +3118,754 @@ msgid ""
 "customization."
 msgstr ""
 
-#: ../../changelog.rst:1482
+#: ../../changelog.rst:1489
 msgid "Important visual changes due to CSS framework upgrade"
 msgstr ""
 
-#: ../../changelog.rst:1483
+#: ../../changelog.rst:1490
 msgid "Improve responsive"
 msgstr ""
 
-#: ../../changelog.rst:1487
+#: ../../changelog.rst:1494
 msgid "Upgrade Bootstrap to 4.6"
 msgstr ""
 
-#: ../../changelog.rst:1488
+#: ../../changelog.rst:1495
 msgid "Upgrade JQuery to 1.9.1"
 msgstr ""
 
-#: ../../changelog.rst:1489
+#: ../../changelog.rst:1496
 msgid "Upgrade DataTables to 1.10.23"
 msgstr ""
 
-#: ../../changelog.rst:1490
+#: ../../changelog.rst:1497
 msgid "Upgrade Chosen to 1.2.0"
 msgstr ""
 
-#: ../../changelog.rst:1491
+#: ../../changelog.rst:1498
 msgid "Move to vendor folder updated JS Libraries used by Mapentity"
 msgstr ""
 
-#: ../../changelog.rst:1492
+#: ../../changelog.rst:1499
 msgid "Update HTML markup in many templates, and update tests too"
 msgstr ""
 
-#: ../../changelog.rst:1493
+#: ../../changelog.rst:1500
 msgid "Expired sessions stored in database are now deleted at each update"
 msgstr ""
 
-#: ../../changelog.rst:1497
+#: ../../changelog.rst:1504
 msgid ""
 "Fix gpx/kml are not generated on all languages (The first object was "
 "working)."
 msgstr ""
 
-#: ../../changelog.rst:1501
+#: ../../changelog.rst:1508
 msgid "2.58.0 (2021-05-20)"
 msgstr ""
 
-#: ../../changelog.rst:1505
+#: ../../changelog.rst:1512
 msgid "Add documentation ssl"
 msgstr ""
 
-#: ../../changelog.rst:1509
+#: ../../changelog.rst:1516
 msgid ""
 "Mobile API returns multiple pictures for objects like Treks and POIs. Can"
 " be configurated with MOBILE_NUMBER_PICTURES_SYNC setting."
 msgstr ""
 
-#: ../../changelog.rst:1510
+#: ../../changelog.rst:1517
 msgid "Add filter bad topologies and geoms"
 msgstr ""
 
-#: ../../changelog.rst:1514
+#: ../../changelog.rst:1521
 msgid "Fix DistanceToPointFilter usage in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1515
+#: ../../changelog.rst:1522
 msgid "Fix pdf/gpx/kml are not generated on all languages"
 msgstr ""
 
-#: ../../changelog.rst:1519
+#: ../../changelog.rst:1526
 msgid "2.57.0 (2021-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:1523
+#: ../../changelog.rst:1530
 msgid "Add managers field to outdoor sites"
 msgstr ""
 
-#: ../../changelog.rst:1527
+#: ../../changelog.rst:1534
 msgid "Fix projection of departure_geom in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1531
+#: ../../changelog.rst:1538
 msgid "2.56.0 (2021-04-27)"
 msgstr ""
 
-#: ../../changelog.rst:1535
+#: ../../changelog.rst:1542
 msgid "Fix API v2 crash when trek geom is a point"
 msgstr ""
 
-#: ../../changelog.rst:1539
+#: ../../changelog.rst:1546
 msgid "Add outdoor course endpoint to API v2"
 msgstr ""
 
-#: ../../changelog.rst:1540
+#: ../../changelog.rst:1547
 msgid "Add all fields to outdoor site/course exports (csv/gpx/shp)"
 msgstr ""
 
-#: ../../changelog.rst:1541
+#: ../../changelog.rst:1548
 msgid ""
 "Link outdoor sites and courses to other objects, especially POIs, "
 "infrastructures and interventions"
 msgstr ""
 
-#: ../../changelog.rst:1546
+#: ../../changelog.rst:1553
 msgid "Update database ULM schemas (with outdoor)"
 msgstr ""
 
-#: ../../changelog.rst:1547
+#: ../../changelog.rst:1554
 msgid "Update faq.rst"
 msgstr ""
 
-#: ../../changelog.rst:1548
+#: ../../changelog.rst:1555
 msgid "Proofreading"
 msgstr ""
 
-#: ../../changelog.rst:1552
+#: ../../changelog.rst:1559
 msgid "Update parser for Esprit Parc National data streams"
 msgstr ""
 
-#: ../../changelog.rst:1553
+#: ../../changelog.rst:1560
 msgid "Upgrade Weasyprint to 52.5"
 msgstr ""
 
-#: ../../changelog.rst:1554
+#: ../../changelog.rst:1561
 msgid "Use screamshotter >= 2.0.9 by default"
 msgstr ""
 
-#: ../../changelog.rst:1558
+#: ../../changelog.rst:1565
 msgid "Bump django-debug-toolbar from 3.1.1 to 3.2.1"
 msgstr ""
 
-#: ../../changelog.rst:1562
+#: ../../changelog.rst:1569
 msgid "2.55.1 (2021-04-15)"
 msgstr ""
 
-#: ../../changelog.rst:1566
+#: ../../changelog.rst:1573
 msgid "Add outdoor section to user manual"
 msgstr ""
 
-#: ../../changelog.rst:1570
+#: ../../changelog.rst:1577
 msgid "Fix themes not including published touristic contents/events in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1571
+#: ../../changelog.rst:1578
 msgid ""
 "Fix duplicate Access-Control-Allow-Origin header in sensitive areas API "
 "endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1572
+#: ../../changelog.rst:1579
 msgid "Fix orientation/wind labels in outdoor course filter"
 msgstr ""
 
-#: ../../changelog.rst:1573
+#: ../../changelog.rst:1580
 msgid "Hide \"Add a brother site\" link if no parent site"
 msgstr ""
 
-#: ../../changelog.rst:1574
+#: ../../changelog.rst:1581
 msgid "Filter outdoor site/course orientations with a OR instead of a AND"
 msgstr ""
 
-#: ../../changelog.rst:1575
+#: ../../changelog.rst:1582
 msgid "Reverse wind arrows"
 msgstr ""
 
-#: ../../changelog.rst:1579
+#: ../../changelog.rst:1586
 msgid "Use upstream appy dependency"
 msgstr ""
 
-#: ../../changelog.rst:1583
+#: ../../changelog.rst:1590
 msgid "2.55.0 (2021-04-09)"
 msgstr ""
 
-#: ../../changelog.rst:1585 ../../changelog.rst:1593 ../../changelog.rst:1612
-#: ../../changelog.rst:1641 ../../changelog.rst:1800 ../../changelog.rst:1833
-#: ../../changelog.rst:1863 ../../changelog.rst:1872 ../../changelog.rst:1903
-#: ../../changelog.rst:1938 ../../changelog.rst:2067 ../../changelog.rst:2091
-#: ../../changelog.rst:2122 ../../changelog.rst:2138 ../../changelog.rst:2154
-#: ../../changelog.rst:2166 ../../changelog.rst:2183 ../../changelog.rst:2200
-#: ../../changelog.rst:2220
+#: ../../changelog.rst:1592 ../../changelog.rst:1600 ../../changelog.rst:1619
+#: ../../changelog.rst:1648 ../../changelog.rst:1807 ../../changelog.rst:1840
+#: ../../changelog.rst:1870 ../../changelog.rst:1879 ../../changelog.rst:1910
+#: ../../changelog.rst:1945 ../../changelog.rst:2074 ../../changelog.rst:2098
+#: ../../changelog.rst:2129 ../../changelog.rst:2145 ../../changelog.rst:2161
+#: ../../changelog.rst:2173 ../../changelog.rst:2190 ../../changelog.rst:2207
+#: ../../changelog.rst:2227
 msgid "**New Feature**"
 msgstr ""
 
-#: ../../changelog.rst:1587
+#: ../../changelog.rst:1594
 msgid "Add /sensitivearea_species endpoint on api v2"
 msgstr ""
 
-#: ../../changelog.rst:1591
+#: ../../changelog.rst:1598
 msgid "2.54.0 (2021-04-09)"
 msgstr ""
 
-#: ../../changelog.rst:1595
+#: ../../changelog.rst:1602
 msgid "Add 'trek' filter on endpoint /sensitivearea in api v2"
 msgstr ""
 
-#: ../../changelog.rst:1599
+#: ../../changelog.rst:1606
 msgid "2.53.1 (2021-04-07)"
 msgstr ""
 
-#: ../../changelog.rst:1603
+#: ../../changelog.rst:1610
 msgid "Fix geojson display in API V2 /trek/ endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1604
+#: ../../changelog.rst:1611
 msgid "Add publication filter by language on /trek/ detail view endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1605
+#: ../../changelog.rst:1612
 msgid ""
 "Fixed the fact that the detail view of /trek/ endpoint crash when a trek "
 "has more than one parent"
 msgstr ""
 
-#: ../../changelog.rst:1606
+#: ../../changelog.rst:1613
 msgid ""
 "Do not display elements linked to content not published or not used at "
 "all in multiple endpoints on API V2"
 msgstr ""
 
-#: ../../changelog.rst:1610
+#: ../../changelog.rst:1617
 msgid "2.53.0 (2021-04-01)"
 msgstr ""
 
-#: ../../changelog.rst:1614
+#: ../../changelog.rst:1621
 msgid "Add departure_city attribute to treks and touristiccontents in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1615
+#: ../../changelog.rst:1622
 msgid "Allow to filter nomenclatures by portal in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1616
+#: ../../changelog.rst:1623
 msgid ""
 "Allow to retrieve a single unpublished trek if its parent is published in"
 " API v2"
 msgstr ""
 
-#: ../../changelog.rst:1620
+#: ../../changelog.rst:1627
 msgid "Simplify code thanks to Python 3 (thanks to Claude Paroz)"
 msgstr ""
 
-#: ../../changelog.rst:1621
+#: ../../changelog.rst:1628
 msgid "Add new sentry-sdk dependency"
 msgstr ""
 
-#: ../../changelog.rst:1625
+#: ../../changelog.rst:1632
 msgid ""
 "Avoid a db connection when requesting time from database (thanks to "
 "Claude Paroz)"
 msgstr ""
 
-#: ../../changelog.rst:1629
+#: ../../changelog.rst:1636
 msgid "Bump lxml from 4.6.2 to 4.6.3"
 msgstr ""
 
-#: ../../changelog.rst:1633
+#: ../../changelog.rst:1640
 msgid "2.52.0 (2021-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:1637
+#: ../../changelog.rst:1644
 msgid ""
 "Allow to add an outdoor sub-site or a course in a site owned by another "
 "structure"
 msgstr ""
 
-#: ../../changelog.rst:1638
+#: ../../changelog.rst:1645
 msgid "Fix outdoor site orientation/wind filtering"
 msgstr ""
 
-#: ../../changelog.rst:1639
+#: ../../changelog.rst:1646
 msgid "Add missing outdoor module translations"
 msgstr ""
 
-#: ../../changelog.rst:1643
+#: ../../changelog.rst:1650
 msgid "Outdoor course itinerancy"
 msgstr ""
 
-#: ../../changelog.rst:1644
+#: ../../changelog.rst:1651
 msgid "Add altimetry informations to outdoor sites and courses"
 msgstr ""
 
-#: ../../changelog.rst:1645
+#: ../../changelog.rst:1652
 msgid "Add outdoor course fields height and equipment"
 msgstr ""
 
-#: ../../changelog.rst:1646
+#: ../../changelog.rst:1653
 msgid "Add course layer to layers control"
 msgstr ""
 
-#: ../../changelog.rst:1647
+#: ../../changelog.rst:1654
 msgid "Allow VAR_DIR setting from environment (thanks to Claude Paroz)"
 msgstr ""
 
-#: ../../changelog.rst:1648
+#: ../../changelog.rst:1655
 msgid "Allow easier customization of loadpaths command (thanks to Claude Paroz)"
 msgstr ""
 
-#: ../../changelog.rst:1652
+#: ../../changelog.rst:1659
 msgid "Bump pillow from 7.1.2 to 8.1.1"
 msgstr ""
 
-#: ../../changelog.rst:1653
+#: ../../changelog.rst:1660
 msgid "Bump jinja2 from 2.11.1 to 2.11.3"
 msgstr ""
 
-#: ../../changelog.rst:1657
+#: ../../changelog.rst:1664
 msgid "2.51.2 (2021-03-16)"
 msgstr ""
 
-#: ../../changelog.rst:1661
+#: ../../changelog.rst:1668
 msgid "Translate all text fields in API v2 trek endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1662
+#: ../../changelog.rst:1669
 msgid "Serve attachments for flatpages"
 msgstr ""
 
-#: ../../changelog.rst:1663
+#: ../../changelog.rst:1670
 msgid "Fix bbox filtering of interventions"
 msgstr ""
 
-#: ../../changelog.rst:1667
+#: ../../changelog.rst:1674
 msgid "Add prefetch to Path exports (CSV/Shapefile/GPX)"
 msgstr ""
 
-#: ../../changelog.rst:1671
+#: ../../changelog.rst:1678
 msgid "2.51.1 (2021-03-05)"
 msgstr ""
 
-#: ../../changelog.rst:1675
+#: ../../changelog.rst:1682
 msgid "Fix departure_geom attribute in API v2 (WGS84 projection, without Z)"
 msgstr ""
 
-#: ../../changelog.rst:1679
+#: ../../changelog.rst:1686
 msgid "2.51.0 (2021-03-02)"
 msgstr ""
 
-#: ../../changelog.rst:1683
+#: ../../changelog.rst:1690
 msgid "Add filtering by restricted area types"
 msgstr ""
 
-#: ../../changelog.rst:1684
+#: ../../changelog.rst:1691
 msgid "Add outdoor course module"
 msgstr ""
 
-#: ../../changelog.rst:1685
+#: ../../changelog.rst:1692
 msgid "Add a site/course tree view in outdoor site and course detail pages"
 msgstr ""
 
-#: ../../changelog.rst:1689
+#: ../../changelog.rst:1696
 msgid ""
 "Fix a backward compatibility to keep MAP_STYLES['xxx'] config working in "
 "custom.py. However, we recommend to use new "
 "MAPENTITY_CONFIG['MAP_STYLES'] for this."
 msgstr ""
 
-#: ../../changelog.rst:1691
+#: ../../changelog.rst:1698
 msgid ""
 "Use 2D lengths instead of 3D length for Geotrek-rando (to be consistent "
 "with Geotrek-mobile)"
 msgstr ""
 
-#: ../../changelog.rst:1692
+#: ../../changelog.rst:1699
 msgid "Translate touristiccontent_category endpoint in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1693
+#: ../../changelog.rst:1700
 msgid ""
 "Fix crash of trek endpoing in API v2 when a geometry is a multilinestring"
 " (the previous fix was not working)"
 msgstr ""
 
-#: ../../changelog.rst:1698
+#: ../../changelog.rst:1705
 msgid "2.50.0 (2021-02-19)"
 msgstr ""
 
-#: ../../changelog.rst:1700 ../../changelog.rst:1728 ../../changelog.rst:1889
-#: ../../changelog.rst:2322 ../../changelog.rst:2406
+#: ../../changelog.rst:1707 ../../changelog.rst:1735 ../../changelog.rst:1896
+#: ../../changelog.rst:2329 ../../changelog.rst:2413
 msgid "**BREAKING CHANGES**"
 msgstr ""
 
-#: ../../changelog.rst:1702
+#: ../../changelog.rst:1709
 msgid "Change URL of some API v2 enpoints. See Swagger online doc."
 msgstr ""
 
-#: ../../changelog.rst:1703
+#: ../../changelog.rst:1710
 msgid "API v2 thumbnails are now 400px large"
 msgstr ""
 
-#: ../../changelog.rst:1704
+#: ../../changelog.rst:1711
 msgid "Split PDF urls by language in API v2"
 msgstr ""
 
-#: ../../changelog.rst:1708
+#: ../../changelog.rst:1715
 msgid "Fix API v2 crash when trek geom is a multilinestring"
 msgstr ""
 
-#: ../../changelog.rst:1709
+#: ../../changelog.rst:1716
 msgid ""
 "Fix touristic content filtering in API v2 when both type1 and type2 are "
 "specified"
 msgstr ""
 
-#: ../../changelog.rst:1710
+#: ../../changelog.rst:1717
 msgid "Synchronize pictogram for service types in mobile app"
 msgstr ""
 
-#: ../../changelog.rst:1714
+#: ../../changelog.rst:1721
 msgid "Cover image for static pages"
 msgstr ""
 
-#: ../../changelog.rst:1718
+#: ../../changelog.rst:1725
 msgid "Automatically remove temporary topologies created before version 2.48.0."
 msgstr ""
 
-#: ../../changelog.rst:1722
+#: ../../changelog.rst:1729
 msgid "Upgrade cryptography from 3.2 to 3.3.2"
 msgstr ""
 
-#: ../../changelog.rst:1726
+#: ../../changelog.rst:1733
 msgid "2.49.0 (2021-02-09)"
 msgstr ""
 
-#: ../../changelog.rst:1730
+#: ../../changelog.rst:1737
 msgid ""
 "MAP_STYLES setting should be now set in MAPENTITY_CONFIG['MAP_STYLES']. A"
 " fallback exists to keep configuration from MAP_STYLES."
 msgstr ""
 
-#: ../../changelog.rst:1732
+#: ../../changelog.rst:1739
 msgid ""
 "The name of several filters in APIv2 are now in plural form. See swagger "
 "doc."
 msgstr ""
 
-#: ../../changelog.rst:1736
+#: ../../changelog.rst:1743
 msgid "Fix cities filter in API v2 when id begins with a zero"
 msgstr ""
 
-#: ../../changelog.rst:1737
+#: ../../changelog.rst:1744
 msgid "Fix cities and districts filter in API v2 when given id is nonexistant"
 msgstr ""
 
-#: ../../changelog.rst:1738
+#: ../../changelog.rst:1745
 msgid "Allow to pass more than one id in most API v2 filters (see swagger doc)"
 msgstr ""
 
-#: ../../changelog.rst:1739
+#: ../../changelog.rst:1746
 msgid "Allow to filter on several items in most list page filter"
 msgstr ""
 
-#: ../../changelog.rst:1743
+#: ../../changelog.rst:1750
 msgid "Add flatpage endpoint to API v2"
 msgstr ""
 
-#: ../../changelog.rst:1744
+#: ../../changelog.rst:1751
 msgid "Add sector filter to outdoor site liste page"
 msgstr ""
 
-#: ../../changelog.rst:1745
+#: ../../changelog.rst:1752
 msgid ""
 "Compute aggregated fields only from children, not parents for outdoor "
 "sites"
 msgstr ""
 
-#: ../../changelog.rst:1746
+#: ../../changelog.rst:1753
 msgid ""
 "Practice, sector, wind and orientation filters on outdoor sites now take "
 "children into account"
 msgstr ""
 
-#: ../../changelog.rst:1750
+#: ../../changelog.rst:1757
 msgid "2.48.1 (2021-02-05)"
 msgstr ""
 
-#: ../../changelog.rst:1754
+#: ../../changelog.rst:1761
 msgid ""
 "Fix missing geometry in API v2 touristiccontent endpoint when using "
 "near_trek filter"
 msgstr ""
 
-#: ../../changelog.rst:1758
+#: ../../changelog.rst:1765
 msgid "2.48.0 (2021-02-03)"
 msgstr ""
 
-#: ../../changelog.rst:1762
+#: ../../changelog.rst:1769
 msgid ""
 "Do not save temporary topologies in database. Sometimes they are not "
 "removed and accumulate"
 msgstr ""
 
-#: ../../changelog.rst:1766
+#: ../../changelog.rst:1773
 msgid "Allow to use zoning app independently of others apps"
 msgstr ""
 
-#: ../../changelog.rst:1770
+#: ../../changelog.rst:1777
 msgid "Add id attribute to source and informationdesk APIv2 endpoints"
 msgstr ""
 
-#: ../../changelog.rst:1771
+#: ../../changelog.rst:1778
 msgid "Add structure attribute to touristic contents/events in API v1"
 msgstr ""
 
-#: ../../changelog.rst:1772
+#: ../../changelog.rst:1779
 msgid ""
 "Add publication, hierarchical level, practices and modification time "
 "columns to outdoor site list"
 msgstr ""
 
-#: ../../changelog.rst:1776
+#: ../../changelog.rst:1783
 msgid "2.47.2 (2021-01-28)"
 msgstr ""
 
-#: ../../changelog.rst:1780
+#: ../../changelog.rst:1787
 msgid "Fix crash in API v2 for touristics contents with alphanumeric external id"
 msgstr ""
 
-#: ../../changelog.rst:1784
+#: ../../changelog.rst:1791
 msgid "2.47.1 (2021-01-27)"
 msgstr ""
 
-#: ../../changelog.rst:1788
+#: ../../changelog.rst:1795
 msgid "Remove thumbnail and pictures attribute from API v2"
 msgstr ""
 
-#: ../../changelog.rst:1789
+#: ../../changelog.rst:1796
 msgid ""
 "Replace them by the attachments attribute on Trek, POI and Touristic "
 "content"
 msgstr ""
 
-#: ../../changelog.rst:1790
+#: ../../changelog.rst:1797
 msgid "The pdf attribute now returns an absolute URL"
 msgstr ""
 
-#: ../../changelog.rst:1794
+#: ../../changelog.rst:1801
 msgid "Do not recreate geometry columns indexes at each upgrade"
 msgstr ""
 
-#: ../../changelog.rst:1798
+#: ../../changelog.rst:1805
 msgid "2.47.0 (2021-01-26)"
 msgstr ""
 
-#: ../../changelog.rst:1802
+#: ../../changelog.rst:1809
 msgid "Add cities and departure_geom fields to API v2 trek endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1803
+#: ../../changelog.rst:1810
 msgid "Add practice filter to API v2 trek endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1804
+#: ../../changelog.rst:1811
 msgid "Add touristiccontentcategory endpoint to API v2 (with types)"
 msgstr ""
 
-#: ../../changelog.rst:1805
+#: ../../changelog.rst:1812
 msgid "Add many fields and filters to touristiccontent API v2 endpoint"
 msgstr ""
 
-#: ../../changelog.rst:1809
+#: ../../changelog.rst:1816
 msgid "Optimize generation of the list of cities in list pages"
 msgstr ""
 
-#: ../../changelog.rst:1813
+#: ../../changelog.rst:1820
 msgid "2.46.0 (2021-01-25)"
 msgstr ""
 
-#: ../../changelog.rst:1815
+#: ../../changelog.rst:1822
 msgid "**Database change**"
 msgstr ""
 
-#: ../../changelog.rst:1817
+#: ../../changelog.rst:1824
 msgid ""
 "\"mnt\" DEM table is now managed by django. It was renamed with "
 "altimetry_dem label. Data coming from mnt will be copied to new table."
 msgstr ""
 
-#: ../../changelog.rst:1820 ../../changelog.rst:1850
+#: ../../changelog.rst:1827 ../../changelog.rst:1857
 msgid "**Security fixes**"
 msgstr ""
 
-#: ../../changelog.rst:1822
+#: ../../changelog.rst:1829
 msgid "Enable XFrameOptionsMiddleware"
 msgstr ""
 
-#: ../../changelog.rst:1823
+#: ../../changelog.rst:1830
 msgid "Hide nginx version"
 msgstr ""
 
-#: ../../changelog.rst:1824
+#: ../../changelog.rst:1831
 msgid ""
 "Disable swagger (API v2 documentation) by default. To enable it, see "
 "swagger item in advanced documentation page."
 msgstr ""
 
-#: ../../changelog.rst:1826
+#: ../../changelog.rst:1833
 msgid "Fix XSS in filter popover"
 msgstr ""
 
-#: ../../changelog.rst:1830
+#: ../../changelog.rst:1837
 msgid "Fix impossibility to add paths on Ubuntu 20.04 (PostGIS 3)"
 msgstr ""
 
-#: ../../changelog.rst:1831
+#: ../../changelog.rst:1838
 msgid "Fix doc that explains how to load fixtures"
 msgstr ""
 
-#: ../../changelog.rst:1835
+#: ../../changelog.rst:1842
 msgid "Allow to select API v2 fields for all endpoints"
 msgstr ""
 
-#: ../../changelog.rst:1836
+#: ../../changelog.rst:1843
 msgid "Optimize development environment"
 msgstr ""
 
-#: ../../changelog.rst:1837
+#: ../../changelog.rst:1844
 msgid "Add an order field on rating scales"
 msgstr ""
 
-#: ../../changelog.rst:1838
+#: ../../changelog.rst:1845
 msgid "Allow multiple cardinal points for wind and orientation"
 msgstr ""
 
-#: ../../changelog.rst:1839
+#: ../../changelog.rst:1846
 msgid "Add sectors for outdoor sites"
 msgstr ""
 
-#: ../../changelog.rst:1840
+#: ../../changelog.rst:1847
 msgid "Add pictograms to outdoor practices and ratings"
 msgstr ""
 
-#: ../../changelog.rst:1841
+#: ../../changelog.rst:1848
 msgid ""
 "Compute outdoor site sector, practice, orientation and wind from childs "
 "and parents"
 msgstr ""
 
-#: ../../changelog.rst:1846
+#: ../../changelog.rst:1853
 msgid "2.45.0 (2021-01-10)"
 msgstr ""
 
-#: ../../changelog.rst:1848
+#: ../../changelog.rst:1855
 msgid "HAPPY NEW YEAR!"
 msgstr ""
 
-#: ../../changelog.rst:1852
+#: ../../changelog.rst:1859
 msgid "Upgrade cairosvg and lxml libraries"
 msgstr ""
 
-#: ../../changelog.rst:1856
+#: ../../changelog.rst:1863
 msgid "Fix migrations if some outdoor sites were created before"
 msgstr ""
 
-#: ../../changelog.rst:1857
+#: ../../changelog.rst:1864
 msgid "Fix missing placeholders for orientations in filter"
 msgstr ""
 
-#: ../../changelog.rst:1858
+#: ../../changelog.rst:1865
 msgid "Fix outdoor fixtures"
 msgstr ""
 
-#: ../../changelog.rst:1859
+#: ../../changelog.rst:1866
 msgid "Fix doc to enable outdoor"
 msgstr ""
 
-#: ../../changelog.rst:1860
+#: ../../changelog.rst:1867
 msgid "Fix path edition with PostGIS 3 (on Ubuntu 20.04)"
 msgstr ""
 
-#: ../../changelog.rst:1861
+#: ../../changelog.rst:1868
 msgid "Allow site type to be blank"
 msgstr ""
 
-#: ../../changelog.rst:1865
+#: ../../changelog.rst:1872
 msgid "Add min/max ratings for outdoor sites"
 msgstr ""
 
-#: ../../changelog.rst:1866
+#: ../../changelog.rst:1873
 msgid "Reorder outdoor site fields"
 msgstr ""
 
-#: ../../changelog.rst:1870
+#: ../../changelog.rst:1877
 msgid "2.44.0 (2020-12-18)"
 msgstr ""
 
-#: ../../changelog.rst:1874
+#: ../../changelog.rst:1881
 msgid "Add new fields to outdoor sites"
 msgstr ""
 
-#: ../../changelog.rst:1875
+#: ../../changelog.rst:1882
 msgid "Allow geometrycollection for site geometry"
 msgstr ""
 
-#: ../../changelog.rst:1879
+#: ../../changelog.rst:1886
 msgid "2.43.1 (2020-12-10)"
 msgstr ""
 
-#: ../../changelog.rst:1883
+#: ../../changelog.rst:1890
 msgid "Remove a SQL debug"
 msgstr ""
 
-#: ../../changelog.rst:1887
+#: ../../changelog.rst:1894
 msgid "2.43.0 (2020-12-10)"
 msgstr ""
 
-#: ../../changelog.rst:1891
+#: ../../changelog.rst:1898
 msgid ""
 "Old attachments are now deleted by default in parser. Add "
 "`delete_attachment = False` attribute to your parsers if you want to keep"
 " old behaviour (unlikely)."
 msgstr ""
 
-#: ../../changelog.rst:1896
+#: ../../changelog.rst:1903
 msgid "Fix creation of interventions with their own topology"
 msgstr ""
 
-#: ../../changelog.rst:1897
+#: ../../changelog.rst:1904
 msgid "Fix height of map on detail/create/update pages"
 msgstr ""
 
-#: ../../changelog.rst:1901
+#: ../../changelog.rst:1908
 msgid "2.42.0 (2020-12-04)"
 msgstr ""
 
-#: ../../changelog.rst:1905
+#: ../../changelog.rst:1912
 msgid "Minimal outdoor module (see documentation to enable)"
 msgstr ""
 
-#: ../../changelog.rst:1909
+#: ../../changelog.rst:1916
 msgid "Fix API v2 swagger"
 msgstr ""
 
-#: ../../changelog.rst:1913
+#: ../../changelog.rst:1920
 msgid "2.41.2 (2020-11-27)"
 msgstr ""
 
-#: ../../changelog.rst:1917
+#: ../../changelog.rst:1924
 msgid ""
 "Do not create point edges on zone borders (fix some crash when adding "
 "paths)"
 msgstr ""
 
-#: ../../changelog.rst:1918
+#: ../../changelog.rst:1925
 msgid ""
 "Enable postgis_raster extension when creating a new DB in Ubuntu 20.04 "
 "package"
 msgstr ""
 
-#: ../../changelog.rst:1922
+#: ../../changelog.rst:1929
 msgid ""
 "Geotrek Ubuntu repository changed to managed two versions (18.04 and "
 "20.04) in parallel. If you already installed Geotrek Ubuntu package "
@@ -3862,493 +3873,493 @@ msgid ""
 "change' to accept these changes."
 msgstr ""
 
-#: ../../changelog.rst:1928
+#: ../../changelog.rst:1935
 msgid "2.41.1 (2020-11-25)"
 msgstr ""
 
-#: ../../changelog.rst:1932
+#: ../../changelog.rst:1939
 msgid "Fix publish ubuntu 20.04/18.04"
 msgstr ""
 
-#: ../../changelog.rst:1936
+#: ../../changelog.rst:1943
 msgid "2.41.0 (2020-11-25)"
 msgstr ""
 
-#: ../../changelog.rst:1940
+#: ../../changelog.rst:1947
 msgid "Allow to install geotrek on ubuntu 20.04 and 18.04"
 msgstr ""
 
-#: ../../changelog.rst:1944
+#: ../../changelog.rst:1951
 msgid "Upgrade from Django 2.2 to Django 3.1"
 msgstr ""
 
-#: ../../changelog.rst:1946 ../../changelog.rst:1962 ../../changelog.rst:2020
-#: ../../changelog.rst:2041 ../../changelog.rst:2591 ../../changelog.rst:2603
-#: ../../changelog.rst:2634 ../../changelog.rst:2646 ../../changelog.rst:2658
-#: ../../changelog.rst:2670 ../../changelog.rst:2690 ../../changelog.rst:2708
-#: ../../changelog.rst:2723 ../../changelog.rst:2731 ../../changelog.rst:2747
-#: ../../changelog.rst:2760 ../../changelog.rst:2768 ../../changelog.rst:2787
-#: ../../changelog.rst:2830 ../../changelog.rst:2843 ../../changelog.rst:2900
+#: ../../changelog.rst:1953 ../../changelog.rst:1969 ../../changelog.rst:2027
+#: ../../changelog.rst:2048 ../../changelog.rst:2598 ../../changelog.rst:2610
+#: ../../changelog.rst:2641 ../../changelog.rst:2653 ../../changelog.rst:2665
+#: ../../changelog.rst:2677 ../../changelog.rst:2697 ../../changelog.rst:2715
+#: ../../changelog.rst:2730 ../../changelog.rst:2738 ../../changelog.rst:2754
+#: ../../changelog.rst:2767 ../../changelog.rst:2775 ../../changelog.rst:2794
+#: ../../changelog.rst:2837 ../../changelog.rst:2850 ../../changelog.rst:2907
 msgid "**Minor Changes**"
 msgstr ""
 
-#: ../../changelog.rst:1948
+#: ../../changelog.rst:1955
 msgid "Names of file in shapefiles changed"
 msgstr ""
 
-#: ../../changelog.rst:1952
+#: ../../changelog.rst:1959
 msgid "Truncate attachment legend too long in AttachmentParserMixin"
 msgstr ""
 
-#: ../../changelog.rst:1956
+#: ../../changelog.rst:1963
 msgid "2.40.1 (2020-11-23)"
 msgstr ""
 
-#: ../../changelog.rst:1960
+#: ../../changelog.rst:1967
 msgid "Fix dive pictogram (fix PDF crash)"
 msgstr ""
 
-#: ../../changelog.rst:1964
+#: ../../changelog.rst:1971
 msgid "Remove language from user profile. Now you can switch language from menu."
 msgstr ""
 
-#: ../../changelog.rst:1965
+#: ../../changelog.rst:1972
 msgid "More API v2 improvements (trek endpoint, new API_IS_PUBLIC setting)"
 msgstr ""
 
-#: ../../changelog.rst:1967 ../../changelog.rst:1984 ../../changelog.rst:2007
-#: ../../changelog.rst:2046 ../../changelog.rst:2062
+#: ../../changelog.rst:1974 ../../changelog.rst:1991 ../../changelog.rst:2014
+#: ../../changelog.rst:2053 ../../changelog.rst:2069
 msgid "**Doc improvements**"
 msgstr ""
 
-#: ../../changelog.rst:1969
+#: ../../changelog.rst:1976
 msgid "Update translation"
 msgstr ""
 
-#: ../../changelog.rst:1973
+#: ../../changelog.rst:1980
 msgid "2.40.0 (2020-11-18)"
 msgstr ""
 
-#: ../../changelog.rst:1975 ../../changelog.rst:2002 ../../changelog.rst:2028
-#: ../../changelog.rst:2036
+#: ../../changelog.rst:1982 ../../changelog.rst:2009 ../../changelog.rst:2035
+#: ../../changelog.rst:2043
 msgid "**New Features**"
 msgstr ""
 
-#: ../../changelog.rst:1977
+#: ../../changelog.rst:1984
 msgid ""
 "Handle different file formats in loadpoi command (all formats supported "
 "by gdal)"
 msgstr ""
 
-#: ../../changelog.rst:1978
+#: ../../changelog.rst:1985
 msgid "Improve API V2 filters and endpoints"
 msgstr ""
 
-#: ../../changelog.rst:1982
+#: ../../changelog.rst:1989
 msgid "Fix tooltip hidden on module bar (change layout mode to display flex)"
 msgstr ""
 
-#: ../../changelog.rst:1986
+#: ../../changelog.rst:1993
 msgid "Reorganize index"
 msgstr ""
 
-#: ../../changelog.rst:1987
+#: ../../changelog.rst:1994
 msgid "Add sphinx container for dev mode"
 msgstr ""
 
-#: ../../changelog.rst:1988
+#: ../../changelog.rst:1995
 msgid "Improve custom dist to give right templates of values in parameters"
 msgstr ""
 
-#: ../../changelog.rst:1992
+#: ../../changelog.rst:1999
 msgid "2.39.1 (2020-10-28)"
 msgstr ""
 
-#: ../../changelog.rst:1996
+#: ../../changelog.rst:2003
 msgid "Fix delete draft permission should allow use delete button"
 msgstr ""
 
-#: ../../changelog.rst:2000
+#: ../../changelog.rst:2007
 msgid "2.39.0 (2020-10-27)"
 msgstr ""
 
-#: ../../changelog.rst:2004
+#: ../../changelog.rst:2011
 msgid "Modification of API V2 routes"
 msgstr ""
 
-#: ../../changelog.rst:2005
+#: ../../changelog.rst:2012
 msgid "Add some filtering on Treks in API V2"
 msgstr ""
 
-#: ../../changelog.rst:2009
+#: ../../changelog.rst:2016
 msgid "Fix doc development command line"
 msgstr ""
 
-#: ../../changelog.rst:2010
+#: ../../changelog.rst:2017
 msgid "Improving docs : advanced configuration / synchronisation"
 msgstr ""
 
-#: ../../changelog.rst:2014
+#: ../../changelog.rst:2021
 msgid "2.38.6 (2020-10-20)"
 msgstr ""
 
-#: ../../changelog.rst:2018
+#: ../../changelog.rst:2025
 msgid "Fix middleware interfaces without ipv4"
 msgstr ""
 
-#: ../../changelog.rst:2022
+#: ../../changelog.rst:2029
 msgid "Pictogram for trek's label is optional"
 msgstr ""
 
-#: ../../changelog.rst:2026
+#: ../../changelog.rst:2033
 msgid "2.38.5 (2020-10-20)"
 msgstr ""
 
-#: ../../changelog.rst:2030
+#: ../../changelog.rst:2037
 msgid "Create new label for trekking, move inside_park to this label"
 msgstr ""
 
-#: ../../changelog.rst:2034
+#: ../../changelog.rst:2041
 msgid "2.38.4 (2020-10-16)"
 msgstr ""
 
-#: ../../changelog.rst:2038
+#: ../../changelog.rst:2045
 msgid "Add relation between a Report and a Trek"
 msgstr ""
 
-#: ../../changelog.rst:2039
+#: ../../changelog.rst:2046
 msgid "Change Report mail template to link the related Report in admin"
 msgstr ""
 
-#: ../../changelog.rst:2043
+#: ../../changelog.rst:2050
 msgid "Handle Z coordinates on GPX files"
 msgstr ""
 
-#: ../../changelog.rst:2044
+#: ../../changelog.rst:2051
 msgid "Force size pictograms in admin"
 msgstr ""
 
-#: ../../changelog.rst:2048
+#: ../../changelog.rst:2055
 msgid "Add info about what's new in 2.33"
 msgstr ""
 
-#: ../../changelog.rst:2049
+#: ../../changelog.rst:2056
 msgid "Change commands and so according to 2.33 [camillemonchicourt]"
 msgstr ""
 
-#: ../../changelog.rst:2050
+#: ../../changelog.rst:2057
 msgid "Fix doc about spatial extent setting"
 msgstr ""
 
-#: ../../changelog.rst:2054
+#: ../../changelog.rst:2061
 msgid "2.38.3 (2020-10-05)"
 msgstr ""
 
-#: ../../changelog.rst:2058
+#: ../../changelog.rst:2065
 msgid "Fix diving levels display on lists"
 msgstr ""
 
-#: ../../changelog.rst:2059
+#: ../../changelog.rst:2066
 msgid "Fix scrollable leaflet right control layer"
 msgstr ""
 
-#: ../../changelog.rst:2060
+#: ../../changelog.rst:2067
 msgid "Fix lists in csv (#2286)"
 msgstr ""
 
-#: ../../changelog.rst:2064
+#: ../../changelog.rst:2071
 msgid "Add doc for translating"
 msgstr ""
 
-#: ../../changelog.rst:2065
+#: ../../changelog.rst:2072
 msgid "Update synchronization with sync_rando options (Thanks JeanLenormand)"
 msgstr ""
 
-#: ../../changelog.rst:2069
+#: ../../changelog.rst:2076
 msgid "Show booklet pdf version on detail view"
 msgstr ""
 
-#: ../../changelog.rst:2073
+#: ../../changelog.rst:2080
 msgid "2.38.2 (2020-09-24)"
 msgstr ""
 
-#: ../../changelog.rst:2077
+#: ../../changelog.rst:2084
 msgid "Fix APIDAE parser when there is no element"
 msgstr ""
 
-#: ../../changelog.rst:2078
+#: ../../changelog.rst:2085
 msgid "Fix booklet generation with pdfimpose"
 msgstr ""
 
-#: ../../changelog.rst:2081
+#: ../../changelog.rst:2088
 msgid "2.38.1 (2020-09-22)"
 msgstr ""
 
-#: ../../changelog.rst:2085
+#: ../../changelog.rst:2092
 msgid "Fix USE_BOOKLET_PDF setting"
 msgstr ""
 
-#: ../../changelog.rst:2089
+#: ../../changelog.rst:2096
 msgid "2.38.0 (2020-09-21)"
 msgstr ""
 
-#: ../../changelog.rst:2093
+#: ../../changelog.rst:2100
 msgid "Add facebook informations on target Portals"
 msgstr ""
 
-#: ../../changelog.rst:2094
+#: ../../changelog.rst:2101
 msgid "Add description and title on target Portals"
 msgstr ""
 
-#: ../../changelog.rst:2095
+#: ../../changelog.rst:2102
 msgid "Synchronize multiple meta informations with target portals."
 msgstr ""
 
-#: ../../changelog.rst:2096
+#: ../../changelog.rst:2103
 msgid "Add booklet pdfs with setting USE_BOOKLET_PDF"
 msgstr ""
 
-#: ../../changelog.rst:2100
+#: ../../changelog.rst:2107
 msgid "Fix stake deletion list"
 msgstr ""
 
-#: ../../changelog.rst:2101
+#: ../../changelog.rst:2108
 msgid "Fix generation of stake automatically created with factories"
 msgstr ""
 
-#: ../../changelog.rst:2105
+#: ../../changelog.rst:2112
 msgid "Fix use of screamshotter and convertit for development"
 msgstr ""
 
-#: ../../changelog.rst:2106
+#: ../../changelog.rst:2113
 msgid "Use official postgis docker image"
 msgstr ""
 
-#: ../../changelog.rst:2107
+#: ../../changelog.rst:2114
 msgid "Change of legend size on pdfs"
 msgstr ""
 
-#: ../../changelog.rst:2109
+#: ../../changelog.rst:2116
 msgid "**Doc fixes**"
 msgstr ""
 
-#: ../../changelog.rst:2111
+#: ../../changelog.rst:2118
 msgid "Update suricate configuration doc"
 msgstr ""
 
-#: ../../changelog.rst:2112
+#: ../../changelog.rst:2119
 msgid "Update anonymize report documentation"
 msgstr ""
 
-#: ../../changelog.rst:2116
+#: ../../changelog.rst:2123
 msgid "2.37.0 (2020-09-16)"
 msgstr ""
 
-#: ../../changelog.rst:2120
+#: ../../changelog.rst:2127
 msgid "Fix script install"
 msgstr ""
 
-#: ../../changelog.rst:2124
+#: ../../changelog.rst:2131
 msgid "Add second external id api v2 for treks"
 msgstr ""
 
-#: ../../changelog.rst:2128
+#: ../../changelog.rst:2135
 msgid "2.36.1 (2020-09-04)"
 msgstr ""
 
-#: ../../changelog.rst:2132
+#: ../../changelog.rst:2139
 msgid "Fix crash in json DEM generation if the topology is a point"
 msgstr ""
 
-#: ../../changelog.rst:2136
+#: ../../changelog.rst:2143
 msgid "2.36.0 (2020-09-01)"
 msgstr ""
 
-#: ../../changelog.rst:2140
+#: ../../changelog.rst:2147
 msgid "Allow to (un)publish some cities/district/areas on Geotrek-rando/mobile"
 msgstr ""
 
-#: ../../changelog.rst:2144
+#: ../../changelog.rst:2151
 msgid "2.35.1 (2020-08-24)"
 msgstr ""
 
-#: ../../changelog.rst:2148
+#: ../../changelog.rst:2155
 msgid "Really add an id field to each SQL view"
 msgstr ""
 
-#: ../../changelog.rst:2152
+#: ../../changelog.rst:2159
 msgid "2.35.0 (2020-08-21)"
 msgstr ""
 
-#: ../../changelog.rst:2156
+#: ../../changelog.rst:2163
 msgid "Allow for custom SQL to be run at install/upgrade"
 msgstr ""
 
-#: ../../changelog.rst:2160
+#: ../../changelog.rst:2167
 msgid "Add an id field to each SQL view to allow QGIS to open them"
 msgstr ""
 
-#: ../../changelog.rst:2164
+#: ../../changelog.rst:2171
 msgid "2.34.0 (2020-07-10)"
 msgstr ""
 
-#: ../../changelog.rst:2168
+#: ../../changelog.rst:2175
 msgid ""
 "Add reservation system/id fields to treks to allow itinerancy online "
 "booking"
 msgstr ""
 
-#: ../../changelog.rst:2169
+#: ../../changelog.rst:2176
 msgid "Add category code (used in Geotrek-rando) to categories list in admin"
 msgstr ""
 
-#: ../../changelog.rst:2173
+#: ../../changelog.rst:2180
 msgid "Add install scripts for Ubuntu packages"
 msgstr ""
 
-#: ../../changelog.rst:2177
+#: ../../changelog.rst:2184
 msgid "Fix icons display in categories list in admin"
 msgstr ""
 
-#: ../../changelog.rst:2181
+#: ../../changelog.rst:2188
 msgid "2.33.13 (2020-07-01)"
 msgstr ""
 
-#: ../../changelog.rst:2185
+#: ../../changelog.rst:2192
 msgid "Add fields to reports for Suricate support"
 msgstr ""
 
-#: ../../changelog.rst:2186
+#: ../../changelog.rst:2193
 msgid ""
 "Add helper to send report to Suricate API on save, if setting "
 "`SURICATE_REPORT_ENABLED` is `True`"
 msgstr ""
 
-#: ../../changelog.rst:2190
+#: ../../changelog.rst:2197
 msgid "2.33.12 (2020-06-23)"
 msgstr ""
 
-#: ../../changelog.rst:2194
+#: ../../changelog.rst:2201
 msgid "Change doc flatpages-flatpages.jpg to png"
 msgstr ""
 
-#: ../../changelog.rst:2195
+#: ../../changelog.rst:2202
 msgid "Fix line topologies create path"
 msgstr ""
 
-#: ../../changelog.rst:2196
+#: ../../changelog.rst:2203
 msgid "Fix svg's fixtures wich cannot be tranform as png with cairosvg"
 msgstr ""
 
-#: ../../changelog.rst:2197
+#: ../../changelog.rst:2204
 msgid "Fix duration's filter mobile"
 msgstr ""
 
-#: ../../changelog.rst:2198
+#: ../../changelog.rst:2205
 msgid "Fix report email OSM coords"
 msgstr ""
 
-#: ../../changelog.rst:2202
+#: ../../changelog.rst:2209
 msgid "Synchro mobile get only used practice, themes, networks ..."
 msgstr ""
 
-#: ../../changelog.rst:2206
+#: ../../changelog.rst:2213
 msgid "2.33.11 (2020-06-05)"
 msgstr ""
 
-#: ../../changelog.rst:2210
+#: ../../changelog.rst:2217
 msgid "Fix long attachments name synchro"
 msgstr ""
 
-#: ../../changelog.rst:2214
+#: ../../changelog.rst:2221
 msgid "2.33.10 (2020-06-02)"
 msgstr ""
 
-#: ../../changelog.rst:2218
+#: ../../changelog.rst:2225
 msgid "Fix migration is_image 0011_attachment_add_is_image"
 msgstr ""
 
-#: ../../changelog.rst:2222
+#: ../../changelog.rst:2229
 msgid "Allow to clean attachments not used anymore (clean_attachments)"
 msgstr ""
 
-#: ../../changelog.rst:2226
+#: ../../changelog.rst:2233
 msgid "2.33.9 (2020-06-02)"
 msgstr ""
 
-#: ../../changelog.rst:2230
+#: ../../changelog.rst:2237
 msgid "Fix small treks profile"
 msgstr ""
 
-#: ../../changelog.rst:2234
+#: ../../changelog.rst:2241
 msgid "2.33.8 (2020-05-22)"
 msgstr ""
 
-#: ../../changelog.rst:2238
+#: ../../changelog.rst:2245
 msgid "Fix package install if geotrek user already exists"
 msgstr ""
 
-#: ../../changelog.rst:2239
+#: ../../changelog.rst:2246
 msgid "Attachment download error breaks global import"
 msgstr ""
 
-#: ../../changelog.rst:2243
+#: ../../changelog.rst:2250
 msgid "2.33.7 (2020-05-18)"
 msgstr ""
 
-#: ../../changelog.rst:2247
+#: ../../changelog.rst:2254
 msgid "Show blades without line in signage detail page"
 msgstr ""
 
-#: ../../changelog.rst:2248
+#: ../../changelog.rst:2255
 msgid "Fix information desks editing"
 msgstr ""
 
-#: ../../changelog.rst:2249
+#: ../../changelog.rst:2256
 msgid "Fix trek and POI filtering"
 msgstr ""
 
-#: ../../changelog.rst:2253
+#: ../../changelog.rst:2260
 msgid "2.33.6 (2020-05-14)"
 msgstr ""
 
-#: ../../changelog.rst:2257
+#: ../../changelog.rst:2264
 msgid "Don't overwrite initial data in existing database on first install"
 msgstr ""
 
-#: ../../changelog.rst:2261
+#: ../../changelog.rst:2268
 msgid "2.33.5 (2020-05-13)"
 msgstr ""
 
-#: ../../changelog.rst:2265
+#: ../../changelog.rst:2272
 msgid "Add a scrollbar to signage and blade forms"
 msgstr ""
 
-#: ../../changelog.rst:2266
+#: ../../changelog.rst:2273
 msgid "Fix city affectation for looping paths"
 msgstr ""
 
-#: ../../changelog.rst:2267
+#: ../../changelog.rst:2274
 msgid "Fix attachment download with redirection"
 msgstr ""
 
-#: ../../changelog.rst:2268
+#: ../../changelog.rst:2275
 msgid "Fix logout next page"
 msgstr ""
 
-#: ../../changelog.rst:2269
+#: ../../changelog.rst:2276
 msgid "Fix blade/line creation crash"
 msgstr ""
 
-#: ../../changelog.rst:2270
+#: ../../changelog.rst:2277
 msgid "Fix lines layout in blade detail page"
 msgstr ""
 
-#: ../../changelog.rst:2272 ../../changelog.rst:2346
+#: ../../changelog.rst:2279 ../../changelog.rst:2353
 msgid "**Upgrade notes**"
 msgstr ""
 
-#: ../../changelog.rst:2274
+#: ../../changelog.rst:2281
 msgid ""
 "If you installed version 2.33.3 before (no matter if you upgrade directly"
 " or from 2.33.4), you should get errors like "
@@ -4357,126 +4368,126 @@ msgid ""
 "0016;``."
 msgstr ""
 
-#: ../../changelog.rst:2280
+#: ../../changelog.rst:2287
 msgid "2.33.4 (2020-05-04)"
 msgstr ""
 
-#: ../../changelog.rst:2284
+#: ../../changelog.rst:2291
 msgid "Improve blade CSV export"
 msgstr ""
 
-#: ../../changelog.rst:2288
+#: ../../changelog.rst:2295
 msgid "Fix ordering of blades"
 msgstr ""
 
-#: ../../changelog.rst:2289
+#: ../../changelog.rst:2296
 msgid "Fix empty attachment link in admin list"
 msgstr ""
 
-#: ../../changelog.rst:2290
+#: ../../changelog.rst:2297
 msgid "Fix some french translations"
 msgstr ""
 
-#: ../../changelog.rst:2291
+#: ../../changelog.rst:2298
 msgid "Fix redirections when downloading attachments in parsers"
 msgstr ""
 
-#: ../../changelog.rst:2292
+#: ../../changelog.rst:2299
 msgid "Fix migrations when DB contains a deleted blade"
 msgstr ""
 
-#: ../../changelog.rst:2293
+#: ../../changelog.rst:2300
 msgid "Fix stdout flush in sync commands"
 msgstr ""
 
-#: ../../changelog.rst:2297
+#: ../../changelog.rst:2304
 msgid "Upgrade from Django 2.0 to Django 2.2"
 msgstr ""
 
-#: ../../changelog.rst:2298
+#: ../../changelog.rst:2305
 msgid "Fix deprecation warnings"
 msgstr ""
 
-#: ../../changelog.rst:2302
+#: ../../changelog.rst:2309
 msgid "2.33.3 (2020-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:2304 ../../changelog.rst:2310 ../../changelog.rst:2316
+#: ../../changelog.rst:2311 ../../changelog.rst:2317 ../../changelog.rst:2323
 msgid "No changes. Just force a new build in CI"
 msgstr ""
 
-#: ../../changelog.rst:2308
+#: ../../changelog.rst:2315
 msgid "2.33.2 (2020-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:2314
+#: ../../changelog.rst:2321
 msgid "2.33.1 (2020-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:2320
+#: ../../changelog.rst:2327
 msgid "2.33.0 (2020-04-28)"
 msgstr ""
 
-#: ../../changelog.rst:2324
+#: ../../changelog.rst:2331
 msgid "New installation method (Ubuntu packaging)"
 msgstr ""
 
-#: ../../changelog.rst:2325
+#: ../../changelog.rst:2332
 msgid "Alternative installation method (Docker, for experts only)"
 msgstr ""
 
-#: ../../changelog.rst:2326
+#: ../../changelog.rst:2333
 msgid "Remove name field from feedback report, to be GDPR compliant"
 msgstr ""
 
-#: ../../changelog.rst:2327
+#: ../../changelog.rst:2334
 msgid "Rename functions, triggers and sequences in database"
 msgstr ""
 
-#: ../../changelog.rst:2331
+#: ../../changelog.rst:2338
 msgid "Fix timeout when saving long treks (increase computation performances)"
 msgstr ""
 
-#: ../../changelog.rst:2332
+#: ../../changelog.rst:2339
 msgid "Fix mecanism to put tables in postgresql schemas"
 msgstr ""
 
-#: ../../changelog.rst:2333
+#: ../../changelog.rst:2340
 msgid "Better download errors handling in parsers"
 msgstr ""
 
-#: ../../changelog.rst:2334
+#: ../../changelog.rst:2341
 msgid "Make sure signage and related blade have the same related structure"
 msgstr ""
 
-#: ../../changelog.rst:2338
+#: ../../changelog.rst:2345
 msgid "Upgrade from Django 1.11 to Django 2.0"
 msgstr ""
 
-#: ../../changelog.rst:2342
+#: ../../changelog.rst:2349
 msgid ""
 "Allow to attach interventions to blades, paths, trails, treks, POIs and "
 "services in addition to infrastructures and signages"
 msgstr ""
 
-#: ../../changelog.rst:2343
+#: ../../changelog.rst:2350
 msgid ""
 "Allow to merge dropdown list items in admin. Check them in list view and "
 "choose \"Action: Merge\""
 msgstr ""
 
-#: ../../changelog.rst:2344
+#: ../../changelog.rst:2351
 msgid "Add a django command to erase email from feedback reports after 365 days"
 msgstr ""
 
-#: ../../changelog.rst:2348
+#: ../../changelog.rst:2355
 msgid ""
 "The installation method has been totally rewritten with an Ubuntu "
 "packaging (``apt install geotrek-admin``), only available for Ubuntu "
 "18.04 actually."
 msgstr ""
 
-#: ../../changelog.rst:2349
+#: ../../changelog.rst:2356
 msgid ""
 "If you upgrade from Geotrek-admin <= 2.32, then apply the dedicated "
 "migration script. See "
@@ -4484,7 +4495,7 @@ msgid ""
 "geotrek-admin-2-32."
 msgstr ""
 
-#: ../../changelog.rst:2350
+#: ../../changelog.rst:2357
 msgid ""
 "Geotrek-admin is now automatically installed in ``/opt/geotrek-admin/`` "
 "directory and the advanced configuration file moved to ``/opt/geotrek-"
@@ -4492,2457 +4503,2457 @@ msgid ""
 "details."
 msgstr ""
 
-#: ../../changelog.rst:2351
+#: ../../changelog.rst:2358
 msgid ""
 "The automatic NGINX configuration can be overriden in ``/opt/geotrek-"
 "admin/var/conf/nginx.conf.in`` file. See NGINX configuration "
 "documentation for details."
 msgstr ""
 
-#: ../../changelog.rst:2355
+#: ../../changelog.rst:2362
 msgid "2.32.11 (2020-03-17)"
 msgstr ""
 
-#: ../../changelog.rst:2359
+#: ../../changelog.rst:2366
 msgid "Add UML digrams of data model to documentation"
 msgstr ""
 
-#: ../../changelog.rst:2360
+#: ../../changelog.rst:2367
 msgid "Remove URL in weblinks dropdown"
 msgstr ""
 
-#: ../../changelog.rst:2361
+#: ../../changelog.rst:2368
 msgid "Move ambiance after description teaser"
 msgstr ""
 
-#: ../../changelog.rst:2365
+#: ../../changelog.rst:2372
 msgid "Fix a WeasyPrint warning"
 msgstr ""
 
-#: ../../changelog.rst:2366
+#: ../../changelog.rst:2373
 msgid "Fix zoning filters on path"
 msgstr ""
 
-#: ../../changelog.rst:2370
+#: ../../changelog.rst:2377
 msgid "2.32.10 (2020-03-11)"
 msgstr ""
 
-#: ../../changelog.rst:2374
+#: ../../changelog.rst:2381
 msgid "Fix POI, touristic contents and touristic events sort in mobile v3 API"
 msgstr ""
 
-#: ../../changelog.rst:2375
+#: ../../changelog.rst:2382
 msgid "Change Lambert93 signage coordinates format"
 msgstr ""
 
-#: ../../changelog.rst:2376
+#: ../../changelog.rst:2383
 msgid "Fix TourInSoftparser with # inside <MoyenDeCom> values"
 msgstr ""
 
-#: ../../changelog.rst:2377
+#: ../../changelog.rst:2384
 msgid "Show File and URL fields as required in attachement form"
 msgstr ""
 
-#: ../../changelog.rst:2378
+#: ../../changelog.rst:2385
 msgid "Do not show Function field as required in Intervention form"
 msgstr ""
 
-#: ../../changelog.rst:2379
+#: ../../changelog.rst:2386
 msgid "Do not show Amount and Organism fields as required in Project form"
 msgstr ""
 
-#: ../../changelog.rst:2383
+#: ../../changelog.rst:2390
 msgid "2.32.9 (2020-03-06)"
 msgstr ""
 
-#: ../../changelog.rst:2387
+#: ../../changelog.rst:2394
 msgid "Fix \"upper bound of FOR loop cannot be null\" crash in SQL triggers"
 msgstr ""
 
-#: ../../changelog.rst:2391
+#: ../../changelog.rst:2398
 msgid "2.32.8 (2020-03-05)"
 msgstr ""
 
-#: ../../changelog.rst:2395
+#: ../../changelog.rst:2402
 msgid "Allow to choose Touristic content ordering in API"
 msgstr ""
 
-#: ../../changelog.rst:2396
+#: ../../changelog.rst:2403
 msgid "Add external ID to projects and interventions"
 msgstr ""
 
-#: ../../changelog.rst:2400
+#: ../../changelog.rst:2407
 msgid ""
 "Fix the modification of the published field without the \"Can publish…\" "
 "permission"
 msgstr ""
 
-#: ../../changelog.rst:2404
+#: ../../changelog.rst:2411
 msgid "2.32.7 (2020-03-02)"
 msgstr ""
 
-#: ../../changelog.rst:2408
+#: ../../changelog.rst:2415
 msgid "Rename tables and fields in database"
 msgstr ""
 
-#: ../../changelog.rst:2412
+#: ../../changelog.rst:2419
 msgid "Retry on HTTP 503 errors in parsers"
 msgstr ""
 
-#: ../../changelog.rst:2416
+#: ../../changelog.rst:2423
 msgid "Fix install on Xenial (again)"
 msgstr ""
 
-#: ../../changelog.rst:2417
+#: ../../changelog.rst:2424
 msgid "Fix video embed url https"
 msgstr ""
 
-#: ../../changelog.rst:2418
+#: ../../changelog.rst:2425
 msgid ""
 "Fix \"Only LINESTRING and MULTILINESTRING are supported\" crash in SQL "
 "triggers"
 msgstr ""
 
-#: ../../changelog.rst:2422
+#: ../../changelog.rst:2429
 msgid "2.32.6 (2020-02-28)"
 msgstr ""
 
-#: ../../changelog.rst:2428
+#: ../../changelog.rst:2435
 msgid "2.32.5 (2020-02-18)"
 msgstr ""
 
-#: ../../changelog.rst:2432
+#: ../../changelog.rst:2439
 msgid "Fix filters sort in mobile v3 API"
 msgstr ""
 
-#: ../../changelog.rst:2436
+#: ../../changelog.rst:2443
 msgid "2.32.4 (2020-02-12)"
 msgstr ""
 
-#: ../../changelog.rst:2440
+#: ../../changelog.rst:2447
 msgid "Fix install on Xenial"
 msgstr ""
 
-#: ../../changelog.rst:2444
+#: ../../changelog.rst:2451
 msgid "2.32.3 (2020-01-27)"
 msgstr ""
 
-#: ../../changelog.rst:2448
+#: ../../changelog.rst:2455
 msgid ""
 "Fix review, publish do not display after resave a published or without "
 "permission to publish"
 msgstr ""
 
-#: ../../changelog.rst:2449
+#: ../../changelog.rst:2456
 msgid "Fix attachment asterisks and crispy form"
 msgstr ""
 
-#: ../../changelog.rst:2450
+#: ../../changelog.rst:2457
 msgid "Display only one time the same path when on trail detail"
 msgstr ""
 
-#: ../../changelog.rst:2454
+#: ../../changelog.rst:2461
 msgid "2.32.2 (2020-01-09)"
 msgstr ""
 
-#: ../../changelog.rst:2458
+#: ../../changelog.rst:2465
 msgid "Upgrade WeasyPrint"
 msgstr ""
 
-#: ../../changelog.rst:2462
+#: ../../changelog.rst:2469
 msgid "2.32.1 (2019-12-20)"
 msgstr ""
 
-#: ../../changelog.rst:2466
+#: ../../changelog.rst:2473
 msgid "Fix a crash in stake computation when adding an intervention"
 msgstr ""
 
-#: ../../changelog.rst:2467
+#: ../../changelog.rst:2474
 msgid "Fix a crash in project list when one of them has no end year"
 msgstr ""
 
-#: ../../changelog.rst:2468
+#: ../../changelog.rst:2475
 msgid "Fix drapping with no-data DEM values"
 msgstr ""
 
-#: ../../changelog.rst:2469
+#: ../../changelog.rst:2476
 msgid "Fix nav pills to choose language in forms"
 msgstr ""
 
-#: ../../changelog.rst:2473
+#: ../../changelog.rst:2480
 msgid "2.32.0 (2019-12-13)"
 msgstr ""
 
-#: ../../changelog.rst:2477
+#: ../../changelog.rst:2484
 msgid ""
 "Add DISPLAY_SRID into settings to allow user to choose it's own format "
 "for GPS coordinates"
 msgstr ""
 
-#: ../../changelog.rst:2478
+#: ../../changelog.rst:2485
 msgid ""
 "Make some fields optional (class Trail, Intervention, Project, "
 "OrdererdTrekChild, POI)"
 msgstr ""
 
-#: ../../changelog.rst:2479
+#: ../../changelog.rst:2486
 msgid "Sort dropdown lists"
 msgstr ""
 
-#: ../../changelog.rst:2480
+#: ../../changelog.rst:2487
 msgid "Document settings"
 msgstr ""
 
-#: ../../changelog.rst:2484
+#: ../../changelog.rst:2491
 msgid "2.31.0 (2019-12-06)"
 msgstr ""
 
-#: ../../changelog.rst:2488
+#: ../../changelog.rst:2495
 msgid "Sync mobile data from web UI"
 msgstr ""
 
-#: ../../changelog.rst:2489
+#: ../../changelog.rst:2496
 msgid "The SHOW_LABELS setting allows to hide status labels on map"
 msgstr ""
 
-#: ../../changelog.rst:2493
+#: ../../changelog.rst:2500
 msgid "2.30.0 (2019-11-26)"
 msgstr ""
 
-#: ../../changelog.rst:2497
+#: ../../changelog.rst:2504
 msgid "Remove support of Ubuntu 14.04 Trusty"
 msgstr ""
 
-#: ../../changelog.rst:2501
+#: ../../changelog.rst:2508
 msgid "Move from Python 2 to Python 3"
 msgstr ""
 
-#: ../../changelog.rst:2505
+#: ../../changelog.rst:2512
 msgid "Fix PDF generation for not published treks"
 msgstr ""
 
-#: ../../changelog.rst:2509
+#: ../../changelog.rst:2516
 msgid "2.29.15 (2019-11-12)"
 msgstr ""
 
-#: ../../changelog.rst:2513
+#: ../../changelog.rst:2520
 msgid "Fix install (use a version of venusian that is compatible with Python 2)"
 msgstr ""
 
-#: ../../changelog.rst:2517
+#: ../../changelog.rst:2524
 msgid "2.29.14 (2019-11-04)"
 msgstr ""
 
-#: ../../changelog.rst:2521
+#: ../../changelog.rst:2528
 msgid "Do not check structure for excluded POIs"
 msgstr ""
 
-#: ../../changelog.rst:2525
+#: ../../changelog.rst:2532
 msgid "2.29.13 (2019-10-30)"
 msgstr ""
 
-#: ../../changelog.rst:2529
+#: ../../changelog.rst:2536
 msgid "Do not set structure by default when creating elements in dropdown lists."
 msgstr ""
 
-#: ../../changelog.rst:2530
+#: ../../changelog.rst:2537
 msgid "Trek duration is now optional"
 msgstr ""
 
-#: ../../changelog.rst:2531
+#: ../../changelog.rst:2538
 msgid "Automatically disable empty filters in API for mobile v3"
 msgstr ""
 
-#: ../../changelog.rst:2532
+#: ../../changelog.rst:2539
 msgid "Add support for Tourinsoft v3 in addition to v2"
 msgstr ""
 
-#: ../../changelog.rst:2533
+#: ../../changelog.rst:2540
 msgid "Add more links form/to sensitive areas"
 msgstr ""
 
-#: ../../changelog.rst:2534
+#: ../../changelog.rst:2541
 msgid "Add more unit tests"
 msgstr ""
 
-#: ../../changelog.rst:2538
+#: ../../changelog.rst:2545
 msgid "Fix SEO for static page titles"
 msgstr ""
 
-#: ../../changelog.rst:2539
+#: ../../changelog.rst:2546
 msgid "Fix TouristicContentParser deletion having type1/2 with same values"
 msgstr ""
 
-#: ../../changelog.rst:2540
+#: ../../changelog.rst:2547
 msgid "Fix serialization of MultiPolygon sensitive areas"
 msgstr ""
 
-#: ../../changelog.rst:2544
+#: ../../changelog.rst:2551
 msgid "2.29.12 (2019-10-23)"
 msgstr ""
 
-#: ../../changelog.rst:2548
+#: ../../changelog.rst:2555
 msgid "Show completeness on dive detail page"
 msgstr ""
 
-#: ../../changelog.rst:2549
+#: ../../changelog.rst:2556
 msgid "Add practice field to trek and dive completeness"
 msgstr ""
 
-#: ../../changelog.rst:2553
+#: ../../changelog.rst:2560
 msgid ""
 "Fix multiple sensitive areas on treks with settings "
 "SENSITIVE_AREA_INTERSECTION_MARGIN = 0"
 msgstr ""
 
-#: ../../changelog.rst:2554
+#: ../../changelog.rst:2561
 msgid "Fix multiple sensitive areas on dives"
 msgstr ""
 
-#: ../../changelog.rst:2558
+#: ../../changelog.rst:2565
 msgid "2.29.11 (2019-10-17)"
 msgstr ""
 
-#: ../../changelog.rst:2562
+#: ../../changelog.rst:2569
 msgid "Fix filter still available after come back to list"
 msgstr ""
 
-#: ../../changelog.rst:2563
+#: ../../changelog.rst:2570
 msgid ""
 "Add settings allowing to change permission on voluminous datas. "
 "Voluminous datas are not stocked at the same place"
 msgstr ""
 
-#: ../../changelog.rst:2567
+#: ../../changelog.rst:2574
 msgid "2.29.10 (2019-10-08)"
 msgstr ""
 
-#: ../../changelog.rst:2571
+#: ../../changelog.rst:2578
 msgid "Do not set username as attachment author by default"
 msgstr ""
 
-#: ../../changelog.rst:2575
+#: ../../changelog.rst:2582
 msgid "Don't crash sync_rando with PIL.Image.DecompressionBombError"
 msgstr ""
 
-#: ../../changelog.rst:2576
+#: ../../changelog.rst:2583
 msgid "Fix mode selection when adding/editing an attachment"
 msgstr ""
 
-#: ../../changelog.rst:2577
+#: ../../changelog.rst:2584
 msgid "Fix authenticated parsers"
 msgstr ""
 
-#: ../../changelog.rst:2581
+#: ../../changelog.rst:2588
 msgid "2.29.9 (2019-10-02)"
 msgstr ""
 
-#: ../../changelog.rst:2585
+#: ../../changelog.rst:2592
 msgid "Fix sync_rando : sensitive area with multi polygons"
 msgstr ""
 
-#: ../../changelog.rst:2589
+#: ../../changelog.rst:2596
 msgid "2.29.8 (2019-09-26)"
 msgstr ""
 
-#: ../../changelog.rst:2593
+#: ../../changelog.rst:2600
 msgid "Increase path name field length"
 msgstr ""
 
-#: ../../changelog.rst:2597
+#: ../../changelog.rst:2604
 msgid "Fix csv_display signage with not ascii character"
 msgstr ""
 
-#: ../../changelog.rst:2601
+#: ../../changelog.rst:2608
 msgid "2.29.7 (2019-09-25)"
 msgstr ""
 
-#: ../../changelog.rst:2605
+#: ../../changelog.rst:2612
 msgid "Add pois services tourism on sync_rando"
 msgstr ""
 
-#: ../../changelog.rst:2606
+#: ../../changelog.rst:2613
 msgid "Add endpoints api for diving"
 msgstr ""
 
-#: ../../changelog.rst:2610
+#: ../../changelog.rst:2617
 msgid "Fix is_public() call checking if the object is ppublic or not."
 msgstr ""
 
-#: ../../changelog.rst:2611
+#: ../../changelog.rst:2618
 msgid "Remove duplicate description detail diving"
 msgstr ""
 
-#: ../../changelog.rst:2615
+#: ../../changelog.rst:2622
 msgid "2.29.6 (2019-09-19)"
 msgstr ""
 
-#: ../../changelog.rst:2619
+#: ../../changelog.rst:2626
 msgid "Fix sync_rando command with diving"
 msgstr ""
 
-#: ../../changelog.rst:2623
+#: ../../changelog.rst:2630
 msgid "2.29.5 (2019-09-13)"
 msgstr ""
 
-#: ../../changelog.rst:2627
+#: ../../changelog.rst:2634
 msgid "Sync POIs related to dives"
 msgstr ""
 
-#: ../../changelog.rst:2628
+#: ../../changelog.rst:2635
 msgid "Fix sync of manual PDF (again)"
 msgstr ""
 
-#: ../../changelog.rst:2632
+#: ../../changelog.rst:2639
 msgid "2.29.4 (2019-09-09)"
 msgstr ""
 
-#: ../../changelog.rst:2636
+#: ../../changelog.rst:2643
 msgid "Add reviews in dives module"
 msgstr ""
 
-#: ../../changelog.rst:2640
+#: ../../changelog.rst:2647
 msgid "Fix length should be length_2d in pdfs"
 msgstr ""
 
-#: ../../changelog.rst:2644
+#: ../../changelog.rst:2651
 msgid "2.29.3 (2019-08-28)"
 msgstr ""
 
-#: ../../changelog.rst:2648
+#: ../../changelog.rst:2655
 msgid "Allow to override nginx port in etc/settings.ini"
 msgstr ""
 
-#: ../../changelog.rst:2652
+#: ../../changelog.rst:2659
 msgid "Fix sync of manual PDF"
 msgstr ""
 
-#: ../../changelog.rst:2656
+#: ../../changelog.rst:2663
 msgid "2.29.2 (2019-08-28)"
 msgstr ""
 
-#: ../../changelog.rst:2660
+#: ../../changelog.rst:2667
 msgid "Add a command to import dives"
 msgstr ""
 
-#: ../../changelog.rst:2662
+#: ../../changelog.rst:2669
 msgid "**Bug Fixes**"
 msgstr ""
 
-#: ../../changelog.rst:2664
+#: ../../changelog.rst:2671
 msgid "Fix crash when a dive is not a point"
 msgstr ""
 
-#: ../../changelog.rst:2668
+#: ../../changelog.rst:2675
 msgid "2.29.1 (2019-08-26)"
 msgstr ""
 
-#: ../../changelog.rst:2672
+#: ../../changelog.rst:2679
 msgid "Show treks related to dives"
 msgstr ""
 
-#: ../../changelog.rst:2676
+#: ../../changelog.rst:2683
 msgid "Fix retrieval of content-length of attachments with HTTPS"
 msgstr ""
 
-#: ../../changelog.rst:2677
+#: ../../changelog.rst:2684
 msgid "Fix detection of hardcoded SRID in migrations"
 msgstr ""
 
-#: ../../changelog.rst:2678
+#: ../../changelog.rst:2685
 msgid "Fix Est/West swap in diving module"
 msgstr ""
 
-#: ../../changelog.rst:2679
+#: ../../changelog.rst:2686
 msgid "Fix version of more-itertools"
 msgstr ""
 
-#: ../../changelog.rst:2680
+#: ../../changelog.rst:2687
 msgid "Fix missing difficulty and technical levels in dive detail page and PDF"
 msgstr ""
 
-#: ../../changelog.rst:2684
+#: ../../changelog.rst:2691
 msgid "2.29.0 (2019-08-20)"
 msgstr ""
 
-#: ../../changelog.rst:2688
+#: ../../changelog.rst:2695
 msgid "Diving module (optional, see manual to enable)"
 msgstr ""
 
-#: ../../changelog.rst:2692
+#: ../../changelog.rst:2699
 msgid "Improve mobile sync"
 msgstr ""
 
-#: ../../changelog.rst:2693
+#: ../../changelog.rst:2700
 msgid "Do not automatically zoom over level 16"
 msgstr ""
 
-#: ../../changelog.rst:2697
+#: ../../changelog.rst:2704
 msgid "Fix black map screenshots (after a manual cache deletion)"
 msgstr ""
 
-#: ../../changelog.rst:2698
+#: ../../changelog.rst:2705
 msgid "Fix related POI order with dynamic segmentation disabled"
 msgstr ""
 
-#: ../../changelog.rst:2702
+#: ../../changelog.rst:2709
 msgid "2.28.0 (2019-08-09)"
 msgstr ""
 
-#: ../../changelog.rst:2706
+#: ../../changelog.rst:2713
 msgid "Geotrek without dynamic segmentation is back"
 msgstr ""
 
-#: ../../changelog.rst:2710
+#: ../../changelog.rst:2717
 msgid "Add a settings allowing to remove certain items from the left menu"
 msgstr ""
 
-#: ../../changelog.rst:2711
+#: ../../changelog.rst:2718
 msgid "Serve attachment with 'Topoguide' type as public PDF"
 msgstr ""
 
-#: ../../changelog.rst:2715
+#: ../../changelog.rst:2722
 msgid "Fix missing pictograms for mobile app"
 msgstr ""
 
-#: ../../changelog.rst:2716
+#: ../../changelog.rst:2723
 msgid "Translate feedback acknoledgment email"
 msgstr ""
 
-#: ../../changelog.rst:2717
+#: ../../changelog.rst:2724
 msgid "Fix sync_mobile command for itinerancy"
 msgstr ""
 
-#: ../../changelog.rst:2721
+#: ../../changelog.rst:2728
 msgid "2.27.12 (2019-07-22)"
 msgstr ""
 
-#: ../../changelog.rst:2725
+#: ../../changelog.rst:2732
 msgid "Add itinerancy mobile"
 msgstr ""
 
-#: ../../changelog.rst:2729
+#: ../../changelog.rst:2736
 msgid "2.27.11 (2019-07-17)"
 msgstr ""
 
-#: ../../changelog.rst:2733
+#: ../../changelog.rst:2740
 msgid "Change condition's on_delete for SET_NULL"
 msgstr ""
 
-#: ../../changelog.rst:2734
+#: ../../changelog.rst:2741
 msgid ""
 "Add the possibility to add Multipoint with one Point on commands "
 "loadinfrastructure/loadsignage"
 msgstr ""
 
-#: ../../changelog.rst:2738
+#: ../../changelog.rst:2745
 msgid ""
 "Fix choices fields, should only take in account existing (not deleted) "
 "elements"
 msgstr ""
 
-#: ../../changelog.rst:2739
+#: ../../changelog.rst:2746
 msgid "Fix delete Organism"
 msgstr ""
 
-#: ../../changelog.rst:2740
+#: ../../changelog.rst:2747
 msgid "Fix sensitivity parser with MultiPolygon"
 msgstr ""
 
-#: ../../changelog.rst:2741
+#: ../../changelog.rst:2748
 msgid "Fix profile and languages"
 msgstr ""
 
-#: ../../changelog.rst:2745
+#: ../../changelog.rst:2752
 msgid "2.27.10 (2019-07-10)"
 msgstr ""
 
-#: ../../changelog.rst:2749
+#: ../../changelog.rst:2756
 msgid "Set OpenTopoMap as default map background"
 msgstr ""
 
-#: ../../changelog.rst:2750
+#: ../../changelog.rst:2757
 msgid "Resize information desk type pictograms in mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2754
+#: ../../changelog.rst:2761
 msgid "Fix delete intervention type"
 msgstr ""
 
-#: ../../changelog.rst:2758
+#: ../../changelog.rst:2765
 msgid "2.27.9 (2019-07-01)"
 msgstr ""
 
-#: ../../changelog.rst:2762
+#: ../../changelog.rst:2769
 msgid "Add ambiance field to trek detail endpoint in mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2766
+#: ../../changelog.rst:2773
 msgid "2.27.8 (2019-06-28)"
 msgstr ""
 
-#: ../../changelog.rst:2770
+#: ../../changelog.rst:2777
 msgid "Add primary color setting for PDF"
 msgstr ""
 
-#: ../../changelog.rst:2771
+#: ../../changelog.rst:2778
 msgid "Allow to override practices pictogram color in custom trek PDF template"
 msgstr ""
 
-#: ../../changelog.rst:2775
+#: ../../changelog.rst:2782
 msgid "2.27.7 (2019-06-26)"
 msgstr ""
 
-#: ../../changelog.rst:2779
+#: ../../changelog.rst:2786
 msgid "Fix public PDF overflow"
 msgstr ""
 
-#: ../../changelog.rst:2780
+#: ../../changelog.rst:2787
 msgid "Resize category and POI pictograms for mobile app"
 msgstr ""
 
-#: ../../changelog.rst:2781
+#: ../../changelog.rst:2788
 msgid "Convert pictograms from SVG to PNG for mobile app"
 msgstr ""
 
-#: ../../changelog.rst:2782
+#: ../../changelog.rst:2789
 msgid "Fix structure (or not) related scrolldowns validation"
 msgstr ""
 
-#: ../../changelog.rst:2783
+#: ../../changelog.rst:2790
 msgid "Remove unvisible paths in remove_duplicate_paths command"
 msgstr ""
 
-#: ../../changelog.rst:2784
+#: ../../changelog.rst:2791
 msgid "Fix list of additional layers in layer selector"
 msgstr ""
 
-#: ../../changelog.rst:2785
+#: ../../changelog.rst:2792
 msgid "Don't reset excluded POIs when saving treks"
 msgstr ""
 
-#: ../../changelog.rst:2789
+#: ../../changelog.rst:2796
 msgid "Allow to merge multiple comment columns when importing paths"
 msgstr ""
 
-#: ../../changelog.rst:2790
+#: ../../changelog.rst:2797
 msgid "Add color field to touristic contents categories (for mobile app only)"
 msgstr ""
 
-#: ../../changelog.rst:2791
+#: ../../changelog.rst:2798
 msgid "Handle invalid geometries when importing districts"
 msgstr ""
 
-#: ../../changelog.rst:2795
+#: ../../changelog.rst:2802
 msgid "2.27.6 (2019-06-04)"
 msgstr ""
 
-#: ../../changelog.rst:2799
+#: ../../changelog.rst:2806
 msgid "Fix mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2803
+#: ../../changelog.rst:2810
 msgid "2.27.5 (2019-05-29)"
 msgstr ""
 
-#: ../../changelog.rst:2807
+#: ../../changelog.rst:2814
 msgid "Fix regulatory sensitive area parser"
 msgstr ""
 
-#: ../../changelog.rst:2808
+#: ../../changelog.rst:2815
 msgid "Fix handling of parser errors"
 msgstr ""
 
-#: ../../changelog.rst:2812
+#: ../../changelog.rst:2819
 msgid "2.27.4 (2019-05-27)"
 msgstr ""
 
-#: ../../changelog.rst:2816
+#: ../../changelog.rst:2823
 msgid "Fix crash with --srid option of loadpaths command"
 msgstr ""
 
-#: ../../changelog.rst:2817
+#: ../../changelog.rst:2824
 msgid "Add option portal in sync_mobile for the treks"
 msgstr ""
 
-#: ../../changelog.rst:2818
+#: ../../changelog.rst:2825
 msgid "Fix encoding error on watermarks"
 msgstr ""
 
-#: ../../changelog.rst:2819
+#: ../../changelog.rst:2826
 msgid "Fix bad references to sync_mobile in sync_rando command"
 msgstr ""
 
-#: ../../changelog.rst:2823
+#: ../../changelog.rst:2830
 msgid "2.27.3 (2019-05-23)"
 msgstr ""
 
-#: ../../changelog.rst:2827
+#: ../../changelog.rst:2834
 msgid "Allow to set order of filters in mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2828
+#: ../../changelog.rst:2835
 msgid "Add ascent and district filters to mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2832
+#: ../../changelog.rst:2839
 msgid "Replace text by an id in url of pictures with watermarks"
 msgstr ""
 
-#: ../../changelog.rst:2833
+#: ../../changelog.rst:2840
 msgid "Change default settings watermark"
 msgstr ""
 
-#: ../../changelog.rst:2837
+#: ../../changelog.rst:2844
 msgid "Add PDF overriding section"
 msgstr ""
 
-#: ../../changelog.rst:2841
+#: ../../changelog.rst:2848
 msgid "2.27.2 (2019-05-14)"
 msgstr ""
 
-#: ../../changelog.rst:2845
+#: ../../changelog.rst:2852
 msgid "Add points_reference by treks in api mobile"
 msgstr ""
 
-#: ../../changelog.rst:2849
+#: ../../changelog.rst:2856
 msgid "Remove public pdf poi"
 msgstr ""
 
-#: ../../changelog.rst:2850
+#: ../../changelog.rst:2857
 msgid "Fix filter cities without paths"
 msgstr ""
 
-#: ../../changelog.rst:2854
+#: ../../changelog.rst:2861
 msgid "2.27.1 (2019-05-06)"
 msgstr ""
 
-#: ../../changelog.rst:2858
+#: ../../changelog.rst:2865
 msgid "Fix api mobile with only sensitivity app"
 msgstr ""
 
-#: ../../changelog.rst:2862
+#: ../../changelog.rst:2869
 msgid "2.27.0 (2019-05-02)"
 msgstr ""
 
-#: ../../changelog.rst:2866
+#: ../../changelog.rst:2873
 msgid "Add watermark on pictures"
 msgstr ""
 
-#: ../../changelog.rst:2867
+#: ../../changelog.rst:2874
 msgid "Allow to change structure of an object with permission by_pass_structure"
 msgstr ""
 
-#: ../../changelog.rst:2871
+#: ../../changelog.rst:2878
 msgid "Fix a floating point computation problem in SQL trigger"
 msgstr ""
 
-#: ../../changelog.rst:2872
+#: ../../changelog.rst:2879
 msgid "Fix trails in detail of intervention and opposite"
 msgstr ""
 
-#: ../../changelog.rst:2873
+#: ../../changelog.rst:2880
 msgid "Fix color on restricted area"
 msgstr ""
 
-#: ../../changelog.rst:2877
+#: ../../changelog.rst:2884
 msgid "2.26.5 (2019-04-19)"
 msgstr ""
 
-#: ../../changelog.rst:2881
+#: ../../changelog.rst:2888
 msgid "Add slug to mobile API"
 msgstr ""
 
-#: ../../changelog.rst:2882
+#: ../../changelog.rst:2889
 msgid "Fix crash with empty images"
 msgstr ""
 
-#: ../../changelog.rst:2886
+#: ../../changelog.rst:2893
 msgid "2.26.4 (2019-04-18)"
 msgstr ""
 
-#: ../../changelog.rst:2890
+#: ../../changelog.rst:2897
 msgid "Fix migration tourism 0004"
 msgstr ""
 
-#: ../../changelog.rst:2894
+#: ../../changelog.rst:2901
 msgid "2.26.3 (2019-04-12)"
 msgstr ""
 
-#: ../../changelog.rst:2898
+#: ../../changelog.rst:2905
 msgid "Fix parsers delete datas"
 msgstr ""
 
-#: ../../changelog.rst:2902
+#: ../../changelog.rst:2909
 msgid "Add command loaddistrict, loadcities, loadpaths"
 msgstr ""
 
-#: ../../changelog.rst:2906
+#: ../../changelog.rst:2913
 msgid "2.26.2 (2019-04-10)"
 msgstr ""
 
-#: ../../changelog.rst:2910
+#: ../../changelog.rst:2917
 msgid "Fix sync_rando command (BadZipfile exception)"
 msgstr ""
 
-#: ../../changelog.rst:2911
+#: ../../changelog.rst:2918
 msgid "Fix nginx and Django conf when SSL is enabled"
 msgstr ""
 
-#: ../../changelog.rst:2912
+#: ../../changelog.rst:2919
 msgid "Fix restricted area layers"
 msgstr ""
 
-#: ../../changelog.rst:2916
+#: ../../changelog.rst:2923
 msgid "2.26.1 (2019-04-03)"
 msgstr ""
 
-#: ../../changelog.rst:2920
+#: ../../changelog.rst:2927
 msgid "Fix blade form"
 msgstr ""
 
-#: ../../changelog.rst:2921
+#: ../../changelog.rst:2928
 msgid "Fix sync_mobile, sync_rando with url https and http"
 msgstr ""
 
-#: ../../changelog.rst:2925
+#: ../../changelog.rst:2932
 msgid "2.26.0 (2019-04-01)"
 msgstr ""
 
-#: ../../changelog.rst:2929
+#: ../../changelog.rst:2936
 msgid "New API for mobile app v3"
 msgstr ""
 
-#: ../../changelog.rst:2933
+#: ../../changelog.rst:2940
 msgid "Fix signage type pictograms"
 msgstr ""
 
-#: ../../changelog.rst:2934
+#: ../../changelog.rst:2941
 msgid "Some cosmetics on tourism detail pages (clickable links)"
 msgstr ""
 
-#: ../../changelog.rst:2935
+#: ../../changelog.rst:2942
 msgid "Fix Tourinsoft opening period parsing (multiple periods)"
 msgstr ""
 
-#: ../../changelog.rst:2936
+#: ../../changelog.rst:2943
 msgid "Fix Bad Status Line exception"
 msgstr ""
 
-#: ../../changelog.rst:2940
+#: ../../changelog.rst:2947
 msgid "2.25.3 (2019-03-26)"
 msgstr ""
 
-#: ../../changelog.rst:2944
+#: ../../changelog.rst:2951
 msgid "Fix Tourinsoft parsers one time again (practical info for events)"
 msgstr ""
 
-#: ../../changelog.rst:2948
+#: ../../changelog.rst:2955
 msgid "2.25.2 (2019-03-26)"
 msgstr ""
 
-#: ../../changelog.rst:2952
+#: ../../changelog.rst:2959
 msgid "Fix Tourinsoft parsers again (postal address)"
 msgstr ""
 
-#: ../../changelog.rst:2956
+#: ../../changelog.rst:2963
 msgid "2.25.1 (2019-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:2960
+#: ../../changelog.rst:2967
 msgid "Fix Tourinsoft parsers"
 msgstr ""
 
-#: ../../changelog.rst:2964
+#: ../../changelog.rst:2971
 msgid "2.25.0 (2019-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:2966
+#: ../../changelog.rst:2973
 msgid "**New features / Performances**"
 msgstr ""
 
-#: ../../changelog.rst:2968
+#: ../../changelog.rst:2975
 msgid "Add the possibility to load layers (do not load them automatically)"
 msgstr ""
 
-#: ../../changelog.rst:2972
+#: ../../changelog.rst:2979
 msgid "Add Touristic Content TourInSoft Parser"
 msgstr ""
 
-#: ../../changelog.rst:2973
+#: ../../changelog.rst:2980
 msgid "Add tool testing ign keys without ggp3"
 msgstr ""
 
-#: ../../changelog.rst:2977
+#: ../../changelog.rst:2984
 msgid "How to update IGN urls"
 msgstr ""
 
-#: ../../changelog.rst:2981
+#: ../../changelog.rst:2988
 msgid "2.24.8 (2019-03-15)"
 msgstr ""
 
-#: ../../changelog.rst:2985
+#: ../../changelog.rst:2992
 msgid "Fix bug parsers filetype not related with structure"
 msgstr ""
 
-#: ../../changelog.rst:2989
+#: ../../changelog.rst:2996
 msgid "2.24.7 (2019-03-13)"
 msgstr ""
 
-#: ../../changelog.rst:2993
+#: ../../changelog.rst:3000
 msgid "Add elevation on sensible areas"
 msgstr ""
 
-#: ../../changelog.rst:2997
+#: ../../changelog.rst:3004
 msgid "Fix retry sync_rando tiles when tiles does not exist (landez 2.4.1)"
 msgstr ""
 
-#: ../../changelog.rst:3001
+#: ../../changelog.rst:3008
 msgid "2.24.6 (2019-03-07)"
 msgstr ""
 
-#: ../../changelog.rst:3005
+#: ../../changelog.rst:3012
 msgid "When updating interventions, stake field is no more required"
 msgstr ""
 
-#: ../../changelog.rst:3006
+#: ../../changelog.rst:3013
 msgid "Fix duplicates in year filters in intervention module"
 msgstr ""
 
-#: ../../changelog.rst:3007
+#: ../../changelog.rst:3014
 msgid "Configurable blade code"
 msgstr ""
 
-#: ../../changelog.rst:3008
+#: ../../changelog.rst:3015
 msgid "Allow letters in blade number"
 msgstr ""
 
-#: ../../changelog.rst:3009
+#: ../../changelog.rst:3016
 msgid "Improve signage templates"
 msgstr ""
 
-#: ../../changelog.rst:3010
+#: ../../changelog.rst:3017
 msgid "Add \"On signage/infrastructure\" filter on intervention list"
 msgstr ""
 
-#: ../../changelog.rst:3014
+#: ../../changelog.rst:3021
 msgid "2.24.5 (2019-03-06)"
 msgstr ""
 
-#: ../../changelog.rst:3018
+#: ../../changelog.rst:3025
 msgid "Add index to date_update columns"
 msgstr ""
 
-#: ../../changelog.rst:3022
+#: ../../changelog.rst:3029
 msgid "2.24.4 (2019-03-01)"
 msgstr ""
 
-#: ../../changelog.rst:3026
+#: ../../changelog.rst:3033
 msgid "Fix get attachments with crop"
 msgstr ""
 
-#: ../../changelog.rst:3030
+#: ../../changelog.rst:3037
 msgid "2.24.3 (2019-02-28)"
 msgstr ""
 
-#: ../../changelog.rst:3034
+#: ../../changelog.rst:3041
 msgid "Fix get attachments using generic foreign and not url"
 msgstr ""
 
-#: ../../changelog.rst:3035
+#: ../../changelog.rst:3042
 msgid "Fix merge path"
 msgstr ""
 
-#: ../../changelog.rst:3039
+#: ../../changelog.rst:3046
 msgid "2.24.2 (2019-02-26)"
 msgstr ""
 
-#: ../../changelog.rst:3043
+#: ../../changelog.rst:3050
 msgid "Fix attachments and history linked with signage and infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:3047
+#: ../../changelog.rst:3054
 msgid "2.24.1 (2019-02-12)"
 msgstr ""
 
-#: ../../changelog.rst:3051
+#: ../../changelog.rst:3058
 msgid "Fix install.sh (pin cairocffi version)"
 msgstr ""
 
-#: ../../changelog.rst:3052
+#: ../../changelog.rst:3059
 msgid "Fix routing on paths with sharp angles"
 msgstr ""
 
-#: ../../changelog.rst:3053
+#: ../../changelog.rst:3060
 msgid "Fix loadrestrictedareas command"
 msgstr ""
 
-#: ../../changelog.rst:3054
+#: ../../changelog.rst:3061
 msgid "Fix altimetry on straight portions of paths"
 msgstr ""
 
-#: ../../changelog.rst:3055
+#: ../../changelog.rst:3062
 msgid "Various signage fixes"
 msgstr ""
 
-#: ../../changelog.rst:3059
+#: ../../changelog.rst:3066
 msgid ""
 "Allow client side caching with systematic revalidation for Layer, "
 "JsonList and graph views"
 msgstr ""
 
-#: ../../changelog.rst:3060
+#: ../../changelog.rst:3067
 msgid "Remove validation of history bar"
 msgstr ""
 
-#: ../../changelog.rst:3061
+#: ../../changelog.rst:3068
 msgid "Don't bringToFront() every single feature on map"
 msgstr ""
 
-#: ../../changelog.rst:3062
+#: ../../changelog.rst:3069
 msgid ""
 "Do not show bullets at path extremities anymore by default. Set "
 "SHOW_EXTREMITIES setting to True in custom.py enable them."
 msgstr ""
 
-#: ../../changelog.rst:3064
+#: ../../changelog.rst:3071
 msgid "Remove networks and trails columns in path list"
 msgstr ""
 
-#: ../../changelog.rst:3068
+#: ../../changelog.rst:3075
 msgid "2.24.0 (2019-01-28)"
 msgstr ""
 
-#: ../../changelog.rst:3072
+#: ../../changelog.rst:3079
 msgid "Bulk path deletion"
 msgstr ""
 
-#: ../../changelog.rst:3076
+#: ../../changelog.rst:3083
 msgid "2.23.0 (2019-01-24)"
 msgstr ""
 
-#: ../../changelog.rst:3080
+#: ../../changelog.rst:3087
 msgid "Signage blades management"
 msgstr ""
 
-#: ../../changelog.rst:3081
+#: ../../changelog.rst:3088
 msgid "Add gpx and kml export for path detail view"
 msgstr ""
 
-#: ../../changelog.rst:3082
+#: ../../changelog.rst:3089
 msgid "Allow to load local GPX/Geojson file in list views"
 msgstr ""
 
-#: ../../changelog.rst:3086
+#: ../../changelog.rst:3093
 msgid "Fix sensitive areas API v2"
 msgstr ""
 
-#: ../../changelog.rst:3087
+#: ../../changelog.rst:3094
 msgid "Fix migrations if infrastructure app not is not installed"
 msgstr ""
 
-#: ../../changelog.rst:3091
+#: ../../changelog.rst:3098
 msgid "2.22.10 (2019-01-09)"
 msgstr ""
 
-#: ../../changelog.rst:3095
+#: ../../changelog.rst:3102
 msgid "Fix duplicated results in API v2 with sensitive area filters"
 msgstr ""
 
-#: ../../changelog.rst:3099
+#: ../../changelog.rst:3106
 msgid "2.22.9 (2019-01-09)"
 msgstr ""
 
-#: ../../changelog.rst:3103
+#: ../../changelog.rst:3110
 msgid "Separate Infrastructure and Signage models"
 msgstr ""
 
-#: ../../changelog.rst:3104
+#: ../../changelog.rst:3111
 msgid "Create parser touristic event for apidae"
 msgstr ""
 
-#: ../../changelog.rst:3105
+#: ../../changelog.rst:3112
 msgid "Refactor ApidaeParser"
 msgstr ""
 
-#: ../../changelog.rst:3109
+#: ../../changelog.rst:3116
 msgid "Add italian translations that are visible on Geotrek-rando"
 msgstr ""
 
-#: ../../changelog.rst:3110
+#: ../../changelog.rst:3117
 msgid "Fix permissions attachments paperclip"
 msgstr ""
 
-#: ../../changelog.rst:3114
+#: ../../changelog.rst:3121
 msgid "Improve map's performances"
 msgstr ""
 
-#: ../../changelog.rst:3118
+#: ../../changelog.rst:3125
 msgid "2.22.8 (2019-01-03)"
 msgstr ""
 
-#: ../../changelog.rst:3122
+#: ../../changelog.rst:3129
 msgid "Now, empty portal field means \"all portals\" instead of \"no portal\""
 msgstr ""
 
-#: ../../changelog.rst:3126
+#: ../../changelog.rst:3133
 msgid "2.22.7 (2019-01-03)"
 msgstr ""
 
-#: ../../changelog.rst:3130
+#: ../../changelog.rst:3137
 msgid "Fix command loadinfrastructure"
 msgstr ""
 
-#: ../../changelog.rst:3134
+#: ../../changelog.rst:3141
 msgid "2.22.6 (2019-01-02)"
 msgstr ""
 
-#: ../../changelog.rst:3138
+#: ../../changelog.rst:3145
 msgid "Index path draft field"
 msgstr ""
 
-#: ../../changelog.rst:3139
+#: ../../changelog.rst:3146
 msgid "Add eid field to load_infrastructure command"
 msgstr ""
 
-#: ../../changelog.rst:3140
+#: ../../changelog.rst:3147
 msgid "Add loadrestrictedarea command"
 msgstr ""
 
-#: ../../changelog.rst:3141
+#: ../../changelog.rst:3148
 msgid "Install postgis package"
 msgstr ""
 
-#: ../../changelog.rst:3145
+#: ../../changelog.rst:3152
 msgid "2.22.5 (2018-12-19)"
 msgstr ""
 
-#: ../../changelog.rst:3149
+#: ../../changelog.rst:3156
 msgid "Fix DB migration"
 msgstr ""
 
-#: ../../changelog.rst:3153
+#: ../../changelog.rst:3160
 msgid "2.22.4 (2018-12-19)"
 msgstr ""
 
-#: ../../changelog.rst:3157
+#: ../../changelog.rst:3164
 msgid ""
 "Replace \\u2028 and \\u2029 by \\n in synced (geo)json files (fix "
 "Geotrek-mobile crash)"
 msgstr ""
 
-#: ../../changelog.rst:3161
+#: ../../changelog.rst:3168
 msgid "Add EID field to all models and increase its length"
 msgstr ""
 
-#: ../../changelog.rst:3165
+#: ../../changelog.rst:3172
 msgid "2.22.3 (2018-12-14)"
 msgstr ""
 
-#: ../../changelog.rst:3169
+#: ../../changelog.rst:3176
 msgid "Don't publish deleted infrastructures/signages"
 msgstr ""
 
-#: ../../changelog.rst:3170
+#: ../../changelog.rst:3177
 msgid "Add default pictograms to published infrastructures/signages"
 msgstr ""
 
-#: ../../changelog.rst:3174
+#: ../../changelog.rst:3181
 msgid "2.22.2 (2018-12-10)"
 msgstr ""
 
-#: ../../changelog.rst:3178
+#: ../../changelog.rst:3185
 msgid "Fix bugs with HTTPS access"
 msgstr ""
 
-#: ../../changelog.rst:3179
+#: ../../changelog.rst:3186
 msgid "Fix for some modules to edit attributes and not the geometry"
 msgstr ""
 
-#: ../../changelog.rst:3183
+#: ../../changelog.rst:3190
 msgid "add options to sync signages and infrastructures"
 msgstr ""
 
-#: ../../changelog.rst:3184
+#: ../../changelog.rst:3191
 msgid "sync global signages and infrastructures"
 msgstr ""
 
-#: ../../changelog.rst:3188
+#: ../../changelog.rst:3195
 msgid "2.22.1 (2018-11-27)"
 msgstr ""
 
-#: ../../changelog.rst:3192
+#: ../../changelog.rst:3199
 msgid "Fix trekking form with pois_excluded"
 msgstr ""
 
-#: ../../changelog.rst:3193
+#: ../../changelog.rst:3200
 msgid ""
 "Give the possibility to get type of infrastructures and signages without "
 "structure"
 msgstr ""
 
-#: ../../changelog.rst:3197
+#: ../../changelog.rst:3204
 msgid "2.22.0 (2018-11-27)"
 msgstr ""
 
-#: ../../changelog.rst:3201
+#: ../../changelog.rst:3208
 msgid "Allow to publish signage and infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:3202
+#: ../../changelog.rst:3209
 msgid "Allow to exclude POIs from a trek"
 msgstr ""
 
-#: ../../changelog.rst:3203
+#: ../../changelog.rst:3210
 msgid "New access rights to edit draft path"
 msgstr ""
 
-#: ../../changelog.rst:3204
+#: ../../changelog.rst:3211
 msgid "New access rights to edit attributes and not the geometry"
 msgstr ""
 
-#: ../../changelog.rst:3205
+#: ../../changelog.rst:3212
 msgid ""
 "Allow to remove duplicate path in database : command "
 "remove_duplicate_paths"
 msgstr ""
 
-#: ../../changelog.rst:3209
+#: ../../changelog.rst:3216
 msgid "Fix snap on crossing point : take all paths easier"
 msgstr ""
 
-#: ../../changelog.rst:3210
+#: ../../changelog.rst:3217
 msgid "Fix a clash between current url and SYNC_RANDO_OPTIONS"
 msgstr ""
 
-#: ../../changelog.rst:3211
+#: ../../changelog.rst:3218
 msgid "Fix screamshotter when SSL is enabled"
 msgstr ""
 
-#: ../../changelog.rst:3215
+#: ../../changelog.rst:3222
 msgid "2.21.1 (2018-09-18)"
 msgstr ""
 
-#: ../../changelog.rst:3219
+#: ../../changelog.rst:3226
 msgid ""
 "Remove type1 from trek API when SPLIT_TREKS_CATEGORIES_BY_PRACTICE is not"
 " set"
 msgstr ""
 
-#: ../../changelog.rst:3220
+#: ../../changelog.rst:3227
 msgid ""
 "Rename Trek category label to Hike in API. You can override this in "
 "geotrek/locale/<language code>/LC_MESSAGES/django.po files"
 msgstr ""
 
-#: ../../changelog.rst:3225
+#: ../../changelog.rst:3232
 msgid "Fix crash in log entries view"
 msgstr ""
 
-#: ../../changelog.rst:3229
+#: ../../changelog.rst:3236
 msgid "Save column sort by module"
 msgstr ""
 
-#: ../../changelog.rst:3230
+#: ../../changelog.rst:3237
 msgid "Rename SITRA to APIDAE"
 msgstr ""
 
-#: ../../changelog.rst:3234
+#: ../../changelog.rst:3241
 msgid "2.21.0 (2018-09-04)"
 msgstr ""
 
-#: ../../changelog.rst:3238
+#: ../../changelog.rst:3245
 msgid "Path deletion warning page now shows linked topologies"
 msgstr ""
 
-#: ../../changelog.rst:3239
+#: ../../changelog.rst:3246
 msgid "Allow to add Dailymotion video attachments"
 msgstr ""
 
-#: ../../changelog.rst:3240
+#: ../../changelog.rst:3247
 msgid ""
 "Add a command to unset structure in lists of choices and group choices "
 "with the same name"
 msgstr ""
 
-#: ../../changelog.rst:3245
+#: ../../changelog.rst:3252
 msgid "Fix Sync_rando View"
 msgstr ""
 
-#: ../../changelog.rst:3246
+#: ../../changelog.rst:3253
 msgid "Fix loaddem"
 msgstr ""
 
-#: ../../changelog.rst:3247
+#: ../../changelog.rst:3254
 msgid "Fix creation of Youtube/Soundcloud attachments"
 msgstr ""
 
-#: ../../changelog.rst:3248
+#: ../../changelog.rst:3255
 msgid "Fix cancellation when editing geometries"
 msgstr ""
 
-#: ../../changelog.rst:3249
+#: ../../changelog.rst:3256
 msgid "Show which structure choices are related to"
 msgstr ""
 
-#: ../../changelog.rst:3250
+#: ../../changelog.rst:3257
 msgid "Add confort and stake filters to path list"
 msgstr ""
 
-#: ../../changelog.rst:3251
+#: ../../changelog.rst:3258
 msgid "Fix sync of touristic contents for mobile app"
 msgstr ""
 
-#: ../../changelog.rst:3255
+#: ../../changelog.rst:3262
 msgid "2.20.1 (2018-07-16)"
 msgstr ""
 
-#: ../../changelog.rst:3259
+#: ../../changelog.rst:3266
 msgid "Fix Completed Filter in Touristic Event"
 msgstr ""
 
-#: ../../changelog.rst:3262
+#: ../../changelog.rst:3269
 msgid "2.20.0 (2018-06-27)"
 msgstr ""
 
-#: ../../changelog.rst:3266
+#: ../../changelog.rst:3273
 msgid ""
 "Allow to share glossaries between structure (just keep structure field "
 "empty)"
 msgstr ""
 
-#: ../../changelog.rst:3267
+#: ../../changelog.rst:3274
 msgid "Allow to import infrastructures, not only signages"
 msgstr ""
 
-#: ../../changelog.rst:3268
+#: ../../changelog.rst:3275
 msgid "Allow to split treks by itinerancy"
 msgstr ""
 
-#: ../../changelog.rst:3269
+#: ../../changelog.rst:3276
 msgid ""
 "Path deletion does not delete the related point topologies anymore. "
 "Instead point topologies are linked to the nearest remaining path."
 msgstr ""
 
-#: ../../changelog.rst:3271
+#: ../../changelog.rst:3278
 msgid "Keep inode and mtime when synced file don't change"
 msgstr ""
 
-#: ../../changelog.rst:3275
+#: ../../changelog.rst:3282
 msgid "Optional img-responsive class on flatpage images"
 msgstr ""
 
-#: ../../changelog.rst:3279
+#: ../../changelog.rst:3286
 msgid "Fix virtualenv install"
 msgstr ""
 
-#: ../../changelog.rst:3280
+#: ../../changelog.rst:3287
 msgid "Upgrade celery to 4.1.1"
 msgstr ""
 
-#: ../../changelog.rst:3281
+#: ../../changelog.rst:3288
 msgid ""
 "Fix the bug which remove a path when we merge 2 paths with a 3rd path on "
 "the point of merge. (ref  #1747)"
 msgstr ""
 
-#: ../../changelog.rst:3285
+#: ../../changelog.rst:3292
 msgid "2.19.1 (2018-05-28)"
 msgstr ""
 
-#: ../../changelog.rst:3289
+#: ../../changelog.rst:3296
 msgid "Update APIDAE API URL"
 msgstr ""
 
-#: ../../changelog.rst:3290
+#: ../../changelog.rst:3297
 msgid "Fix filename encoding errors in import"
 msgstr ""
 
-#: ../../changelog.rst:3294
+#: ../../changelog.rst:3301
 msgid "2.19.0 (2018-05-22)"
 msgstr ""
 
-#: ../../changelog.rst:3298
+#: ../../changelog.rst:3305
 msgid "Allow to specify encoding when importing data"
 msgstr ""
 
-#: ../../changelog.rst:3302
+#: ../../changelog.rst:3309
 msgid "2.18.5 (2018-05-07)"
 msgstr ""
 
-#: ../../changelog.rst:3306
+#: ../../changelog.rst:3313
 msgid "Fix related structure when creating new objects"
 msgstr ""
 
-#: ../../changelog.rst:3310
+#: ../../changelog.rst:3317
 msgid "Show related structure on all detail pages"
 msgstr ""
 
-#: ../../changelog.rst:3314
+#: ../../changelog.rst:3321
 msgid "2.18.4 (2018-05-02)"
 msgstr ""
 
-#: ../../changelog.rst:3318
+#: ../../changelog.rst:3325
 msgid "Fix sync of deleted sensitive areas"
 msgstr ""
 
-#: ../../changelog.rst:3319
+#: ../../changelog.rst:3326
 msgid "Fix touristiccontents.geojson crash when reservation_system is None"
 msgstr ""
 
-#: ../../changelog.rst:3323
+#: ../../changelog.rst:3330
 msgid "Add Ubuntu 18.04 Bionic Beaver support"
 msgstr ""
 
-#: ../../changelog.rst:3327
+#: ../../changelog.rst:3334
 msgid "2.18.3 (2018-04-27)"
 msgstr ""
 
-#: ../../changelog.rst:3331
+#: ../../changelog.rst:3338
 msgid "Fix imports when enabling only sensitivity app"
 msgstr ""
 
-#: ../../changelog.rst:3335
+#: ../../changelog.rst:3342
 msgid "2.18.2 (2018-04-27)"
 msgstr ""
 
-#: ../../changelog.rst:3337 ../../changelog.rst:3381
+#: ../../changelog.rst:3344 ../../changelog.rst:3388
 msgid "**Preventive maintainance**"
 msgstr ""
 
-#: ../../changelog.rst:3339
+#: ../../changelog.rst:3346
 msgid "Upgrade to Django 1.11"
 msgstr ""
 
-#: ../../changelog.rst:3340 ../../changelog.rst:3384
+#: ../../changelog.rst:3347 ../../changelog.rst:3391
 msgid "Upgrade several python dependencies"
 msgstr ""
 
-#: ../../changelog.rst:3344
+#: ../../changelog.rst:3351
 msgid ""
 "Allow user with can_bypass_structure permission to set or update the "
 "related structure on sensitive areas"
 msgstr ""
 
-#: ../../changelog.rst:3349
+#: ../../changelog.rst:3356
 msgid "Put back filter widgets in two columns (#1663)"
 msgstr ""
 
-#: ../../changelog.rst:3350
+#: ../../changelog.rst:3357
 msgid "Do not include (possibly forged) structure field in post requests"
 msgstr ""
 
-#: ../../changelog.rst:3351
+#: ../../changelog.rst:3358
 msgid "Fix geojson format in sensitive areas API"
 msgstr ""
 
-#: ../../changelog.rst:3352
+#: ../../changelog.rst:3359
 msgid "Fix filtering by practices in sensitive areas API"
 msgstr ""
 
-#: ../../changelog.rst:3353
+#: ../../changelog.rst:3360
 msgid "Fix sync_rando when sensitivity app is not enabled"
 msgstr ""
 
-#: ../../changelog.rst:3354
+#: ../../changelog.rst:3361
 msgid "Adapt BiodivParser to API modifications"
 msgstr ""
 
-#: ../../changelog.rst:3355
+#: ../../changelog.rst:3362
 msgid ""
 "Order sensitive areas by decreasing area in API to be able to clic on "
 "each of them"
 msgstr ""
 
-#: ../../changelog.rst:3356
+#: ../../changelog.rst:3363
 msgid "Set ownership in parsers depending on logged user"
 msgstr ""
 
-#: ../../changelog.rst:3357
+#: ../../changelog.rst:3364
 msgid "Pagination requires ordering in v2 API"
 msgstr ""
 
-#: ../../changelog.rst:3361
+#: ../../changelog.rst:3368
 msgid "2.18.1 (2018-03-26)"
 msgstr ""
 
-#: ../../changelog.rst:3365
+#: ../../changelog.rst:3372
 msgid "Fix distribution of tables in schemas"
 msgstr ""
 
-#: ../../changelog.rst:3366
+#: ../../changelog.rst:3373
 msgid "Allow to reset type1/type2 in TouristicContentSitraParser"
 msgstr ""
 
-#: ../../changelog.rst:3370
+#: ../../changelog.rst:3377
 msgid "Do not truncate install.log"
 msgstr ""
 
-#: ../../changelog.rst:3374
+#: ../../changelog.rst:3381
 msgid "2.18.0 (2018-03-22)"
 msgstr ""
 
-#: ../../changelog.rst:3378
+#: ../../changelog.rst:3385
 msgid ""
 "Drop support of Ubuntu Precise 12.04, please upgrade to Trusty 14.04 or "
 "Xenial 16.04 before upgrading Geotrek-admin"
 msgstr ""
 
-#: ../../changelog.rst:3383
+#: ../../changelog.rst:3390
 msgid "Upgrade to Django 1.9"
 msgstr ""
 
-#: ../../changelog.rst:3388
+#: ../../changelog.rst:3395
 msgid "Fix path duplication in path split trigger"
 msgstr ""
 
-#: ../../changelog.rst:3392
+#: ../../changelog.rst:3399
 msgid "Show total path length in path list"
 msgstr ""
 
-#: ../../changelog.rst:3396
+#: ../../changelog.rst:3403
 msgid "2.17.3 (2018-03-23)"
 msgstr ""
 
-#: ../../changelog.rst:3398 ../../changelog.rst:4786 ../../changelog.rst:4796
-#: ../../changelog.rst:4849 ../../changelog.rst:4867
+#: ../../changelog.rst:3405 ../../changelog.rst:4793 ../../changelog.rst:4803
+#: ../../changelog.rst:4856 ../../changelog.rst:4874
 msgid "** Bug fixes **"
 msgstr ""
 
-#: ../../changelog.rst:3400
+#: ../../changelog.rst:3407
 msgid "Fix install"
 msgstr ""
 
-#: ../../changelog.rst:3404
+#: ../../changelog.rst:3411
 msgid "2.17.2 (2018-02-07)"
 msgstr ""
 
-#: ../../changelog.rst:3408
+#: ../../changelog.rst:3415
 msgid ""
 "Use id rather than french name for practices and structure in sensitive "
 "areas API"
 msgstr ""
 
-#: ../../changelog.rst:3409
+#: ../../changelog.rst:3416
 msgid "Add permission to import sensitive areas"
 msgstr ""
 
-#: ../../changelog.rst:3413
+#: ../../changelog.rst:3420
 msgid "2.17.1 (2018-02-02)"
 msgstr ""
 
-#: ../../changelog.rst:3417
+#: ../../changelog.rst:3424
 msgid ""
 "Implantation year on signages and infrastructures is now a filter with "
 "current existing values"
 msgstr ""
 
-#: ../../changelog.rst:3418
+#: ../../changelog.rst:3425
 msgid "Trek form field 'practice' is moved to first panel"
 msgstr ""
 
-#: ../../changelog.rst:3419
+#: ../../changelog.rst:3426
 msgid "Add sensitive areas to public trek PDF"
 msgstr ""
 
-#: ../../changelog.rst:3420
+#: ../../changelog.rst:3427
 msgid "Do not show paths on PDF"
 msgstr ""
 
-#: ../../changelog.rst:3421
+#: ../../changelog.rst:3428
 msgid "Add SENSITIVE_AREA_INTERSECTION_MARGIN setting"
 msgstr ""
 
-#: ../../changelog.rst:3425
+#: ../../changelog.rst:3432
 msgid "Fix snapping"
 msgstr ""
 
-#: ../../changelog.rst:3426
+#: ../../changelog.rst:3433
 msgid "Fix import of sensitive areas when languages lists do not match"
 msgstr ""
 
-#: ../../changelog.rst:3427
+#: ../../changelog.rst:3434
 msgid "Fix trail links in project detail view"
 msgstr ""
 
-#: ../../changelog.rst:3428
+#: ../../changelog.rst:3435
 msgid "Add 'approved' field in touristic content and event exports"
 msgstr ""
 
-#: ../../changelog.rst:3429
+#: ../../changelog.rst:3436
 msgid "Fix service type with specials character in trek detail"
 msgstr ""
 
-#: ../../changelog.rst:3430
+#: ../../changelog.rst:3437
 msgid "Fix bbox filtering in sensitive areas API"
 msgstr ""
 
-#: ../../changelog.rst:3431
+#: ../../changelog.rst:3438
 msgid "Add CORS header to sensitive areas API"
 msgstr ""
 
-#: ../../changelog.rst:3432
+#: ../../changelog.rst:3439
 msgid "Filter on spatial extent when importing from Biodiv'sport"
 msgstr ""
 
-#: ../../changelog.rst:3433
+#: ../../changelog.rst:3440
 msgid "Fix celery task runner version"
 msgstr ""
 
-#: ../../changelog.rst:3437
+#: ../../changelog.rst:3444
 msgid "2.17.0 (2018-01-15)"
 msgstr ""
 
-#: ../../changelog.rst:3441
+#: ../../changelog.rst:3448
 msgid "Sensitive Areas"
 msgstr ""
 
-#: ../../changelog.rst:3445
+#: ../../changelog.rst:3452
 msgid "2.16.1 (2018-01-10)"
 msgstr ""
 
-#: ../../changelog.rst:3449
+#: ../../changelog.rst:3456
 msgid "Fix encoding errors while generating static versions of rando pages"
 msgstr ""
 
-#: ../../changelog.rst:3450
+#: ../../changelog.rst:3457
 msgid "SEO for static versions of rando pages"
 msgstr ""
 
-#: ../../changelog.rst:3451
+#: ../../changelog.rst:3458
 msgid "Disable template caching (fix ODT generation)"
 msgstr ""
 
-#: ../../changelog.rst:3455
+#: ../../changelog.rst:3462
 msgid "2.16.0 (2017-12-21)"
 msgstr ""
 
-#: ../../changelog.rst:3459
+#: ../../changelog.rst:3466
 msgid "Create static versions of rando pages with opengraph data (Facebook)"
 msgstr ""
 
-#: ../../changelog.rst:3460
+#: ../../changelog.rst:3467
 msgid "Add external id field to POI form"
 msgstr ""
 
-#: ../../changelog.rst:3464
+#: ../../changelog.rst:3471
 msgid "Fix download of python packages for pypi.python.org (SSL is now required)"
 msgstr ""
 
-#: ../../changelog.rst:3465
+#: ../../changelog.rst:3472
 msgid "API v2 : Fix full URL pictures in nested serializers"
 msgstr ""
 
-#: ../../changelog.rst:3466
+#: ../../changelog.rst:3473
 msgid "Fix network SVG (add viewbox) to make them visible in Geotrek-rando"
 msgstr ""
 
-#: ../../changelog.rst:3467
+#: ../../changelog.rst:3474
 msgid "Hide file parsers form if no one is available"
 msgstr ""
 
-#: ../../changelog.rst:3471
+#: ../../changelog.rst:3478
 msgid "2.15.2 (2017-09-28)"
 msgstr ""
 
-#: ../../changelog.rst:3475
+#: ../../changelog.rst:3482
 msgid ""
 "Fix existing path split in particular cases where postgis doesn't see "
 "real intersections."
 msgstr ""
 
-#: ../../changelog.rst:3476
+#: ../../changelog.rst:3483
 msgid "Fix project and intervention detail template."
 msgstr ""
 
-#: ../../changelog.rst:3477
+#: ../../changelog.rst:3484
 msgid "Fix synchronization of POI media other than images"
 msgstr ""
 
-#: ../../changelog.rst:3478
+#: ../../changelog.rst:3485
 msgid "Include pois, parking and reference points to compute PDF map zoom"
 msgstr ""
 
-#: ../../changelog.rst:3482
+#: ../../changelog.rst:3489
 msgid "2.15.1 (2017-08-23)"
 msgstr ""
 
-#: ../../changelog.rst:3486
+#: ../../changelog.rst:3493
 msgid "Add es translation for PDF"
 msgstr ""
 
-#: ../../changelog.rst:3487
+#: ../../changelog.rst:3494
 msgid "Add mailssl setting"
 msgstr ""
 
-#: ../../changelog.rst:3491
+#: ../../changelog.rst:3498
 msgid "Fix APIDAE import illustrations"
 msgstr ""
 
-#: ../../changelog.rst:3492
+#: ../../changelog.rst:3499
 msgid "Fix double import parsers"
 msgstr ""
 
-#: ../../changelog.rst:3493
+#: ../../changelog.rst:3500
 msgid "Fix cirkwi export"
 msgstr ""
 
-#: ../../changelog.rst:3494
+#: ../../changelog.rst:3501
 msgid "Select only published POIs in GPX and KML files"
 msgstr ""
 
-#: ../../changelog.rst:3495
+#: ../../changelog.rst:3502
 msgid "Remove deprecated experimental setting"
 msgstr ""
 
-#: ../../changelog.rst:3496
+#: ../../changelog.rst:3503
 msgid "Fix HTML tags & entities in feedback email"
 msgstr ""
 
-#: ../../changelog.rst:3500
+#: ../../changelog.rst:3507
 msgid "2.15.0 (2017-07-13)"
 msgstr ""
 
-#: ../../changelog.rst:3504
+#: ../../changelog.rst:3511
 msgid ""
 "API v2 Beta 1. Optimized multilingual filtered endpoints for paths, "
 "treks, tours and pois."
 msgstr ""
 
-#: ../../changelog.rst:3505
+#: ../../changelog.rst:3512
 msgid ""
 "See HTML doc and examples in /api/v2/. Authentication with Basic HTTP "
 "(https://en.wikipedia.org/wiki/Basic_access_authentication)."
 msgstr ""
 
-#: ../../changelog.rst:3506
+#: ../../changelog.rst:3513
 msgid "Don't use it in production without HTTPS"
 msgstr ""
 
-#: ../../changelog.rst:3510
+#: ../../changelog.rst:3517
 msgid "Fix pdf default public templates (weasyprint)"
 msgstr ""
 
-#: ../../changelog.rst:3511
+#: ../../changelog.rst:3518
 msgid "Fix screamshotter standalone install (map screenshots)"
 msgstr ""
 
-#: ../../changelog.rst:3515
+#: ../../changelog.rst:3522
 msgid "2.14.3 (2017-07-03)"
 msgstr ""
 
-#: ../../changelog.rst:3519
+#: ../../changelog.rst:3526
 msgid "Cirkwi export fixes and improvements"
 msgstr ""
 
-#: ../../changelog.rst:3523
+#: ../../changelog.rst:3530
 msgid "2.14.2 (2017-06-21)"
 msgstr ""
 
-#: ../../changelog.rst:3527
+#: ../../changelog.rst:3534
 msgid "Fix attachments edition"
 msgstr ""
 
-#: ../../changelog.rst:3531
+#: ../../changelog.rst:3538
 msgid "2.14.1 (2017-06-22)"
 msgstr ""
 
-#: ../../changelog.rst:3535
+#: ../../changelog.rst:3542
 msgid "Refactor signals pre / post migrate according Django 1.8"
 msgstr ""
 
-#: ../../changelog.rst:3536 ../../changelog.rst:3658
+#: ../../changelog.rst:3543 ../../changelog.rst:3665
 msgid "Update translations"
 msgstr ""
 
-#: ../../changelog.rst:3537
+#: ../../changelog.rst:3544
 msgid "Fix path splitting"
 msgstr ""
 
-#: ../../changelog.rst:3538
+#: ../../changelog.rst:3545
 msgid "Fix AutoLogin Middleware with mapentity 3.1.4"
 msgstr ""
 
-#: ../../changelog.rst:3542
+#: ../../changelog.rst:3549
 msgid "2.14.0"
 msgstr ""
 
-#: ../../changelog.rst:3546
+#: ../../changelog.rst:3553
 msgid "Upgrade to version 2.14.0 is only possible from version 2.13.0"
 msgstr ""
 
-#: ../../changelog.rst:3550
+#: ../../changelog.rst:3557
 msgid ""
 "Upgrade to Django 1.8. This is a big step, migrations are reset, please "
 "backup before upgrade."
 msgstr ""
 
-#: ../../changelog.rst:3551
+#: ../../changelog.rst:3558
 msgid "Ability to skip attachment download in parsers and use external links."
 msgstr ""
 
-#: ../../changelog.rst:3555
+#: ../../changelog.rst:3562
 msgid ""
 "Possibility to exclude pois in cirkwi xml export by adding ?withoutpois=1"
 " to url (http://XXXXX/api/cirkwi/circuits.xml?withoutpois=1"
 msgstr ""
 
-#: ../../changelog.rst:3556
+#: ../../changelog.rst:3563
 msgid ""
 "Add MOBILE_TILES_EXTENSION setting (for compatibility with old mobile "
 "apps, set it to 'png')"
 msgstr ""
 
-#: ../../changelog.rst:3557
+#: ../../changelog.rst:3564
 msgid "API optimization"
 msgstr ""
 
-#: ../../changelog.rst:3558
+#: ../../changelog.rst:3565
 msgid "Disable auto size for service icon in trek description."
 msgstr ""
 
-#: ../../changelog.rst:3562 ../../changelog.rst:3593
+#: ../../changelog.rst:3569 ../../changelog.rst:3600
 msgid "Fix topologies and cities intersections"
 msgstr ""
 
-#: ../../changelog.rst:3566
+#: ../../changelog.rst:3573
 msgid "2.13.0 (2017-03-02)"
 msgstr ""
 
-#: ../../changelog.rst:3570
+#: ../../changelog.rst:3577
 msgid ""
 "MOBILE_TILES_URL settings is now a list which can be used to merge "
 "different layers in mobile application"
 msgstr ""
 
-#: ../../changelog.rst:3575
+#: ../../changelog.rst:3582
 msgid "2.12.0 (2017-02-16)"
 msgstr ""
 
-#: ../../changelog.rst:3579
+#: ../../changelog.rst:3586
 msgid "add loadsignage command"
 msgstr ""
 
-#: ../../changelog.rst:3583
+#: ../../changelog.rst:3590
 msgid "add field implantation_year to model BaseInfrastructure"
 msgstr ""
 
-#: ../../changelog.rst:3584
+#: ../../changelog.rst:3591
 msgid "add field owner to model LandEdge"
 msgstr ""
 
-#: ../../changelog.rst:3585
+#: ../../changelog.rst:3592
 msgid "add field agreement to model LandEdge"
 msgstr ""
 
-#: ../../changelog.rst:3589
+#: ../../changelog.rst:3596
 msgid "2.11.5 (2017-02-06)"
 msgstr ""
 
-#: ../../changelog.rst:3597
+#: ../../changelog.rst:3604
 msgid "2.11.4 (2017-02-01)"
 msgstr ""
 
-#: ../../changelog.rst:3601
+#: ../../changelog.rst:3608
 msgid "Remove deprecated datasource (replaced by import parsers)"
 msgstr ""
 
-#: ../../changelog.rst:3602
+#: ../../changelog.rst:3609
 msgid "Stop install.sh if make update or wget fails"
 msgstr ""
 
-#: ../../changelog.rst:3603
+#: ../../changelog.rst:3610
 msgid "Create database with right owner if user exists but database does not"
 msgstr ""
 
-#: ../../changelog.rst:3604
+#: ../../changelog.rst:3611
 msgid "Make sure supervisor service is started after install"
 msgstr ""
 
-#: ../../changelog.rst:3605
+#: ../../changelog.rst:3612
 msgid "Fix HTML entities in feedback email"
 msgstr ""
 
-#: ../../changelog.rst:3606
+#: ../../changelog.rst:3613
 msgid "Fix cirkwi export for treks with multilinestring geom"
 msgstr ""
 
-#: ../../changelog.rst:3610
+#: ../../changelog.rst:3617
 msgid "Add filter usages on paths"
 msgstr ""
 
-#: ../../changelog.rst:3611
+#: ../../changelog.rst:3618
 msgid "Add filters name and description on infrastructures and signages"
 msgstr ""
 
-#: ../../changelog.rst:3612
+#: ../../changelog.rst:3619
 msgid "Add picture to PDF for feedback reports (only in Weasyprint mode)"
 msgstr ""
 
-#: ../../changelog.rst:3616
+#: ../../changelog.rst:3623
 msgid "2.11.3 (2016-11-15)"
 msgstr ""
 
-#: ../../changelog.rst:3620
+#: ../../changelog.rst:3627
 msgid "Upgrade mapentity (fix map centering in PDF exports)"
 msgstr ""
 
-#: ../../changelog.rst:3621
+#: ../../changelog.rst:3628
 msgid "Fix cirkwi export when trek geom is not a linestring"
 msgstr ""
 
-#: ../../changelog.rst:3625
+#: ../../changelog.rst:3632
 msgid "2.11.2 (2016-09-15)"
 msgstr ""
 
-#: ../../changelog.rst:3629
+#: ../../changelog.rst:3636
 msgid "Do not synchronize not-published treks with published but deleted parents"
 msgstr ""
 
-#: ../../changelog.rst:3630
+#: ../../changelog.rst:3637
 msgid "Allow to specify portal in touristic content parsers"
 msgstr ""
 
-#: ../../changelog.rst:3631
+#: ../../changelog.rst:3638
 msgid "Fix import of type1 in HebergementsSitraParser"
 msgstr ""
 
-#: ../../changelog.rst:3632
+#: ../../changelog.rst:3639
 msgid "Fix source and portal missing in shapefile exports"
 msgstr ""
 
-#: ../../changelog.rst:3636
+#: ../../changelog.rst:3643
 msgid "Improve performances of DEM computation for huge treks"
 msgstr ""
 
-#: ../../changelog.rst:3640
+#: ../../changelog.rst:3647
 msgid "2.11.1 (2016-08-17)"
 msgstr ""
 
-#: ../../changelog.rst:3644
+#: ../../changelog.rst:3651
 msgid "Fix slug URL for \"oe\" ligature"
 msgstr ""
 
-#: ../../changelog.rst:3645
+#: ../../changelog.rst:3652
 msgid "Improve zoom of map captures in PDF"
 msgstr ""
 
-#: ../../changelog.rst:3649
+#: ../../changelog.rst:3656
 msgid "2.11.0 (2016-08-02)"
 msgstr ""
 
-#: ../../changelog.rst:3653
+#: ../../changelog.rst:3660
 msgid "Fix weasyprint install"
 msgstr ""
 
-#: ../../changelog.rst:3654
+#: ../../changelog.rst:3661
 msgid "Fix label displayed twice with Sitra Parser"
 msgstr ""
 
-#: ../../changelog.rst:3659
+#: ../../changelog.rst:3666
 msgid "Update import documentation"
 msgstr ""
 
-#: ../../changelog.rst:3660
+#: ../../changelog.rst:3667
 msgid "Record source is no nore structure related"
 msgstr ""
 
-#: ../../changelog.rst:3664
+#: ../../changelog.rst:3671
 msgid "ability to filter synchronized content with different portals"
 msgstr ""
 
-#: ../../changelog.rst:3668
+#: ../../changelog.rst:3675
 msgid "2.10.4 (2016-05-19)"
 msgstr ""
 
-#: ../../changelog.rst:3672
+#: ../../changelog.rst:3679
 msgid ""
 "Deprecate MAPENTITY_WEASYPRINT setting. Now public PDF use Weasyprint "
 "HTML templates and private PDF use legacy ODT template."
 msgstr ""
 
-#: ../../changelog.rst:3677
+#: ../../changelog.rst:3684
 msgid "Improve altitude profile computation (increase smoothing)"
 msgstr ""
 
-#: ../../changelog.rst:3678
+#: ../../changelog.rst:3685
 msgid "Improve HTML templates for public exports"
 msgstr ""
 
-#: ../../changelog.rst:3679
+#: ../../changelog.rst:3686
 msgid "Improve SITRA parser"
 msgstr ""
 
-#: ../../changelog.rst:3680
+#: ../../changelog.rst:3687
 msgid "Allow to use source variable in PDF templates"
 msgstr ""
 
-#: ../../changelog.rst:3684
+#: ../../changelog.rst:3691
 msgid "Fix comparison of zip files to keep mtime when nothing changed"
 msgstr ""
 
-#: ../../changelog.rst:3685
+#: ../../changelog.rst:3692
 msgid "Upgrade simplekml lib (should fix KML exports)"
 msgstr ""
 
-#: ../../changelog.rst:3689
+#: ../../changelog.rst:3696
 msgid "2.10.3 (2016-05-11)"
 msgstr ""
 
-#: ../../changelog.rst:3693
+#: ../../changelog.rst:3700
 msgid "Update default pictograms for touristic content categories"
 msgstr ""
 
-#: ../../changelog.rst:3694
+#: ../../changelog.rst:3701
 msgid "Update default pictograms for themes"
 msgstr ""
 
-#: ../../changelog.rst:3698
+#: ../../changelog.rst:3705
 msgid "Workaround a bun in supervisor init script"
 msgstr ""
 
-#: ../../changelog.rst:3699
+#: ../../changelog.rst:3706
 msgid "Fix multilinestring instead of linestring in trek shapefile parser"
 msgstr ""
 
-#: ../../changelog.rst:3703
+#: ../../changelog.rst:3710
 msgid "2.10.2 (2016-04-12)"
 msgstr ""
 
-#: ../../changelog.rst:3707
+#: ../../changelog.rst:3714
 msgid "Add source filter to touristic contents/events"
 msgstr ""
 
-#: ../../changelog.rst:3708
+#: ../../changelog.rst:3715
 msgid "Allow installation as root (not recommended, use with caution)"
 msgstr ""
 
-#: ../../changelog.rst:3712
+#: ../../changelog.rst:3719
 msgid "Restore contents deleted and then created again in EspritParcParser"
 msgstr ""
 
-#: ../../changelog.rst:3713
+#: ../../changelog.rst:3720
 msgid "Add a warning if type1/type2 is not created in EspritParcParser"
 msgstr ""
 
-#: ../../changelog.rst:3714
+#: ../../changelog.rst:3721
 msgid "Replace input by textarea in flatpage form"
 msgstr ""
 
-#: ../../changelog.rst:3718
+#: ../../changelog.rst:3725
 msgid "2.10.1 (2016-03-17)"
 msgstr ""
 
-#: ../../changelog.rst:3722
+#: ../../changelog.rst:3729
 msgid ""
 "Allow access to information desks in API (and so to map capture and PDF) "
 "for unpublished treks"
 msgstr ""
 
-#: ../../changelog.rst:3726
+#: ../../changelog.rst:3733
 msgid "Parsers improvements"
 msgstr ""
 
-#: ../../changelog.rst:3730
+#: ../../changelog.rst:3737
 msgid "2.10.0 (2016-03-03)"
 msgstr ""
 
-#: ../../changelog.rst:3734
+#: ../../changelog.rst:3741
 msgid "Add support for Ubuntu 15.04 Vivid"
 msgstr ""
 
-#: ../../changelog.rst:3738
+#: ../../changelog.rst:3745
 msgid ""
 "Remove TileCache service (you should set up tiles source with "
 "LEAFLET_CONFIG variable in `geotrek/settings/custom.py` now)"
 msgstr ""
 
-#: ../../changelog.rst:3739
+#: ../../changelog.rst:3746
 msgid ""
 "Run supervisor as root (you should now run `sudo supervisorctl` instead "
 "of `./bin/supervisor`)"
 msgstr ""
 
-#: ../../changelog.rst:3740
+#: ../../changelog.rst:3747
 msgid "Move nginx and supervisor logs to system dir `/var/log/`"
 msgstr ""
 
-#: ../../changelog.rst:3744
+#: ../../changelog.rst:3751
 msgid "Update default pictograms for difficulty levels"
 msgstr ""
 
-#: ../../changelog.rst:3748
+#: ../../changelog.rst:3755
 msgid "Fix sync_rando after deleting a trek with children"
 msgstr ""
 
-#: ../../changelog.rst:3752
+#: ../../changelog.rst:3759
 msgid "2.9.3 (2016-02-25)"
 msgstr ""
 
-#: ../../changelog.rst:3756
+#: ../../changelog.rst:3763
 msgid "Fix line break at start of contact in EspritParcParser"
 msgstr ""
 
-#: ../../changelog.rst:3760
+#: ../../changelog.rst:3767
 msgid "Add parameters.json and themes.json files to API"
 msgstr ""
 
-#: ../../changelog.rst:3764
+#: ../../changelog.rst:3771
 msgid "2.9.2 (2016-02-17)"
 msgstr ""
 
-#: ../../changelog.rst:3768
+#: ../../changelog.rst:3775
 msgid "Increase web link size"
 msgstr ""
 
-#: ../../changelog.rst:3772
+#: ../../changelog.rst:3779
 msgid "Fix path split"
 msgstr ""
 
-#: ../../changelog.rst:3773
+#: ../../changelog.rst:3780
 msgid "Fix attachment parsing with same document type for several structures"
 msgstr ""
 
-#: ../../changelog.rst:3777
+#: ../../changelog.rst:3784
 msgid "2.9.1 (2016-02-10)"
 msgstr ""
 
-#: ../../changelog.rst:3781
+#: ../../changelog.rst:3788
 msgid "Don't forget to sync touristic contents/events media when skipping PDF"
 msgstr ""
 
-#: ../../changelog.rst:3782
+#: ../../changelog.rst:3789
 msgid "Don't delete attachments of other objects when importing"
 msgstr ""
 
-#: ../../changelog.rst:3783
+#: ../../changelog.rst:3790
 msgid "Don't delete other objects when constant fields are set in parsers"
 msgstr ""
 
-#: ../../changelog.rst:3787
+#: ../../changelog.rst:3794
 msgid "2.9.0 (2016-02-04)"
 msgstr ""
 
-#: ../../changelog.rst:3791
+#: ../../changelog.rst:3798
 msgid "Add parser for brand \"Esprit Parc National\""
 msgstr ""
 
-#: ../../changelog.rst:3795
+#: ../../changelog.rst:3802
 msgid "Set user structure as related structure for all new objects"
 msgstr ""
 
-#: ../../changelog.rst:3799
+#: ../../changelog.rst:3806
 msgid "2.8.1 (2016-01-29)"
 msgstr ""
 
-#: ../../changelog.rst:3803
+#: ../../changelog.rst:3810
 msgid "Synchronize information desk thumbnails"
 msgstr ""
 
-#: ../../changelog.rst:3807
+#: ../../changelog.rst:3814
 msgid "2.8.0 (2016-01-28)"
 msgstr ""
 
-#: ../../changelog.rst:3811
+#: ../../changelog.rst:3818
 msgid "Use POI pictures in PDF if the trek has no picture itself"
 msgstr ""
 
-#: ../../changelog.rst:3812
+#: ../../changelog.rst:3819
 msgid "Use a placeholder in PDF if there is no picture"
 msgstr ""
 
-#: ../../changelog.rst:3813
+#: ../../changelog.rst:3820
 msgid "Parser to import touristic contents from SITRA"
 msgstr ""
 
-#: ../../changelog.rst:3814
+#: ../../changelog.rst:3821
 msgid "Add list of all information desks to API"
 msgstr ""
 
-#: ../../changelog.rst:3818
+#: ../../changelog.rst:3825
 msgid "Allow NULL values for id_externe fields in database"
 msgstr ""
 
-#: ../../changelog.rst:3819
+#: ../../changelog.rst:3826
 msgid "Fix missing elements (eg. POI enumeration) on trek map capture"
 msgstr ""
 
-#: ../../changelog.rst:3820
+#: ../../changelog.rst:3827
 msgid "Prevent overlaping controls at bottom of list view"
 msgstr ""
 
-#: ../../changelog.rst:3821
+#: ../../changelog.rst:3828
 msgid "Translation of column names in shapefiles export"
 msgstr ""
 
-#: ../../changelog.rst:3822
+#: ../../changelog.rst:3829
 msgid "UTF-8 and truncated alerts in shapefile export"
 msgstr ""
 
-#: ../../changelog.rst:3826
+#: ../../changelog.rst:3833
 msgid "2.7.2 (2016-01-26)"
 msgstr ""
 
-#: ../../changelog.rst:3830
+#: ../../changelog.rst:3837
 msgid "Synchronize touristic events with no end date"
 msgstr ""
 
-#: ../../changelog.rst:3831
+#: ../../changelog.rst:3838
 msgid "Fix PDF synchronization (eg. missing list of POI)"
 msgstr ""
 
-#: ../../changelog.rst:3835
+#: ../../changelog.rst:3842
 msgid "2.7.1 (2016-01-18)"
 msgstr ""
 
-#: ../../changelog.rst:3839
+#: ../../changelog.rst:3846
 msgid "Fix random z-index on forced layer polygon"
 msgstr ""
 
-#: ../../changelog.rst:3840
+#: ../../changelog.rst:3847
 msgid "Fix pretty duration"
 msgstr ""
 
-#: ../../changelog.rst:3844
+#: ../../changelog.rst:3851
 msgid "2.7.0 (2016-01-14)"
 msgstr ""
 
-#: ../../changelog.rst:3848
+#: ../../changelog.rst:3855
 msgid "New button to add Youtube videos in flat pages"
 msgstr ""
 
-#: ../../changelog.rst:3852
+#: ../../changelog.rst:3859
 msgid "Fix iframe inclusion in flatpages."
 msgstr ""
 
-#: ../../changelog.rst:3853
+#: ../../changelog.rst:3860
 msgid "Fix double column buttons in gridmanager."
 msgstr ""
 
-#: ../../changelog.rst:3854
+#: ../../changelog.rst:3861
 msgid "Fix validation on flatpages for combo external_url + content."
 msgstr ""
 
-#: ../../changelog.rst:3855
+#: ../../changelog.rst:3862
 msgid "Fix responsive layout for provided templates in flatpages."
 msgstr ""
 
-#: ../../changelog.rst:3856
+#: ../../changelog.rst:3863
 msgid "Fix event link to closest visible path only"
 msgstr ""
 
-#: ../../changelog.rst:3857
+#: ../../changelog.rst:3864
 msgid "Do not log anymore an error when submitting a form with an empty geometry"
 msgstr ""
 
-#: ../../changelog.rst:3861
+#: ../../changelog.rst:3868
 msgid "2.6.0 (2015-12-30)"
 msgstr ""
 
-#: ../../changelog.rst:3865
+#: ../../changelog.rst:3872
 msgid "Customization of practices ordering"
 msgstr ""
 
-#: ../../changelog.rst:3869
+#: ../../changelog.rst:3876
 msgid "Synchronize record source pictograms"
 msgstr ""
 
-#: ../../changelog.rst:3870
+#: ../../changelog.rst:3877
 msgid "Add buttons to attachment update form"
 msgstr ""
 
-#: ../../changelog.rst:3871
+#: ../../changelog.rst:3878
 msgid "Fix timestamps in database when connection with timezone other than UTC"
 msgstr ""
 
-#: ../../changelog.rst:3875
+#: ../../changelog.rst:3882
 msgid "2.5.2 (2015-12-29)"
 msgstr ""
 
-#: ../../changelog.rst:3879
+#: ../../changelog.rst:3886
 msgid "Fix hyphenation language in public PDF templates"
 msgstr ""
 
-#: ../../changelog.rst:3880
+#: ../../changelog.rst:3887
 msgid "Add parents to trek public PDF template"
 msgstr ""
 
-#: ../../changelog.rst:3881
+#: ../../changelog.rst:3888
 msgid "Fix numbering style in trek public PDF template"
 msgstr ""
 
-#: ../../changelog.rst:3882
+#: ../../changelog.rst:3889
 msgid "Show points of reference over other features on trek detail map"
 msgstr ""
 
-#: ../../changelog.rst:3886
+#: ../../changelog.rst:3893
 msgid "2.5.1 (2015-12-18)"
 msgstr ""
 
-#: ../../changelog.rst:3890
+#: ../../changelog.rst:3897
 msgid ""
 "Trek public PDF fixes (size of service pictos, style of numbered lists, "
 "stages)"
 msgstr ""
 
-#: ../../changelog.rst:3894
+#: ../../changelog.rst:3901
 msgid "2.5.0 (2015-12-08)"
 msgstr ""
 
-#: ../../changelog.rst:3898
+#: ../../changelog.rst:3905
 msgid ""
 "Order has been added to flatpages which is reflected in the export for "
 "geotrek-rando frontend."
 msgstr ""
 
-#: ../../changelog.rst:3899
+#: ../../changelog.rst:3906
 msgid "Added 2 templates buttons for flatpages creating two layouts"
 msgstr ""
 
-#: ../../changelog.rst:3900
+#: ../../changelog.rst:3907
 msgid "Option to add pois pictures to trek ones in Geotrek-Rando"
 msgstr ""
 
-#: ../../changelog.rst:3904
+#: ../../changelog.rst:3911
 msgid "Generate tiles zip files for all children of published treks"
 msgstr ""
 
-#: ../../changelog.rst:3905
+#: ../../changelog.rst:3912
 msgid "Fix URL of video/audio media in API"
 msgstr ""
 
-#: ../../changelog.rst:3906
+#: ../../changelog.rst:3913
 msgid "Fix default filtering of past touristic events in UI"
 msgstr ""
 
-#: ../../changelog.rst:3910
+#: ../../changelog.rst:3917
 msgid "2.4.4 (2015-12-02)"
 msgstr ""
 
-#: ../../changelog.rst:3914
+#: ../../changelog.rst:3921
 msgid "Show pending import/sync tasks"
 msgstr ""
 
-#: ../../changelog.rst:3917
+#: ../../changelog.rst:3924
 msgid "2.4.3 (2015-11-27)"
 msgstr ""
 
-#: ../../changelog.rst:3921
+#: ../../changelog.rst:3928
 msgid "Fix filtering by source in sync_rando for flatpages and tiles too"
 msgstr ""
 
-#: ../../changelog.rst:3925
+#: ../../changelog.rst:3932
 msgid "2.4.2 (2015-11-26)"
 msgstr ""
 
-#: ../../changelog.rst:3929
+#: ../../changelog.rst:3936
 msgid "Fix permissions of sync rando output directory"
 msgstr ""
 
-#: ../../changelog.rst:3930
+#: ../../changelog.rst:3937
 msgid "Fix filtering by source in sync_rando"
 msgstr ""
 
-#: ../../changelog.rst:3934
+#: ../../changelog.rst:3941
 msgid "2.4.1 (2015-11-25)"
 msgstr ""
 
-#: ../../changelog.rst:3938
+#: ../../changelog.rst:3945
 msgid "Condition field of infrastructures is no more required"
 msgstr ""
 
-#: ../../changelog.rst:3939
+#: ../../changelog.rst:3946
 msgid "Fix zipfile detection at import."
 msgstr ""
 
-#: ../../changelog.rst:3940
+#: ../../changelog.rst:3947
 msgid "Fix error handling at import (raise exception to browser)."
 msgstr ""
 
-#: ../../changelog.rst:3944
+#: ../../changelog.rst:3951
 msgid "2.4.0 (2015-11-18)"
 msgstr ""
 
-#: ../../changelog.rst:3948
+#: ../../changelog.rst:3955
 msgid "Paths can be merged"
 msgstr ""
 
-#: ../../changelog.rst:3949
+#: ../../changelog.rst:3956
 msgid "Add trek parents to API"
 msgstr ""
 
-#: ../../changelog.rst:3950
+#: ../../changelog.rst:3957
 msgid "Allow to sync public web site from web interface"
 msgstr ""
 
-#: ../../changelog.rst:3951
+#: ../../changelog.rst:3958
 msgid "Add begin and end dates to touristic events list"
 msgstr ""
 
-#: ../../changelog.rst:3952
+#: ../../changelog.rst:3959
 msgid "Filter conmpleted touristic events by default"
 msgstr ""
 
-#: ../../changelog.rst:3956
+#: ../../changelog.rst:3963
 msgid "Prevent concurrent imports and/or synchronization"
 msgstr ""
 
-#: ../../changelog.rst:3957
+#: ../../changelog.rst:3964
 msgid "Fix rendering of HTML markup in weasyprint templates"
 msgstr ""
 
-#: ../../changelog.rst:3958
+#: ../../changelog.rst:3965
 msgid "Fix missing publication field in some cases"
 msgstr ""
 
-#: ../../changelog.rst:3962
+#: ../../changelog.rst:3969
 msgid "2.3.0 (2015-11-09)"
 msgstr ""
 
-#: ../../changelog.rst:3966
+#: ../../changelog.rst:3973
 msgid "Sync rando now synchronizes touristic contents and events."
 msgstr ""
 
-#: ../../changelog.rst:3967
+#: ../../changelog.rst:3974
 msgid "Sync rando now exports only future events based on current date."
 msgstr ""
 
-#: ../../changelog.rst:3968
+#: ../../changelog.rst:3975
 msgid "Sync rando now synchronizes touristic content categories."
 msgstr ""
 
-#: ../../changelog.rst:3972
+#: ../../changelog.rst:3979
 msgid ""
 "Added a custom validation to accept url only contribution in flatpages "
 "without content."
 msgstr ""
 
-#: ../../changelog.rst:3973
+#: ../../changelog.rst:3980
 msgid "Sync rando now handles crashes when it calls django views."
 msgstr ""
 
-#: ../../changelog.rst:3977
+#: ../../changelog.rst:3984
 msgid "2.2.0 (2015-10-09)"
 msgstr ""
 
-#: ../../changelog.rst:3981
+#: ../../changelog.rst:3988
 msgid "Added normalisation for altimetry's json export"
 msgstr ""
 
-#: ../../changelog.rst:3982
+#: ../../changelog.rst:3989
 msgid "Clarify 2D/3D lengths (fixes #1400)"
 msgstr ""
 
-#: ../../changelog.rst:3986
+#: ../../changelog.rst:3993
 msgid "Change plural on accessibility label for admin filter"
 msgstr ""
 
-#: ../../changelog.rst:3990
+#: ../../changelog.rst:3997
 msgid "2.1.0 (2015-09-29)"
 msgstr ""
 
-#: ../../changelog.rst:3994
+#: ../../changelog.rst:4001
 msgid ""
 "Instead of storing the parent of a trek, Geotrek now stores the children "
 "of a trek. This allows to use the same trek in several parents and to "
@@ -6950,805 +6961,805 @@ msgid ""
 "have to set them again after upgrade. Fixes #1479"
 msgstr ""
 
-#: ../../changelog.rst:4001
+#: ../../changelog.rst:4008
 msgid "Add trek infos (aka services for now)"
 msgstr ""
 
-#: ../../changelog.rst:4002
+#: ../../changelog.rst:4009
 msgid "Add email sent to reporting user after submit"
 msgstr ""
 
-#: ../../changelog.rst:4003
+#: ../../changelog.rst:4010
 msgid "Handle multiple reservation systems (fixes #1488)"
 msgstr ""
 
-#: ../../changelog.rst:4004
+#: ../../changelog.rst:4011
 msgid "Add an option to sync_rando to filter by source (fixes #1480)"
 msgstr ""
 
-#: ../../changelog.rst:4005
+#: ../../changelog.rst:4012
 msgid "Add add condition field to infrastructure table (fixes #1494)"
 msgstr ""
 
-#: ../../changelog.rst:4006
+#: ../../changelog.rst:4013
 msgid "New Geotrek logo"
 msgstr ""
 
-#: ../../changelog.rst:4010
+#: ../../changelog.rst:4017
 msgid "Reload supervisor configuration after Geotrek upgrade"
 msgstr ""
 
-#: ../../changelog.rst:4011
+#: ../../changelog.rst:4018
 msgid "Fix projection of waypoints in GPX exports"
 msgstr ""
 
-#: ../../changelog.rst:4012
+#: ../../changelog.rst:4019
 msgid ""
 "Prevent unnecessary save for geom fields if they are not updated. This "
 "prevents triggering geom recalculation in postgres."
 msgstr ""
 
-#: ../../changelog.rst:4014
+#: ../../changelog.rst:4021
 msgid "Fix crash in case of missing or invalid picture"
 msgstr ""
 
-#: ../../changelog.rst:4015
+#: ../../changelog.rst:4022
 msgid "Fix feedback API"
 msgstr ""
 
-#: ../../changelog.rst:4016
+#: ../../changelog.rst:4023
 msgid "Unzip eggs to fix templates not found error"
 msgstr ""
 
-#: ../../changelog.rst:4017
+#: ../../changelog.rst:4024
 msgid "Various parsers (import system) fixes and improvements"
 msgstr ""
 
-#: ../../changelog.rst:4021
+#: ../../changelog.rst:4028
 msgid "Document server migration"
 msgstr ""
 
-#: ../../changelog.rst:4025
+#: ../../changelog.rst:4032
 msgid "2.0.0 (2015-07-20)"
 msgstr ""
 
-#: ../../changelog.rst:4029
+#: ../../changelog.rst:4036
 msgid "Rework API URL schemas"
 msgstr ""
 
-#: ../../changelog.rst:4033
+#: ../../changelog.rst:4040
 msgid "Static API to disconnect Geotrek-rando from Geotrek-Admin (fixes #1428)"
 msgstr ""
 
-#: ../../changelog.rst:4034
+#: ../../changelog.rst:4041
 msgid "Build zip files for mobile application"
 msgstr ""
 
-#: ../../changelog.rst:4035
+#: ../../changelog.rst:4042
 msgid "Trek / Touristic content association distance depending on trek practice"
 msgstr ""
 
-#: ../../changelog.rst:4036
+#: ../../changelog.rst:4043
 msgid "Option to hide published treks nearby topologies"
 msgstr ""
 
-#: ../../changelog.rst:4037
+#: ../../changelog.rst:4044
 msgid "Add previous/next treks and category slugs to geojson API"
 msgstr ""
 
-#: ../../changelog.rst:4038
+#: ../../changelog.rst:4045
 msgid "Add external id in trekking/tourism detail pages and exports"
 msgstr ""
 
-#: ../../changelog.rst:4039
+#: ../../changelog.rst:4046
 msgid "Zip touristic contents as POI for mobile app v1"
 msgstr ""
 
-#: ../../changelog.rst:4040
+#: ../../changelog.rst:4047
 msgid "Add external id field on Path"
 msgstr ""
 
-#: ../../changelog.rst:4041
+#: ../../changelog.rst:4048
 msgid "Order intersections in Geotrek light mode"
 msgstr ""
 
-#: ../../changelog.rst:4042
+#: ../../changelog.rst:4049
 msgid "Add reservation id field for touristic contents"
 msgstr ""
 
-#: ../../changelog.rst:4043
+#: ../../changelog.rst:4050
 msgid "Integration of WeasyPrint to generate PDF from HTML/CSS instead of ODT"
 msgstr ""
 
-#: ../../changelog.rst:4047
+#: ../../changelog.rst:4054
 msgid "Remove HTTP calls to SoundCloud API at serialization"
 msgstr ""
 
-#: ../../changelog.rst:4048
+#: ../../changelog.rst:4055
 msgid "Allow DEM to partially cover spatial extent"
 msgstr ""
 
-#: ../../changelog.rst:4052
+#: ../../changelog.rst:4059
 msgid "0.35.1 (2015-07-17)"
 msgstr ""
 
-#: ../../changelog.rst:4056
+#: ../../changelog.rst:4063
 msgid "Fix installation on ubuntu 12.04 with recent updates"
 msgstr ""
 
-#: ../../changelog.rst:4060
+#: ../../changelog.rst:4067
 msgid "0.35.0 (2015-07-10)"
 msgstr ""
 
-#: ../../changelog.rst:4064
+#: ../../changelog.rst:4071
 msgid "Add an import framework"
 msgstr ""
 
-#: ../../changelog.rst:4068
+#: ../../changelog.rst:4075
 msgid "Fix a crash in appy pod (PDF generation)"
 msgstr ""
 
-#: ../../changelog.rst:4069
+#: ../../changelog.rst:4076
 msgid "Fix login with restricted access to some contents"
 msgstr ""
 
-#: ../../changelog.rst:4070
+#: ../../changelog.rst:4077
 msgid "Fix buildout bootstrap arguments"
 msgstr ""
 
-#: ../../changelog.rst:4074
+#: ../../changelog.rst:4081
 msgid "0.34.0 (2015-05-20)"
 msgstr ""
 
-#: ../../changelog.rst:4078
+#: ../../changelog.rst:4085
 msgid "Itinerancy (parent/children treks)"
 msgstr ""
 
-#: ../../changelog.rst:4079
+#: ../../changelog.rst:4086
 msgid "Allow to choose ordering of categories for Geotrek-Rando"
 msgstr ""
 
-#: ../../changelog.rst:4080
+#: ../../changelog.rst:4087
 msgid "Bootstrap grid editor for flatpages"
 msgstr ""
 
-#: ../../changelog.rst:4081
+#: ../../changelog.rst:4088
 msgid "Approved touristic contents and events"
 msgstr ""
 
-#: ../../changelog.rst:4082
+#: ../../changelog.rst:4089
 msgid "Option to split trek category by practice or accessibility"
 msgstr ""
 
-#: ../../changelog.rst:4086
+#: ../../changelog.rst:4093
 msgid "Fix duration notation"
 msgstr ""
 
-#: ../../changelog.rst:4087
+#: ../../changelog.rst:4094
 msgid "Flatten altimetry profiles"
 msgstr ""
 
-#: ../../changelog.rst:4091
+#: ../../changelog.rst:4098
 msgid "Show accessibility in trek detail page (fixes #1399)"
 msgstr ""
 
-#: ../../changelog.rst:4095
+#: ../../changelog.rst:4102
 msgid "0.33.4 (2015-04-07)"
 msgstr ""
 
-#: ../../changelog.rst:4099
+#: ../../changelog.rst:4106
 msgid "Ensure trek duration is a positive number"
 msgstr ""
 
-#: ../../changelog.rst:4100
+#: ../../changelog.rst:4107
 msgid "Fix cirkwi exports (second try)"
 msgstr ""
 
-#: ../../changelog.rst:4101
+#: ../../changelog.rst:4108
 msgid "Fix public PDF templates"
 msgstr ""
 
-#: ../../changelog.rst:4105
+#: ../../changelog.rst:4112
 msgid "0.33.3 (2015-04-01)"
 msgstr ""
 
-#: ../../changelog.rst:4109
+#: ../../changelog.rst:4116
 msgid "Fix systematic crash in PDF conversions"
 msgstr ""
 
-#: ../../changelog.rst:4113
+#: ../../changelog.rst:4120
 msgid "0.33.2 (2015-04-01)"
 msgstr ""
 
-#: ../../changelog.rst:4117
+#: ../../changelog.rst:4124
 msgid "Remove italian from fixtures"
 msgstr ""
 
-#: ../../changelog.rst:4118
+#: ../../changelog.rst:4125
 msgid "Fix crash when generating two PDF in parallel"
 msgstr ""
 
-#: ../../changelog.rst:4122
+#: ../../changelog.rst:4129
 msgid "0.33.1 (2015-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:4126
+#: ../../changelog.rst:4133
 msgid "Fix flat pages crash"
 msgstr ""
 
-#: ../../changelog.rst:4127
+#: ../../changelog.rst:4134
 msgid "N to N source field (rel #1354)"
 msgstr ""
 
-#: ../../changelog.rst:4131
+#: ../../changelog.rst:4138
 msgid "0.33.0 (2015-03-25)"
 msgstr ""
 
-#: ../../changelog.rst:4135
+#: ../../changelog.rst:4142
 msgid ""
 "A new permission \"Can publish ...\" is required to publish treks, pois, "
 "touristic contents and touristic events. Grant it to your users and "
 "groups if need be"
 msgstr ""
 
-#: ../../changelog.rst:4138
+#: ../../changelog.rst:4145
 msgid "DB table ``l_b_source`` is renamed as ``l_b_source_troncon``"
 msgstr ""
 
-#: ../../changelog.rst:4142
+#: ../../changelog.rst:4149
 msgid "Publication workflow (fixes #1018)"
 msgstr ""
 
-#: ../../changelog.rst:4143
+#: ../../changelog.rst:4150
 msgid "Allow to add links to Youtube or Soundcloud media as attachment"
 msgstr ""
 
-#: ../../changelog.rst:4144
+#: ../../changelog.rst:4151
 msgid "Make pictograms optional in some places when not required by Geotrek-Rando"
 msgstr ""
 
-#: ../../changelog.rst:4145
+#: ../../changelog.rst:4152
 msgid ""
 "Add source for treks, touristic contents and touristic events (fixes "
 "#1354)"
 msgstr ""
 
-#: ../../changelog.rst:4146
+#: ../../changelog.rst:4153
 msgid ""
 "Add external id field for treks, pois, touristic contents and touristic "
 "events"
 msgstr ""
 
-#: ../../changelog.rst:4147
+#: ../../changelog.rst:4154
 msgid "Group cirkwi matchings in admin site (fixes #1402)"
 msgstr ""
 
-#: ../../changelog.rst:4151
+#: ../../changelog.rst:4158
 msgid "Fix projection of OSM link in feedback email"
 msgstr ""
 
-#: ../../changelog.rst:4152
+#: ../../changelog.rst:4159
 msgid "Fix language in cirkwi exports"
 msgstr ""
 
-#: ../../changelog.rst:4156
+#: ../../changelog.rst:4163
 msgid "0.32.2 (2015-03-06)"
 msgstr ""
 
-#: ../../changelog.rst:4160
+#: ../../changelog.rst:4167
 msgid "Home now redirects to treks list in light version (without topologies)"
 msgstr ""
 
-#: ../../changelog.rst:4161
+#: ../../changelog.rst:4168
 msgid "Fix Cirkwi export in light version"
 msgstr ""
 
-#: ../../changelog.rst:4162
+#: ../../changelog.rst:4169
 msgid "Fix SRID in database migrations"
 msgstr ""
 
-#: ../../changelog.rst:4163
+#: ../../changelog.rst:4170
 msgid "Add signage type filter again (fixes #1352)"
 msgstr ""
 
-#: ../../changelog.rst:4164
+#: ../../changelog.rst:4171
 msgid "Add missing date filters to touristic events list"
 msgstr ""
 
-#: ../../changelog.rst:4168
+#: ../../changelog.rst:4175
 msgid "0.32.1 (2015-03-04)"
 msgstr ""
 
-#: ../../changelog.rst:4172
+#: ../../changelog.rst:4179
 msgid "Fix creation of a loop topology with two paths (fixes #1026)"
 msgstr ""
 
-#: ../../changelog.rst:4176
+#: ../../changelog.rst:4183
 msgid "0.32.0 (2015-03-04)"
 msgstr ""
 
-#: ../../changelog.rst:4180
+#: ../../changelog.rst:4187
 msgid ""
 "Export to cirkwi/espace loisirs IGN. After upgrade, run ``bin/django "
 "loaddata cirkwi`` to load data cirkwi tags and categories"
 msgstr ""
 
-#: ../../changelog.rst:4182
+#: ../../changelog.rst:4189
 msgid "Wysiwyg editor for static web pages"
 msgstr ""
 
-#: ../../changelog.rst:4186
+#: ../../changelog.rst:4193
 msgid "Hide not published static pages in public REST API"
 msgstr ""
 
-#: ../../changelog.rst:4190
+#: ../../changelog.rst:4197
 msgid "0.31.0 (2015-03-02)"
 msgstr ""
 
-#: ../../changelog.rst:4194
+#: ../../changelog.rst:4201
 msgid "Add support of Ubuntu 14.04 to installer"
 msgstr ""
 
-#: ../../changelog.rst:4195
+#: ../../changelog.rst:4202
 msgid "Public PDF for touristic contents/events (fixes #1206)"
 msgstr ""
 
-#: ../../changelog.rst:4196
+#: ../../changelog.rst:4203
 msgid "Add treks close to other treks in REST API"
 msgstr ""
 
-#: ../../changelog.rst:4197
+#: ../../changelog.rst:4204
 msgid ""
 "Add pictograms for trek accessibilities, touristic content types and "
 "touristic event types"
 msgstr ""
 
-#: ../../changelog.rst:4202
+#: ../../changelog.rst:4209
 msgid "Show edit button when having bypass structure permission"
 msgstr ""
 
-#: ../../changelog.rst:4203
+#: ../../changelog.rst:4210
 msgid "Export missing fields in list exports (fixes #1167)"
 msgstr ""
 
-#: ../../changelog.rst:4204
+#: ../../changelog.rst:4211
 msgid ""
 "Fix formating of float and boolean values in list exports (fixes #1366, "
 "#1380)"
 msgstr ""
 
-#: ../../changelog.rst:4205
+#: ../../changelog.rst:4212
 msgid "Fix french translation"
 msgstr ""
 
-#: ../../changelog.rst:4206
+#: ../../changelog.rst:4213
 msgid "Allow anonymous access to altimetry API for public objects"
 msgstr ""
 
-#: ../../changelog.rst:4207
+#: ../../changelog.rst:4214
 msgid "Hide not published and deleted items in public REST API"
 msgstr ""
 
-#: ../../changelog.rst:4211
+#: ../../changelog.rst:4218
 msgid "0.30.0 (2015-02-19)"
 msgstr ""
 
-#: ../../changelog.rst:4215
+#: ../../changelog.rst:4222
 msgid ""
 "Trek practice (formerly usage) is no single valued so if a trek has "
 "multiple usages only one will be kept after upgrade. Others will be "
 "**lost**!"
 msgstr ""
 
-#: ../../changelog.rst:4217
+#: ../../changelog.rst:4224
 msgid ""
 "After upgrade, run ``make load_data`` to load fixtures for "
 "accessibilities or create them by hand. You should clean-up the list of "
 "practices by hand."
 msgstr ""
 
-#: ../../changelog.rst:4219
+#: ../../changelog.rst:4226
 msgid ""
 "Don't forget to set up permissions to administrate practices and "
 "accessibilities."
 msgstr ""
 
-#: ../../changelog.rst:4224
+#: ../../changelog.rst:4231
 msgid "Split trek usage field into practice and accessibility"
 msgstr ""
 
-#: ../../changelog.rst:4225
+#: ../../changelog.rst:4232
 msgid "Treks and POIs are now structure related"
 msgstr ""
 
-#: ../../changelog.rst:4226
+#: ../../changelog.rst:4233
 msgid "Allow anonymous access to media related to published items"
 msgstr ""
 
-#: ../../changelog.rst:4227
+#: ../../changelog.rst:4234
 msgid "Check model read permission to give access to media"
 msgstr ""
 
-#: ../../changelog.rst:4228
+#: ../../changelog.rst:4235
 msgid "Add a settings to set up CORS (cross-origin resource sharing)"
 msgstr ""
 
-#: ../../changelog.rst:4229
+#: ../../changelog.rst:4236
 msgid "Allow to get POIs for a specific trek in REST API"
 msgstr ""
 
-#: ../../changelog.rst:4230
+#: ../../changelog.rst:4237
 msgid ""
 "Consistent REST API (type1, type2, category for treks, touristic contents"
 " and touristic events)"
 msgstr ""
 
-#: ../../changelog.rst:4235
+#: ../../changelog.rst:4242
 msgid "Ensure path snapping is done on the closest point and is idempotent"
 msgstr ""
 
-#: ../../changelog.rst:4236
+#: ../../changelog.rst:4243
 msgid "Fix language of PNG elevation charts"
 msgstr ""
 
-#: ../../changelog.rst:4237
+#: ../../changelog.rst:4244
 msgid "Fix logo on login page"
 msgstr ""
 
-#: ../../changelog.rst:4238
+#: ../../changelog.rst:4245
 msgid "Fix logs rotation"
 msgstr ""
 
-#: ../../changelog.rst:4239
+#: ../../changelog.rst:4246
 msgid "Fix permissions creation"
 msgstr ""
 
-#: ../../changelog.rst:4243
+#: ../../changelog.rst:4250
 msgid "0.29.0 (2015-02-04)"
 msgstr ""
 
-#: ../../changelog.rst:4247
+#: ../../changelog.rst:4254
 msgid "GeoJSON API with all properties for Trek and Tourism"
 msgstr ""
 
-#: ../../changelog.rst:4251
+#: ../../changelog.rst:4258
 msgid "Fix permissions required to sync static Web pages"
 msgstr ""
 
-#: ../../changelog.rst:4252
+#: ../../changelog.rst:4259
 msgid "Fix geom computation on line topologies with offset"
 msgstr ""
 
-#: ../../changelog.rst:4256
+#: ../../changelog.rst:4263
 msgid "0.28.8 (2014-12-22)"
 msgstr ""
 
-#: ../../changelog.rst:4260
+#: ../../changelog.rst:4267
 msgid "Fix altimetry sampling for segment with 0 length (rel #1337)"
 msgstr ""
 
-#: ../../changelog.rst:4264
+#: ../../changelog.rst:4271
 msgid "0.28.7 (2014-12-22)"
 msgstr ""
 
-#: ../../changelog.rst:4268
+#: ../../changelog.rst:4275
 msgid "Fix altimetry trigger when TREKKING_TOPOLOGY_ENABLED is set to False"
 msgstr ""
 
-#: ../../changelog.rst:4272
+#: ../../changelog.rst:4279
 msgid "0.28.6 (2014-12-18)"
 msgstr ""
 
-#: ../../changelog.rst:4276
+#: ../../changelog.rst:4283
 msgid ""
 "Fix 3D length shorter than 2D length (run sql command ``UPDATE "
 "l_t_troncon SET geom=geom;`` after upgrade to update altimetry "
 "informations of existing geometries)"
 msgstr ""
 
-#: ../../changelog.rst:4277
+#: ../../changelog.rst:4284
 msgid "Fix translation of \"Information desks\" in public trek PDF"
 msgstr ""
 
-#: ../../changelog.rst:4278
+#: ../../changelog.rst:4285
 msgid ""
 "Fix prepare_map_images and prepare_elevation_charts commands failing for "
 "deleted objects and for objects without geom"
 msgstr ""
 
-#: ../../changelog.rst:4282
+#: ../../changelog.rst:4289
 msgid "0.28.5 (2014-12-09)"
 msgstr ""
 
-#: ../../changelog.rst:4286
+#: ../../changelog.rst:4293
 msgid "Fix DEM optimizations when minimum elevation is zero (fixes #1291)"
 msgstr ""
 
-#: ../../changelog.rst:4287
+#: ../../changelog.rst:4294
 msgid "Fix regression for translations of tourism (fixes #1315)"
 msgstr ""
 
-#: ../../changelog.rst:4288
+#: ../../changelog.rst:4295
 msgid "Fix duplicate entries with year filter (fixes #1324)"
 msgstr ""
 
-#: ../../changelog.rst:4292
+#: ../../changelog.rst:4299
 msgid "French user manual first step about general interface"
 msgstr ""
 
-#: ../../changelog.rst:4296
+#: ../../changelog.rst:4303
 msgid "Set PostgreSQL search_path at user level (fixes #1311)"
 msgstr ""
 
-#: ../../changelog.rst:4297
+#: ../../changelog.rst:4304
 msgid "Show 3D and 2D length in detail pages (fixes #1101)"
 msgstr ""
 
-#: ../../changelog.rst:4298
+#: ../../changelog.rst:4305
 msgid ""
 "Show length and elevation infos in trail and all statuts detail pages "
 "(fixes #1222)"
 msgstr ""
 
-#: ../../changelog.rst:4299
+#: ../../changelog.rst:4306
 msgid "Show trail length in list and exports (fixes #1282)"
 msgstr ""
 
-#: ../../changelog.rst:4300
+#: ../../changelog.rst:4307
 msgid "Replace stake by length in path list (fixes #956, fixes #1281)"
 msgstr ""
 
-#: ../../changelog.rst:4301
+#: ../../changelog.rst:4308
 msgid "Add subcontracting in intervention filter (fixes #1144)"
 msgstr ""
 
-#: ../../changelog.rst:4302
+#: ../../changelog.rst:4309
 msgid "Add missing fields in project filter (fixes #219, fixes #910)"
 msgstr ""
 
-#: ../../changelog.rst:4303
+#: ../../changelog.rst:4310
 msgid "Show status in interventions table among detail pages (fixes #1193)"
 msgstr ""
 
-#: ../../changelog.rst:4304
+#: ../../changelog.rst:4311
 msgid "Add missing field in projects exports (ref #1167)"
 msgstr ""
 
-#: ../../changelog.rst:4305
+#: ../../changelog.rst:4312
 msgid "Add length column to land module lists"
 msgstr ""
 
-#: ../../changelog.rst:4306
+#: ../../changelog.rst:4313
 msgid ""
 "Number of workers and request timeout can be now configured in "
 "``settings.ini``"
 msgstr ""
 
-#: ../../changelog.rst:4307
+#: ../../changelog.rst:4314
 msgid "Various improvements on trek public template, by Camille Monchicourt"
 msgstr ""
 
-#: ../../changelog.rst:4311
+#: ../../changelog.rst:4318
 msgid "0.28.4 (2014-11-21)"
 msgstr ""
 
-#: ../../changelog.rst:4315
+#: ../../changelog.rst:4322
 msgid ""
 "Fix mouse position indicator on ``/tools/extents/`` page when map tiles "
 "have Google projection"
 msgstr ""
 
-#: ../../changelog.rst:4316
+#: ../../changelog.rst:4323
 msgid "Fix missing filters in trails list (fixes #1297)"
 msgstr ""
 
-#: ../../changelog.rst:4317
+#: ../../changelog.rst:4324
 msgid "Fix infrastructure main type filter (fixes #1096)"
 msgstr ""
 
-#: ../../changelog.rst:4318
+#: ../../changelog.rst:4325
 msgid "Fix flatpage creation without external url in adminsite"
 msgstr ""
 
-#: ../../changelog.rst:4319
+#: ../../changelog.rst:4326
 msgid "Fix path detail page where deleted objects were shown (fixes #1302)"
 msgstr ""
 
-#: ../../changelog.rst:4320
+#: ../../changelog.rst:4327
 msgid "Fix position of POIs on trek detail maps (fixes #1209)"
 msgstr ""
 
-#: ../../changelog.rst:4321
+#: ../../changelog.rst:4328
 msgid "Fix TinyMCE not preserving colors (fixes #1170)"
 msgstr ""
 
-#: ../../changelog.rst:4322
+#: ../../changelog.rst:4329
 msgid ""
 "Raise validation error instead of crashing when submitted topology is "
 "empty (fixes #1272)"
 msgstr ""
 
-#: ../../changelog.rst:4326
+#: ../../changelog.rst:4333
 msgid "Fix mention of MAP_STYLES (ref #1226)"
 msgstr ""
 
-#: ../../changelog.rst:4328
+#: ../../changelog.rst:4335
 msgid "**Changes in experimental features**"
 msgstr ""
 
-#: ../../changelog.rst:4330
+#: ../../changelog.rst:4337
 msgid "Renamed *usage* to *type* in touristic events (fixes #1289)"
 msgstr ""
 
-#: ../../changelog.rst:4334
+#: ../../changelog.rst:4341
 msgid "0.28.3 (2014-11-12)"
 msgstr ""
 
-#: ../../changelog.rst:4338
+#: ../../changelog.rst:4345
 msgid "Fix upload form author/legend format (fixes #1293)"
 msgstr ""
 
-#: ../../changelog.rst:4339
+#: ../../changelog.rst:4346
 msgid "Fixes history list (ref #1276)"
 msgstr ""
 
-#: ../../changelog.rst:4340
+#: ../../changelog.rst:4347
 msgid "Prevent email to be sent twice on conversion error. Use info instead."
 msgstr ""
 
-#: ../../changelog.rst:4341
+#: ../../changelog.rst:4348
 msgid "Fix paperclip translations missing (fixes #1294)"
 msgstr ""
 
-#: ../../changelog.rst:4342
+#: ../../changelog.rst:4349
 msgid "Fix filetypes not being filtered by structure (fixes #1292)"
 msgstr ""
 
-#: ../../changelog.rst:4343
+#: ../../changelog.rst:4350
 msgid "Fix apparence of multiple-choices in forms (fixes #1295)"
 msgstr ""
 
-#: ../../changelog.rst:4347
+#: ../../changelog.rst:4354
 msgid "0.28.2 (2014-11-05)"
 msgstr ""
 
-#: ../../changelog.rst:4351
+#: ../../changelog.rst:4358
 msgid "Fix upgrade of django-leaflet to 0.15.0 (overlay layers)"
 msgstr ""
 
-#: ../../changelog.rst:4352
+#: ../../changelog.rst:4359
 msgid ""
 "Fix apparence of overlay layers for tourism when experimental features "
 "are disabled"
 msgstr ""
 
-#: ../../changelog.rst:4353
+#: ../../changelog.rst:4360
 msgid "Fix plural in tourism translation"
 msgstr ""
 
-#: ../../changelog.rst:4354
+#: ../../changelog.rst:4361
 msgid "Fix unit tests"
 msgstr ""
 
-#: ../../changelog.rst:4355
+#: ../../changelog.rst:4362
 msgid ""
 "Run this command to set the default information desk type with the "
 "original pictogram (or select a pictogram from the adminsite)"
 msgstr ""
 
-#: ../../changelog.rst:4366
+#: ../../changelog.rst:4373
 msgid "0.28.1 (2014-11-05)"
 msgstr ""
 
-#: ../../changelog.rst:4370
+#: ../../changelog.rst:4377
 msgid "Fix deployment when tourism is not enabled"
 msgstr ""
 
-#: ../../changelog.rst:4371
+#: ../../changelog.rst:4378
 msgid "Fix default duration when invalid value is filled (fixes #1279)"
 msgstr ""
 
-#: ../../changelog.rst:4372
+#: ../../changelog.rst:4379
 msgid ""
 "Fix year filters for intervention, infrastructure and project (fixes "
 "#1287)"
 msgstr ""
 
-#: ../../changelog.rst:4373
+#: ../../changelog.rst:4380
 msgid "Fix list filters not being restored (fixes #1236)"
 msgstr ""
 
-#: ../../changelog.rst:4377
+#: ../../changelog.rst:4384
 msgid "0.28.0 (2014-11-04)"
 msgstr ""
 
-#: ../../changelog.rst:4381
+#: ../../changelog.rst:4388
 msgid ""
 "Before running install, run this SQL command to add a column for file "
 "attachments :"
 msgstr ""
 
-#: ../../changelog.rst:4390
+#: ../../changelog.rst:4397
 msgid ""
 "Information desks now have a type (*Maison du parc*, *Tourist office*, "
 "...) with the ability to set dedicated pictograms (fixes #1192)."
 msgstr ""
 
-#: ../../changelog.rst:4392
+#: ../../changelog.rst:4399
 msgid ""
 "Ability to control which picture will be used in trek, using clicks on "
 "stars in attachments list (fixes #1117)"
 msgstr ""
 
-#: ../../changelog.rst:4394
+#: ../../changelog.rst:4401
 msgid ""
 "Ability to edit attachments from detail pages directly (fixes #177, the "
 "5th oldest issue!)"
 msgstr ""
 
-#: ../../changelog.rst:4395
+#: ../../changelog.rst:4402
 msgid "Add missing columns in intervention exports (fixes #1167)"
 msgstr ""
 
-#: ../../changelog.rst:4396
+#: ../../changelog.rst:4403
 msgid ""
 "Add ability (for super-admin) to add/change/delete zoning objects in "
 "Adminsite (ref #1246)"
 msgstr ""
 
-#: ../../changelog.rst:4397
+#: ../../changelog.rst:4404
 msgid ""
 "Add ability to have paths records in database that will not appear in "
 "Geotrek lists and maps. Just set column ``visible`` to false in "
 "``l_t_troncon`` table."
 msgstr ""
 
-#: ../../changelog.rst:4399
+#: ../../changelog.rst:4406
 msgid "Add ability to add external overlay tile layers (fixes #1203)"
 msgstr ""
 
-#: ../../changelog.rst:4403
+#: ../../changelog.rst:4410
 msgid "Fix position of attachment upload form on small screens"
 msgstr ""
 
-#: ../../changelog.rst:4404
+#: ../../changelog.rst:4411
 msgid "Clearer action message in object history table"
 msgstr ""
 
-#: ../../changelog.rst:4405
+#: ../../changelog.rst:4412
 msgid "Prevent image ratio warning from disappearing (fixes #1225)"
 msgstr ""
 
-#: ../../changelog.rst:4406
+#: ../../changelog.rst:4413
 msgid "Touristic contents"
 msgstr ""
 
-#: ../../changelog.rst:4407
+#: ../../changelog.rst:4414
 msgid "Touristic events"
 msgstr ""
 
-#: ../../changelog.rst:4409 ../../changelog.rst:4501 ../../changelog.rst:4620
-#: ../../changelog.rst:4757 ../../changelog.rst:5095
+#: ../../changelog.rst:4416 ../../changelog.rst:4508 ../../changelog.rst:4627
+#: ../../changelog.rst:4764 ../../changelog.rst:5102
 msgid "**Internal changes**"
 msgstr ""
 
-#: ../../changelog.rst:4411
+#: ../../changelog.rst:4418
 msgid "Upgraded Chosen library for dropdown form fields"
 msgstr ""
 
-#: ../../changelog.rst:4412
+#: ../../changelog.rst:4419
 msgid ""
 "Set ``valide`` column default value to false on paths table "
 "``l_t_troncon`` (fixes #1217)"
 msgstr ""
 
-#: ../../changelog.rst:4413
+#: ../../changelog.rst:4420
 msgid ""
 "All information desks are now available in GeoJSON (*will be useful to "
 "show them all at once on Geotrek-rando*)."
 msgstr ""
 
-#: ../../changelog.rst:4415
+#: ../../changelog.rst:4422
 msgid ""
 "All tables and functions are now stored in different schemas. It allows "
 "to distinguish Geotrek objects from *postgreSQL* and *PostGIS*, and to "
@@ -7756,29 +7767,29 @@ msgid ""
 "*pgAdmin* and *QGis*."
 msgstr ""
 
-#: ../../changelog.rst:4419
+#: ../../changelog.rst:4426
 msgid ""
 "**Caution**: if you created additional database users, you may have to "
 "change their ``search_path`` and/or their ``USAGE`` privilege."
 msgstr ""
 
-#: ../../changelog.rst:4422
+#: ../../changelog.rst:4429
 msgid "**Experimental features**"
 msgstr ""
 
-#: ../../changelog.rst:4424
+#: ../../changelog.rst:4431
 msgid ""
 "We introduced models for touristic contents and events. In order to load "
 "example values for categories and types, run the following commands:"
 msgstr ""
 
-#: ../../changelog.rst:4432
+#: ../../changelog.rst:4439
 msgid ""
 "We introduced models for static pages, allowing edition of public static "
 "Web pages from Geotrek adminsite."
 msgstr ""
 
-#: ../../changelog.rst:4435
+#: ../../changelog.rst:4442
 msgid ""
 "In order to enable those features under construction, add ``experimental "
 "= True`` in ``etc/settings.ini``. Note that none of them are used in "
@@ -7789,64 +7800,64 @@ msgstr ""
 msgid "notes"
 msgstr ""
 
-#: ../../changelog.rst:4440
+#: ../../changelog.rst:4447
 msgid ""
 "Give related permissions to the managers group in order to allow edition "
 "(``add_flatpage``, ``change_flatpage``, ``delete_flatpage``, "
 "``add_touristiccontent`` ...)."
 msgstr ""
 
-#: ../../changelog.rst:4445
+#: ../../changelog.rst:4452
 msgid "0.27.2 (2010-10-14)"
 msgstr ""
 
-#: ../../changelog.rst:4449
+#: ../../changelog.rst:4456
 msgid ""
 "Fix elevation info not being computed when intervention is created (ref "
 "#1221)"
 msgstr ""
 
-#: ../../changelog.rst:4450
+#: ../../changelog.rst:4457
 msgid "Fix list of values for infrastructure and signage types (fixes #1223)"
 msgstr ""
 
-#: ../../changelog.rst:4451
+#: ../../changelog.rst:4458
 msgid ""
 "Signages can now be lines if setting SIGNAGE_LINE_ENABLED is True (fixes "
 "#1141)"
 msgstr ""
 
-#: ../../changelog.rst:4452
+#: ../../changelog.rst:4459
 msgid "Fix HTML tags in PDF exports (fixes #1235)"
 msgstr ""
 
-#: ../../changelog.rst:4453
+#: ../../changelog.rst:4460
 msgid "Fix regression with Geotrek light"
 msgstr ""
 
-#: ../../changelog.rst:4457
+#: ../../changelog.rst:4464
 msgid "0.27.1 (2010-10-13)"
 msgstr ""
 
-#: ../../changelog.rst:4461
+#: ../../changelog.rst:4468
 msgid "Fix problems in forms, prevent Javascript errors"
 msgstr ""
 
-#: ../../changelog.rst:4465
+#: ../../changelog.rst:4472
 msgid "0.27.0 (2010-10-09)"
 msgstr ""
 
-#: ../../changelog.rst:4469
+#: ../../changelog.rst:4476
 msgid ""
 "Attribute for single information desk was removed (was used in **Geotrek-"
 "rando** < 1.29)"
 msgstr ""
 
-#: ../../changelog.rst:4470
+#: ../../changelog.rst:4477
 msgid "Renamed setting ``TREK_PUBLISHED_BY_LANG`` to ``PUBLISHED_BY_LANG``"
 msgstr ""
 
-#: ../../changelog.rst:4471
+#: ../../changelog.rst:4478
 msgid ""
 "Renamed setting ``TREK_EXPORT_MAP_IMAGE_SIZE`` to "
 "``EXPORT_MAP_IMAGE_SIZE``, ``TREK_EXPORT_HEADER_IMAGE_SIZE`` to "
@@ -7856,797 +7867,797 @@ msgid ""
 "<https://github.com/makinacorpus/Geotrek/blob/v0.27dev0/geotrek/settings/base.py#L443-L449>`_)"
 msgstr ""
 
-#: ../../changelog.rst:4478
+#: ../../changelog.rst:4485
 msgid "POI publication is now controlled like treks"
 msgstr ""
 
-#: ../../changelog.rst:4479
+#: ../../changelog.rst:4486
 msgid "POI now have a public PDF too"
 msgstr ""
 
-#: ../../changelog.rst:4480
+#: ../../changelog.rst:4487
 msgid ""
 "Introduced ``VIEWPORT_MARGIN`` setting to control list page viewport "
 "margin around spatial extent from ``settings.ini`` (default: 0.1 degree)"
 msgstr ""
 
-#: ../../changelog.rst:4485
+#: ../../changelog.rst:4492
 msgid ""
 "After upgrading, mark all POIs as published in the languages of your "
 "choice ::"
 msgstr ""
 
-#: ../../changelog.rst:4492
+#: ../../changelog.rst:4499
 msgid "Add missing credit for main picture in trek PDF (fixes #1178)"
 msgstr ""
 
-#: ../../changelog.rst:4493
+#: ../../changelog.rst:4500
 msgid ""
 "Paths module is now removed from user interface in *Geotrek-light* mode. "
 "(i.e. with ``TREKKING_TOPOLOGY_ENABLED = False``)"
 msgstr ""
 
-#: ../../changelog.rst:4495
+#: ../../changelog.rst:4502
 msgid "Make sure text fields are cleared (fixes #1207)"
 msgstr ""
 
-#: ../../changelog.rst:4496
+#: ../../changelog.rst:4503
 msgid "Intervention subcontracting was missing in detail pages (fixes #1201)"
 msgstr ""
 
-#: ../../changelog.rst:4497
+#: ../../changelog.rst:4504
 msgid "Make sure TLS is disabled when ``mailtls`` is False in settings"
 msgstr ""
 
-#: ../../changelog.rst:4498
+#: ../../changelog.rst:4505
 msgid "Fix list of POIs in path detail pages (fixes #1213)"
 msgstr ""
 
-#: ../../changelog.rst:4499
+#: ../../changelog.rst:4506
 msgid "Fix highlight from map for project list page (fixes #1180)"
 msgstr ""
 
-#: ../../changelog.rst:4503
+#: ../../changelog.rst:4510
 msgid "Extracted the trek publication to a generic and reusable notion"
 msgstr ""
 
-#: ../../changelog.rst:4504
+#: ../../changelog.rst:4511
 msgid ""
 "Complete refactor of Trek JSON API, now taking advantage of Django REST "
 "framework instead of custom code"
 msgstr ""
 
-#: ../../changelog.rst:4506
+#: ../../changelog.rst:4513
 msgid "Added read/write REST API on all entities"
 msgstr ""
 
-#: ../../changelog.rst:4507
+#: ../../changelog.rst:4514
 msgid "Refactored URLs declaration for altimetry and publishable entities"
 msgstr ""
 
-#: ../../changelog.rst:4508
+#: ../../changelog.rst:4515
 msgid ""
 "Change editable status of topology paths in Django forms, since it was "
 "posing problems with Django-rest-framework"
 msgstr ""
 
-#: ../../changelog.rst:4510
+#: ../../changelog.rst:4517
 msgid "Add elevation profile SVG URL in trek detail JSON (fixes #1205)"
 msgstr ""
 
-#: ../../changelog.rst:4511
+#: ../../changelog.rst:4518
 msgid ""
 "Simplified upgrade commands for ``etc/`` and ``var/``, and mention "
 "advanced configuration file"
 msgstr ""
 
-#: ../../changelog.rst:4516
+#: ../../changelog.rst:4523
 msgid "0.26.3 (2014-09-15)"
 msgstr ""
 
-#: ../../changelog.rst:4520
+#: ../../changelog.rst:4527
 msgid "Fix pretty trek duration when duration is between 24 and 48H (fixes #1188)"
 msgstr ""
 
-#: ../../changelog.rst:4521
+#: ../../changelog.rst:4528
 msgid ""
 "Invalidate projet maps captures when interventions change, and treks maps"
 " when POIs change (fixes #1181)"
 msgstr ""
 
-#: ../../changelog.rst:4526
+#: ../../changelog.rst:4533
 msgid "0.26.2 (2014-08-22)"
 msgstr ""
 
-#: ../../changelog.rst:4530
+#: ../../changelog.rst:4537
 msgid "Fix search among attached files in Adminsite (fixes #1172)"
 msgstr ""
 
-#: ../../changelog.rst:4534
+#: ../../changelog.rst:4541
 msgid "0.26.1 (2014-08-21)"
 msgstr ""
 
-#: ../../changelog.rst:4538
+#: ../../changelog.rst:4545
 msgid ""
 "Upgrade *django-mapentity* for bug fix in ODT export and list of values "
 "in detail pages"
 msgstr ""
 
-#: ../../changelog.rst:4543
+#: ../../changelog.rst:4550
 msgid "0.26.0 (2014-08-21)"
 msgstr ""
 
-#: ../../changelog.rst:4547
+#: ../../changelog.rst:4554
 msgid ""
 "Interventions in project detail page is now shown as a simple table (ref "
 "#214)"
 msgstr ""
 
-#: ../../changelog.rst:4548
+#: ../../changelog.rst:4555
 msgid ""
 "A generic system for interaction between objects attributes and details "
 "map was developped. It works with project interactions, topologies paths,"
 " etc. (ref #214)"
 msgstr ""
 
-#: ../../changelog.rst:4550
+#: ../../changelog.rst:4557
 msgid "Show enumeration of interventions in project PDF exports (fixes #960)"
 msgstr ""
 
-#: ../../changelog.rst:4551
+#: ../../changelog.rst:4558
 msgid "Number of POIs in now limited to 14 items in trek export (ref #1120)"
 msgstr ""
 
-#: ../../changelog.rst:4552
+#: ../../changelog.rst:4559
 msgid ""
 "Number of information desks in now limited to 2 items in trek export (ref"
 " #1120). See settings ``TREK_EXPORT_INFORMATION_DESK_LIST_LIMIT`` and "
 "``TREK_EXPORT_POI_LIST_LIMIT``"
 msgstr ""
 
-#: ../../changelog.rst:4554
+#: ../../changelog.rst:4561
 msgid "Justify texts of POIs in trek export, now converted to plain text."
 msgstr ""
 
-#: ../../changelog.rst:4555
+#: ../../changelog.rst:4562
 msgid ""
 "Trek export geometries are now translucid red by default (see "
 "``MAP_STYLES`` setting) (ref #1120)"
 msgstr ""
 
-#: ../../changelog.rst:4556
+#: ../../changelog.rst:4563
 msgid ""
 "Paths apparence in trek exports are now controlled by MAP_STYLES setting "
 "too."
 msgstr ""
 
-#: ../../changelog.rst:4557
+#: ../../changelog.rst:4564
 msgid ""
 "Images attachments are now resized to 800x800 for publication (instead of"
 " 500x500)"
 msgstr ""
 
-#: ../../changelog.rst:4558
+#: ../../changelog.rst:4565
 msgid "Clarify intervention cost by function and mandays (fixes #1169)"
 msgstr ""
 
-#: ../../changelog.rst:4562
+#: ../../changelog.rst:4569
 msgid "Fix paths layer not being shown in detail pages (fixes #1161)"
 msgstr ""
 
-#: ../../changelog.rst:4563
+#: ../../changelog.rst:4570
 msgid ""
 "Fix position of point topologies when closest path is not perpendicular "
 "(fixes #1156)"
 msgstr ""
 
-#: ../../changelog.rst:4564
+#: ../../changelog.rst:4571
 msgid "Prevent parking to be cropped on map exports (fixes #1006)"
 msgstr ""
 
-#: ../../changelog.rst:4566
+#: ../../changelog.rst:4573
 msgid "**Upgrades notes**"
 msgstr ""
 
-#: ../../changelog.rst:4568
+#: ../../changelog.rst:4575
 msgid "Since the map export have changed, empty the cache :"
 msgstr ""
 
-#: ../../changelog.rst:4576
+#: ../../changelog.rst:4583
 msgid "0.25.2 (2014-08-14)"
 msgstr ""
 
-#: ../../changelog.rst:4580
+#: ../../changelog.rst:4587
 msgid "Fix translation of Job in intervention form (fixes #1090)"
 msgstr ""
 
-#: ../../changelog.rst:4581
+#: ../../changelog.rst:4588
 msgid "Fix form error when no geometry is provided (fixes #1082)"
 msgstr ""
 
-#: ../../changelog.rst:4582
+#: ../../changelog.rst:4589
 msgid "Show attachments in adminsite (fixes #1162)"
 msgstr ""
 
-#: ../../changelog.rst:4583
+#: ../../changelog.rst:4590
 msgid "Fix JSON formatting of object attachment lists in API"
 msgstr ""
 
-#: ../../changelog.rst:4587
+#: ../../changelog.rst:4594
 msgid "0.25.1 (2014-08-01)"
 msgstr ""
 
-#: ../../changelog.rst:4591
+#: ../../changelog.rst:4598
 msgid "Fix Geotrek CSS not being deployed properly"
 msgstr ""
 
-#: ../../changelog.rst:4592
+#: ../../changelog.rst:4599
 msgid "Fix trek relationships causing errors for PDF export"
 msgstr ""
 
-#: ../../changelog.rst:4596
+#: ../../changelog.rst:4603
 msgid "0.25.0 (2014-08-01)"
 msgstr ""
 
-#: ../../changelog.rst:4600
+#: ../../changelog.rst:4607
 msgid "Added projection file EPSG:32622 (fixes #1150)"
 msgstr ""
 
-#: ../../changelog.rst:4601
+#: ../../changelog.rst:4608
 msgid "Now log addition and suppression of attachments in history"
 msgstr ""
 
-#: ../../changelog.rst:4602
+#: ../../changelog.rst:4609
 msgid ""
 "Added notion of points of reference for treks (fixes #1105). (Can be "
 "disabled with ``TREK_POINTS_OF_REFERENCE_ENABLED = False``)"
 msgstr ""
 
-#: ../../changelog.rst:4604
+#: ../../changelog.rst:4611
 msgid "Edit the parking location directly on the trek map (ref #387)"
 msgstr ""
 
-#: ../../changelog.rst:4605
+#: ../../changelog.rst:4612
 msgid "Show enumeration of POIs in trek PDF exports (fixes #871)"
 msgstr ""
 
-#: ../../changelog.rst:4607 ../../changelog.rst:4632 ../../changelog.rst:4641
-#: ../../changelog.rst:4655 ../../changelog.rst:5080 ../../changelog.rst:5111
-#: ../../changelog.rst:5126 ../../changelog.rst:5155 ../../changelog.rst:5243
-#: ../../changelog.rst:5275
+#: ../../changelog.rst:4614 ../../changelog.rst:4639 ../../changelog.rst:4648
+#: ../../changelog.rst:4662 ../../changelog.rst:5087 ../../changelog.rst:5118
+#: ../../changelog.rst:5133 ../../changelog.rst:5162 ../../changelog.rst:5250
+#: ../../changelog.rst:5282
 msgid "**BUG fixes**"
 msgstr ""
 
-#: ../../changelog.rst:4609
+#: ../../changelog.rst:4616
 msgid "Fix permission check to see attachments (fixes #1147, ref #1146)"
 msgstr ""
 
-#: ../../changelog.rst:4610
+#: ../../changelog.rst:4617
 msgid "Fix grouping of interventions in detail pages (fixes #1145)"
 msgstr ""
 
-#: ../../changelog.rst:4611
+#: ../../changelog.rst:4618
 msgid "Fix project total intervention cost (fixes #958)"
 msgstr ""
 
-#: ../../changelog.rst:4612
+#: ../../changelog.rst:4619
 msgid "Fix history entries not being saved when using formsets (fixes #1139)"
 msgstr ""
 
-#: ../../changelog.rst:4613
+#: ../../changelog.rst:4620
 msgid ""
 "Fix postal code being saved as integer (fixes #1138). Existing records "
 "will have a leading zero when shorter than 5 charaters."
 msgstr ""
 
-#: ../../changelog.rst:4615
+#: ../../changelog.rst:4622
 msgid "Fix bug when form of intervention on infrastracture is not valid"
 msgstr ""
 
-#: ../../changelog.rst:4616
+#: ../../changelog.rst:4623
 msgid "Limit height of layer switcher on small screens (fixes #1136)"
 msgstr ""
 
-#: ../../changelog.rst:4617
+#: ../../changelog.rst:4624
 msgid ""
 "Get rid of next parameter when redirecting to login when permission "
 "missing (fixes #1142)"
 msgstr ""
 
-#: ../../changelog.rst:4618
+#: ../../changelog.rst:4625
 msgid ""
 "Fix apparence of main menu when permissions are missing to view logbook "
 "and admin (ref #1142)"
 msgstr ""
 
-#: ../../changelog.rst:4622
+#: ../../changelog.rst:4629
 msgid "Rework display of lists in detail pages, better factorization"
 msgstr ""
 
-#: ../../changelog.rst:4623
+#: ../../changelog.rst:4630
 msgid "Removed links in logbook list for certain models"
 msgstr ""
 
-#: ../../changelog.rst:4624
+#: ../../changelog.rst:4631
 msgid "Display messages in login page too (useful for redirections)"
 msgstr ""
 
-#: ../../changelog.rst:4626
+#: ../../changelog.rst:4633
 msgid ""
 "Support edition of several fields on the same map, via django-leaflet new"
 " feature (fixes #53)"
 msgstr ""
 
-#: ../../changelog.rst:4630
+#: ../../changelog.rst:4637
 msgid "0.24.3 (2014-06-27)"
 msgstr ""
 
-#: ../../changelog.rst:4634
+#: ../../changelog.rst:4641
 msgid "Fix cursor not removed when terminating topology (fixes #1134)"
 msgstr ""
 
-#: ../../changelog.rst:4635
+#: ../../changelog.rst:4642
 msgid "Fix information desk geometry hard-coded SRID"
 msgstr ""
 
-#: ../../changelog.rst:4639
+#: ../../changelog.rst:4646
 msgid "0.24.2 (2014-06-27)"
 msgstr ""
 
-#: ../../changelog.rst:4643
+#: ../../changelog.rst:4650
 msgid "Fix EPSG:32620 projection file"
 msgstr ""
 
-#: ../../changelog.rst:4644
+#: ../../changelog.rst:4651
 msgid "Fix JS error when path layer is not on map"
 msgstr ""
 
-#: ../../changelog.rst:4645
+#: ../../changelog.rst:4652
 msgid ""
 "Fix start and end markers not shown as snapped on path edition (fixes "
 "#1116)"
 msgstr ""
 
-#: ../../changelog.rst:4646
+#: ../../changelog.rst:4653
 msgid "Fix groups not shown in Adminsite with external authent (fixes #1118)"
 msgstr ""
 
-#: ../../changelog.rst:4647
+#: ../../changelog.rst:4654
 msgid ""
 "Use markers as mouse icons for topology creation, use resize cursors as "
 "fallback only (fixes #1100)"
 msgstr ""
 
-#: ../../changelog.rst:4649
+#: ../../changelog.rst:4656
 msgid "Minor changes in trek print template (ref #1120)"
 msgstr ""
 
-#: ../../changelog.rst:4653
+#: ../../changelog.rst:4660
 msgid "0.24.1 (2014-06-26)"
 msgstr ""
 
-#: ../../changelog.rst:4657
+#: ../../changelog.rst:4664
 msgid "Fix SVG files for difficulty pictograms"
 msgstr ""
 
-#: ../../changelog.rst:4658
+#: ../../changelog.rst:4665
 msgid "Fix group fixtures for \"Rédacteurs\" (fixes #1128)"
 msgstr ""
 
-#: ../../changelog.rst:4659
+#: ../../changelog.rst:4666
 msgid "Fix tab \"None\" in list view (fixes #1127)"
 msgstr ""
 
-#: ../../changelog.rst:4660
+#: ../../changelog.rst:4667
 msgid "Fix external datasources icons in Admin (fixes #1132)"
 msgstr ""
 
-#: ../../changelog.rst:4661
+#: ../../changelog.rst:4668
 msgid "Fix information desk maps in Admin forms (fixes #1130)"
 msgstr ""
 
-#: ../../changelog.rst:4662
+#: ../../changelog.rst:4669
 msgid "Fix topology edition when two forced passages on same path (fixes #1131)"
 msgstr ""
 
-#: ../../changelog.rst:4666
+#: ../../changelog.rst:4673
 msgid "Ordered log entries by date descending (ref #1123)"
 msgstr ""
 
-#: ../../changelog.rst:4667
+#: ../../changelog.rst:4674
 msgid "Renamed \"Data sources\" by \"External data sources\" (fixes #1125)"
 msgstr ""
 
-#: ../../changelog.rst:4668
+#: ../../changelog.rst:4675
 msgid "Renamed \"Foncier\" to \"Statuts\" (fixes #1126)"
 msgstr ""
 
-#: ../../changelog.rst:4672
+#: ../../changelog.rst:4679
 msgid "0.24.0 (2014-06-23)"
 msgstr ""
 
-#: ../../changelog.rst:4674 ../../changelog.rst:4858
+#: ../../changelog.rst:4681 ../../changelog.rst:4865
 msgid "** Breaking changes **"
 msgstr ""
 
-#: ../../changelog.rst:4676
+#: ../../changelog.rst:4683
 msgid ""
 "POI icons shall now have a solid background, since no background is added"
 " in trek detail map anymore."
 msgstr ""
 
-#: ../../changelog.rst:4679
+#: ../../changelog.rst:4686
 msgid ""
 "Pictograms fields were added to trek difficulty, route, network. You can "
 "use the images provided in the ``trekking/fixtures/upload/`` folder."
 msgstr ""
 
-#: ../../changelog.rst:4684
+#: ../../changelog.rst:4691
 msgid "Just before upgrading, delete the following folders ::"
 msgstr ""
 
-#: ../../changelog.rst:4688
+#: ../../changelog.rst:4695
 msgid ""
 "After upgrading, mark all treks as published in the languages of your "
 "choice ::"
 msgstr ""
 
-#: ../../changelog.rst:4696
+#: ../../changelog.rst:4703
 msgid "Public TREK export - hide block label if value is empty (fixes #873)"
 msgstr ""
 
-#: ../../changelog.rst:4697
+#: ../../changelog.rst:4704
 msgid "Add POIs on trek GPX (fixes #774)"
 msgstr ""
 
-#: ../../changelog.rst:4698
+#: ../../changelog.rst:4705
 msgid "Close list filter when click outside (fixes #916)"
 msgstr ""
 
-#: ../../changelog.rst:4699
+#: ../../changelog.rst:4706
 msgid "Rename recurrent field to subcontracting on intervention (fixes #911)"
 msgstr ""
 
-#: ../../changelog.rst:4700
+#: ../../changelog.rst:4707
 msgid "Rename comments field to description on intervention (fixes #927)"
 msgstr ""
 
-#: ../../changelog.rst:4701 ../../changelog.rst:4814
+#: ../../changelog.rst:4708 ../../changelog.rst:4821
 msgid "Show object type in ODT export (fixes #1000)"
 msgstr ""
 
-#: ../../changelog.rst:4702
+#: ../../changelog.rst:4709
 msgid "Show paths extremities on map (fixes #355)"
 msgstr ""
 
-#: ../../changelog.rst:4703
+#: ../../changelog.rst:4710
 msgid ""
 "Ability to reuse topology when adding objects from detail pages (fixes "
 "#574, fixes #998)"
 msgstr ""
 
-#: ../../changelog.rst:4704
+#: ../../changelog.rst:4711
 msgid "Command to generate all elevation charts (fixes #799)"
 msgstr ""
 
-#: ../../changelog.rst:4705
+#: ../../changelog.rst:4712
 msgid "SITRA support in Tourism datasources (fixes #1064)"
 msgstr ""
 
-#: ../../changelog.rst:4706
+#: ../../changelog.rst:4713
 msgid "Added status field on feedback reports (fixes #1075)"
 msgstr ""
 
-#: ../../changelog.rst:4707
+#: ../../changelog.rst:4714
 msgid "Show restricted areas by type in layer switcher (fixes #961)"
 msgstr ""
 
-#: ../../changelog.rst:4708
+#: ../../changelog.rst:4715
 msgid ""
 "Publication status is now controlled by language (fixes #1003). Previous "
 "behaviour can restored by setting ``TREK_PUBLISHED_BY_LANG``` to False."
 msgstr ""
 
-#: ../../changelog.rst:4710
+#: ../../changelog.rst:4717
 msgid "Added publication date on trek (ref #1003)"
 msgstr ""
 
-#: ../../changelog.rst:4711
+#: ../../changelog.rst:4718
 msgid "Ability to see a trek in the different published languages (ref #1003)"
 msgstr ""
 
-#: ../../changelog.rst:4712
+#: ../../changelog.rst:4719
 msgid "A trek can now have several information desks (fixes #1001)"
 msgstr ""
 
-#: ../../changelog.rst:4713
+#: ../../changelog.rst:4720
 msgid "Information desks are now shown in trek detail map (fixes #1001)"
 msgstr ""
 
-#: ../../changelog.rst:4714
+#: ../../changelog.rst:4721
 msgid ""
 "Information desks now have optional photo and position, as well as some "
 "additional fields (fixes #1001)"
 msgstr ""
 
-#: ../../changelog.rst:4716
+#: ../../changelog.rst:4723
 msgid "Disabled marker cluster in trek detail map"
 msgstr ""
 
-#: ../../changelog.rst:4717
+#: ../../changelog.rst:4724
 msgid "Remove background and halo effect on POI icons"
 msgstr ""
 
-#: ../../changelog.rst:4718
+#: ../../changelog.rst:4725
 msgid ""
 "Added 3 new settings to control trek detail map icons size "
 "(``TREK_ICON_SIZE_POI``, ``TREK_ICON_SIZE_PARKING``, "
 "``TREK_ICON_SIZE_INFORMATION_DESK``)"
 msgstr ""
 
-#: ../../changelog.rst:4721
+#: ../../changelog.rst:4728
 msgid "**Minor features**"
 msgstr ""
 
-#: ../../changelog.rst:4723
+#: ../../changelog.rst:4730
 msgid "Intervention disorders is not mandatory anymore (fixes #661)"
 msgstr ""
 
-#: ../../changelog.rst:4724
+#: ../../changelog.rst:4731
 msgid "Improved details in trek form, use Chosen for many-to-many widgets"
 msgstr ""
 
-#: ../../changelog.rst:4725
+#: ../../changelog.rst:4732
 msgid "Documented the configuration of map layers apparence"
 msgstr ""
 
-#: ../../changelog.rst:4726
+#: ../../changelog.rst:4733
 msgid "Show layers colors in layer switcher"
 msgstr ""
 
-#: ../../changelog.rst:4727
+#: ../../changelog.rst:4734
 msgid "Detail page : replace \"Maintenance\" by \"Works\" (fixes #889)"
 msgstr ""
 
-#: ../../changelog.rst:4728
+#: ../../changelog.rst:4735
 msgid ""
 "Detail page : interventions on paths are now grouped together, and a "
 "small icon is shown (fixes #735)"
 msgstr ""
 
-#: ../../changelog.rst:4730
+#: ../../changelog.rst:4737
 msgid "Detail page : show intervention costs (ref #958, fixes #764)"
 msgstr ""
 
-#: ../../changelog.rst:4731
+#: ../../changelog.rst:4738
 msgid "Show project intervention total costs (fixes #958)"
 msgstr ""
 
-#: ../../changelog.rst:4732
+#: ../../changelog.rst:4739
 msgid ""
 "Allow to override the Trek public document template (see *advanced "
 "configuration* in docs)"
 msgstr ""
 
-#: ../../changelog.rst:4734
+#: ../../changelog.rst:4741
 msgid "Close calendar after date choice in intervention form (fixes #928)"
 msgstr ""
 
-#: ../../changelog.rst:4735
+#: ../../changelog.rst:4742
 msgid "Renamed Attachment submit button (fixes #925)"
 msgstr ""
 
-#: ../../changelog.rst:4736
+#: ../../changelog.rst:4743
 msgid ""
 "Added a new setting ``PATH_SNAPPING_DISTANCE`` to control paths snapping "
 "distance in database (default: 1m)"
 msgstr ""
 
-#: ../../changelog.rst:4738
+#: ../../changelog.rst:4745
 msgid ""
 "Allow to disable trails notion (fixes #997) (see *advanced configuration*"
 " in docs)"
 msgstr ""
 
-#: ../../changelog.rst:4740
+#: ../../changelog.rst:4747
 msgid ""
 "Show POI name on hover instead of category in trek detail pages (fixes "
 "#1004)"
 msgstr ""
 
-#: ../../changelog.rst:4741
+#: ../../changelog.rst:4748
 msgid "Form tabs are now always visible while scrolling (fixes #926)"
 msgstr ""
 
-#: ../../changelog.rst:4742
+#: ../../changelog.rst:4749
 msgid "New URL to obtain the attached filelist of an object"
 msgstr ""
 
-#: ../../changelog.rst:4743
+#: ../../changelog.rst:4750
 msgid "Remove float notation in altimetry altitude labels"
 msgstr ""
 
-#: ../../changelog.rst:4744
+#: ../../changelog.rst:4751
 msgid "Control altimetry profiles font using ``ALTIMETRIC_PROFILE_FONT`` setting"
 msgstr ""
 
-#: ../../changelog.rst:4745
+#: ../../changelog.rst:4752
 msgid "Add pictograms to routes and networks (fixes #1102)"
 msgstr ""
 
-#: ../../changelog.rst:4749
+#: ../../changelog.rst:4756
 msgid "Fixed Signage and Infrastructure year filter label (fixes #293)"
 msgstr ""
 
-#: ../../changelog.rst:4750
+#: ../../changelog.rst:4757
 msgid "Fixed paths layers not always shown below other layers (fixes #912)"
 msgstr ""
 
-#: ../../changelog.rst:4751
+#: ../../changelog.rst:4758
 msgid "Clarify legend and title for attachments (fixes #888)"
 msgstr ""
 
-#: ../../changelog.rst:4752
+#: ../../changelog.rst:4759
 msgid "Fixed cannot clear trek fields in database (fixes #1095)"
 msgstr ""
 
-#: ../../changelog.rst:4753
+#: ../../changelog.rst:4760
 msgid "Fixed missing translation of \"Load local file\" (fixes #1085)"
 msgstr ""
 
-#: ../../changelog.rst:4754
+#: ../../changelog.rst:4761
 msgid "POI types are displayed as such in adminsite"
 msgstr ""
 
-#: ../../changelog.rst:4755
+#: ../../changelog.rst:4762
 msgid "Fix duplicate authors in history list in detail pages"
 msgstr ""
 
-#: ../../changelog.rst:4759
+#: ../../changelog.rst:4766
 msgid "Added pictogram on difficulty, useful for *Geotrek-mobile* (fixes #1109)"
 msgstr ""
 
-#: ../../changelog.rst:4760
+#: ../../changelog.rst:4767
 msgid "Added experimental *Geotrek-light* support (ref #1019)"
 msgstr ""
 
-#: ../../changelog.rst:4764
+#: ../../changelog.rst:4771
 msgid "0.23.5 (2014-06-19)"
 msgstr ""
 
-#: ../../changelog.rst:4768
+#: ../../changelog.rst:4775
 msgid "Fix crash when TourInFrance has malformed website or phone"
 msgstr ""
 
-#: ../../changelog.rst:4769
+#: ../../changelog.rst:4776
 msgid "Fix translations not being installed"
 msgstr ""
 
-#: ../../changelog.rst:4773
+#: ../../changelog.rst:4780
 msgid "0.23.4 (2014-06-18)"
 msgstr ""
 
-#: ../../changelog.rst:4777
+#: ../../changelog.rst:4784
 msgid ""
 "Fix massive upgrade bug, where new migrations were ignored. Due to "
 "migration operation introduction in 0.22 installation script."
 msgstr ""
 
-#: ../../changelog.rst:4780
+#: ../../changelog.rst:4787
 msgid ""
 "Special thanks to Noël Martinon, Félix Merzeau, Gil Deluermoz and Camille"
 " Montchicourt for their patience on this."
 msgstr ""
 
-#: ../../changelog.rst:4784
+#: ../../changelog.rst:4791
 msgid "0.23.3 (2014-06-18)"
 msgstr ""
 
-#: ../../changelog.rst:4788
+#: ../../changelog.rst:4795
 msgid "Fix static files compression when using Google Mercator projection in maps"
 msgstr ""
 
-#: ../../changelog.rst:4789
+#: ../../changelog.rst:4796
 msgid ""
 "Fix intermediary points order in topology de/serialization, and remove "
 "useless topology serialization optimizations (fixes #1031)"
 msgstr ""
 
-#: ../../changelog.rst:4794
+#: ../../changelog.rst:4801
 msgid "0.23.2 (2014-06-13)"
 msgstr ""
 
-#: ../../changelog.rst:4798
+#: ../../changelog.rst:4805
 msgid "Fixed land records not shown in detail pages"
 msgstr ""
 
-#: ../../changelog.rst:4799
+#: ../../changelog.rst:4806
 msgid "Fixed JSON DEM area extent for treks"
 msgstr ""
 
-#: ../../changelog.rst:4800
+#: ../../changelog.rst:4807
 msgid "Fixed targets list for tourism datasources (fixes #1091)"
 msgstr ""
 
-#: ../../changelog.rst:4801
+#: ../../changelog.rst:4808
 msgid ""
 "Cache tourism datasources for one day (setting "
 "``CACHE_TIMEOUT_TOURISM_DATASOURCES``)"
 msgstr ""
 
-#: ../../changelog.rst:4802
+#: ../../changelog.rst:4809
 msgid "Fix crashes with TourInFrance sources"
 msgstr ""
 
-#: ../../changelog.rst:4803
+#: ../../changelog.rst:4810
 msgid "Add link to OSM in feedback email (fixes #1089, #1093)"
 msgstr ""
 
-#: ../../changelog.rst:4804
+#: ../../changelog.rst:4811
 msgid "Fix feedback email translation (fixes #1087)"
 msgstr ""
 
-#: ../../changelog.rst:4805
+#: ../../changelog.rst:4812
 msgid ""
 "Fix problem with permission check \"read attachment\" in detail page "
 "(fixes #1092)"
 msgstr ""
 
-#: ../../changelog.rst:4806
+#: ../../changelog.rst:4813
 msgid "Fix measure control appearing twice in forms (fixes #1078)"
 msgstr ""
 
-#: ../../changelog.rst:4807
+#: ../../changelog.rst:4814
 msgid "Fix 404 on download buttons from list views"
 msgstr ""
 
-#: ../../changelog.rst:4808
+#: ../../changelog.rst:4815
 msgid "Fix POI translated fields not tabbed (fixes #1065)"
 msgstr ""
 
-#: ../../changelog.rst:4809
+#: ../../changelog.rst:4816
 msgid "Fix missing translation of \"Add a new POI\" (fixes #1086)"
 msgstr ""
 
-#: ../../changelog.rst:4810
+#: ../../changelog.rst:4817
 msgid "Fix invalid snapping when save path without editing geometry (fixes #1099)"
 msgstr ""
 
-#: ../../changelog.rst:4811
+#: ../../changelog.rst:4818
 msgid "Add missing properties in feedback report detail page."
 msgstr ""
 
-#: ../../changelog.rst:4812
+#: ../../changelog.rst:4819
 msgid "Hide all modules information in report detail page."
 msgstr ""
 
-#: ../../changelog.rst:4813
+#: ../../changelog.rst:4820
 msgid "Add missing translations of feedback module."
 msgstr ""
 
-#: ../../changelog.rst:4817 ../../changelog.rst:4898
+#: ../../changelog.rst:4824 ../../changelog.rst:4905
 msgid "** Internal changes **"
 msgstr ""
 
-#: ../../changelog.rst:4819
+#: ../../changelog.rst:4826
 msgid "Upgraded to Mapentity 1.4.0"
 msgstr ""
 
-#: ../../changelog.rst:4820
+#: ../../changelog.rst:4827
 msgid "Upgraded to Leaflet 0.7.3"
 msgstr ""
 
-#: ../../changelog.rst:4822
+#: ../../changelog.rst:4829
 msgid "** Installation **"
 msgstr ""
 
-#: ../../changelog.rst:4824
+#: ../../changelog.rst:4831
 msgid ""
 "Fixed content types migration of land to zoning apps (Thanks Noël "
 "Martinon)"
 msgstr ""
 
-#: ../../changelog.rst:4826
+#: ../../changelog.rst:4833
 msgid ""
 "UbuntuGIS stable maintainers have *upgraded* (sic) GDAL to 1.10.0. "
 "Upgrading GDAL is painful, and PostGIS packages may have to be "
@@ -8654,25 +8665,25 @@ msgid ""
 " to run PostGIS on a different server*."
 msgstr ""
 
-#: ../../changelog.rst:4833
+#: ../../changelog.rst:4840
 msgid ""
 "On June 2th 2014, the Ubuntu GIS stable repository switched from "
 "``libgdal1`` to ``libgdal1h``. It broke the deployment script of many "
 "projects, including *Geotrek*."
 msgstr ""
 
-#: ../../changelog.rst:4837
+#: ../../changelog.rst:4844
 msgid ""
 "It is a good thing, since it paves the way for the last Ubuntu LTS "
 "release (14.04). However, it breaks the *Long Term Support* philosophy of"
 " the previous one (12.04), supposed to be supported until 2019."
 msgstr ""
 
-#: ../../changelog.rst:4839
+#: ../../changelog.rst:4846
 msgid "**Morality** : we cannot trust the *Ubuntu GIS stable* repository anymore."
 msgstr ""
 
-#: ../../changelog.rst:4841
+#: ../../changelog.rst:4848
 msgid ""
 "Regarding *Geotrek*, such upgrades of Ubuntu packages is not supposed to "
 "be covered by its installation script. If you face any problems, please "
@@ -8680,1187 +8691,1187 @@ msgid ""
 " example)."
 msgstr ""
 
-#: ../../changelog.rst:4847
+#: ../../changelog.rst:4854
 msgid "0.23.1 (2014-05-22)"
 msgstr ""
 
-#: ../../changelog.rst:4851
+#: ../../changelog.rst:4858
 msgid "Fixed regression when editing topologies without modification"
 msgstr ""
 
-#: ../../changelog.rst:4852
+#: ../../changelog.rst:4859
 msgid "Fixed widget for Trails to allow linear topologies only"
 msgstr ""
 
-#: ../../changelog.rst:4856
+#: ../../changelog.rst:4863
 msgid "0.23 (2014-05-22)"
 msgstr ""
 
-#: ../../changelog.rst:4860
+#: ../../changelog.rst:4867
 msgid "Read all release notes carefully."
 msgstr ""
 
-#: ../../changelog.rst:4862
+#: ../../changelog.rst:4869
 msgid ""
 "Trails are now managed as topologies (fixes #370). Existing trails "
 "geometries are likely to be **LOST** (*see below*)"
 msgstr ""
 
-#: ../../changelog.rst:4864
+#: ../../changelog.rst:4871
 msgid "Rename ``mailadmin`` to ``mailadmins`` in ``etc/settings.ini``"
 msgstr ""
 
-#: ../../changelog.rst:4865
+#: ../../changelog.rst:4872
 msgid "Permission systems has been refactored (*see below*)"
 msgstr ""
 
-#: ../../changelog.rst:4869
+#: ../../changelog.rst:4876
 msgid "Force browser cache revalidation of geojson data (fixes #843)"
 msgstr ""
 
-#: ../../changelog.rst:4870
+#: ../../changelog.rst:4877
 msgid "Force browser cache revalidation for path graph (fixes #1029)"
 msgstr ""
 
-#: ../../changelog.rst:4871
+#: ../../changelog.rst:4878
 msgid "Fix deletion porblems in AdminSite (fixes #1008)"
 msgstr ""
 
-#: ../../changelog.rst:4872
+#: ../../changelog.rst:4879
 msgid "Trek advised parking and public transport are translatable (fixes #1024)"
 msgstr ""
 
-#: ../../changelog.rst:4873
+#: ../../changelog.rst:4880
 msgid ""
 "Fix missing translation \"no filters\" and \"current criterias\" (fixes "
 "#884)"
 msgstr ""
 
-#: ../../changelog.rst:4874
+#: ../../changelog.rst:4881
 msgid "Fix PDF versions of documents not being translated (fixes #1028)"
 msgstr ""
 
-#: ../../changelog.rst:4876
+#: ../../changelog.rst:4883
 msgid "** New features **"
 msgstr ""
 
-#: ../../changelog.rst:4878
+#: ../../changelog.rst:4885
 msgid ""
 "Command to import shapefile with points into POI as topologies (fixes "
 "#952)"
 msgstr ""
 
-#: ../../changelog.rst:4879
+#: ../../changelog.rst:4886
 msgid "Add views to serve DEM on object area as JSON (*Geotrek-Rando 3D*)"
 msgstr ""
 
-#: ../../changelog.rst:4880
+#: ../../changelog.rst:4887
 msgid ""
 "New tourism module : external datasources can be configured from "
 "Adminsite (*GeoJSON, TourInFrance, ...*) and added to maps (by module, or"
 " published on *Geotrek-rando*...)"
 msgstr ""
 
-#: ../../changelog.rst:4882
+#: ../../changelog.rst:4889
 msgid "Show number of attached files in tab (fixes #743)"
 msgstr ""
 
-#: ../../changelog.rst:4883
+#: ../../changelog.rst:4890
 msgid "New permission to control download of attachments"
 msgstr ""
 
-#: ../../changelog.rst:4884
+#: ../../changelog.rst:4891
 msgid "New permission to allow users or groups to bypass structure restrictions"
 msgstr ""
 
-#: ../../changelog.rst:4885
+#: ../../changelog.rst:4892
 msgid ""
 "Add a setting to serve attached files as download (default: True) (fixes "
 "#976)"
 msgstr ""
 
-#: ../../changelog.rst:4886
+#: ../../changelog.rst:4893
 msgid "Track objects creations, changes and deletions (fixes #300)"
 msgstr ""
 
-#: ../../changelog.rst:4887
+#: ../../changelog.rst:4894
 msgid "Added a reader group (fixes #495)"
 msgstr ""
 
-#: ../../changelog.rst:4888
+#: ../../changelog.rst:4895
 msgid "Topologies are not recreated if user did not edit field (fixes #833)"
 msgstr ""
 
-#: ../../changelog.rst:4889
+#: ../../changelog.rst:4896
 msgid "Added static file for projection EPSG:32620"
 msgstr ""
 
-#: ../../changelog.rst:4890
+#: ../../changelog.rst:4897
 msgid "Show land objects in menu (fixes #942)"
 msgstr ""
 
-#: ../../changelog.rst:4891
+#: ../../changelog.rst:4898
 msgid "Documented configuration of custom projections (fixes #1037)"
 msgstr ""
 
-#: ../../changelog.rst:4892
+#: ../../changelog.rst:4899
 msgid "Buttons in the list menu to add new objects easily"
 msgstr ""
 
-#: ../../changelog.rst:4893
+#: ../../changelog.rst:4900
 msgid "Add fullscreen button on maps (fixes #904)"
 msgstr ""
 
-#: ../../changelog.rst:4894
+#: ../../changelog.rst:4901
 msgid "Add all controls on detail map (fixes #907)"
 msgstr ""
 
-#: ../../changelog.rst:4895
+#: ../../changelog.rst:4902
 msgid "Add a button to close filters (fixes #424)"
 msgstr ""
 
-#: ../../changelog.rst:4896
+#: ../../changelog.rst:4903
 msgid ""
 "Added new sections in documention : *FAQ*, *User-manal* and *Advanced "
 "configuration*"
 msgstr ""
 
-#: ../../changelog.rst:4900
+#: ../../changelog.rst:4907
 msgid "Enabled database connection pooling in production"
 msgstr ""
 
-#: ../../changelog.rst:4901
+#: ../../changelog.rst:4908
 msgid "An error is raised if SRID has not unit in meters (fixes #921)"
 msgstr ""
 
-#: ../../changelog.rst:4902
+#: ../../changelog.rst:4909
 msgid "Zoning and land modules are now splitted (fixes #954)"
 msgstr ""
 
-#: ../../changelog.rst:4903
+#: ../../changelog.rst:4910
 msgid ""
 "Complete refactor of geographical form fields. Now uses *django-"
 "mapentity* from its own repository instead of internal orphan branch."
 msgstr ""
 
-#: ../../changelog.rst:4905
+#: ../../changelog.rst:4912
 msgid ""
 "Complete refactor of maps initialization, without inline preprocessed "
 "JavaScript"
 msgstr ""
 
-#: ../../changelog.rst:4906
+#: ../../changelog.rst:4913
 msgid ""
 "Rely on Django permissions to control access to detail, list and exports "
 "(fixes #675)"
 msgstr ""
 
-#: ../../changelog.rst:4907
+#: ../../changelog.rst:4914
 msgid "Core and altimetry modules are now splitted (fixes #996)"
 msgstr ""
 
-#: ../../changelog.rst:4908
+#: ../../changelog.rst:4915
 msgid "Renamed treks POIs GeoJSON properties"
 msgstr ""
 
-#: ../../changelog.rst:4912
+#: ../../changelog.rst:4919
 msgid ""
 "Before upgrading, backup your trail records and geometries, using pgAdmin"
 " ::"
 msgstr ""
 
-#: ../../changelog.rst:4921
+#: ../../changelog.rst:4928
 msgid ""
 "Before upgrade, rename ``mailadmin`` to ``mailadmins`` and add a new line"
 " ``mailmanagers`` in ``etc/settings.ini``. See *Email settings* section "
 "in documentation."
 msgstr ""
 
-#: ../../changelog.rst:4925
+#: ../../changelog.rst:4932
 msgid "Just before upgrading, delete the following folders  ::"
 msgstr ""
 
-#: ../../changelog.rst:4931
+#: ../../changelog.rst:4938
 msgid ""
 "After upgrading, load the default permissions of the previous groups, "
 "otherwise users won't have access to their modules ::"
 msgstr ""
 
-#: ../../changelog.rst:4937
+#: ../../changelog.rst:4944
 msgid ""
 "After upgrading, make sure *Active* is checked for the user "
 "*__internal__* otherwise screenshotting won't work."
 msgstr ""
 
-#: ../../changelog.rst:4940
+#: ../../changelog.rst:4947
 msgid "After upgrading, load basic data for the new module ::"
 msgstr ""
 
-#: ../../changelog.rst:4944
+#: ../../changelog.rst:4951
 msgid ""
 "After upgrading, make sure the user specified in *Geotrek-rando* is in "
 "the group *Geotrek-rando*, or has at least the following permissions in "
 "the AdminSite :"
 msgstr ""
 
-#: ../../changelog.rst:4948
+#: ../../changelog.rst:4955
 msgid "``paperclip | attachment | Can read attachments``"
 msgstr ""
 
-#: ../../changelog.rst:4949
+#: ../../changelog.rst:4956
 msgid "``trekking | Trek | Can read Trek``"
 msgstr ""
 
-#: ../../changelog.rst:4950
+#: ../../changelog.rst:4957
 msgid "``trekking | Trek | Can export Trek``"
 msgstr ""
 
-#: ../../changelog.rst:4951
+#: ../../changelog.rst:4958
 msgid "``trekking | POI | Can read POI``"
 msgstr ""
 
-#: ../../changelog.rst:4952
+#: ../../changelog.rst:4959
 msgid "``trekking | POI | Can export POI``"
 msgstr ""
 
-#: ../../changelog.rst:4953
+#: ../../changelog.rst:4960
 msgid "``feedback | Report | Can add report``"
 msgstr ""
 
-#: ../../changelog.rst:4955
+#: ../../changelog.rst:4962
 msgid ""
 "After upgrading, compare visually the resulting migrated trails using "
 "QGis, by opening both layers ``l_v_sentier`` and ``backup_sentiers``."
 msgstr ""
 
-#: ../../changelog.rst:4960
+#: ../../changelog.rst:4967
 msgid "0.22.6 (2014-04-27)"
 msgstr ""
 
-#: ../../changelog.rst:4962
+#: ../../changelog.rst:4969
 msgid ""
 "Remove hard-coded mentions of EPSG:2154 in database initial migrations "
 "(fixes #1020)"
 msgstr ""
 
-#: ../../changelog.rst:4964
+#: ../../changelog.rst:4971
 msgid "Fix version download and unzip in installation script."
 msgstr ""
 
-#: ../../changelog.rst:4966
+#: ../../changelog.rst:4973
 msgid ""
 "Thanks Noël Martinon, from Guadeloupe National Park, for reporting both "
 "issues."
 msgstr ""
 
-#: ../../changelog.rst:4970
+#: ../../changelog.rst:4977
 msgid "0.22.5 (2014-03-19)"
 msgstr ""
 
-#: ../../changelog.rst:4972
+#: ../../changelog.rst:4979
 msgid "Fix compilation of translations (ref #970)"
 msgstr ""
 
-#: ../../changelog.rst:4973
+#: ../../changelog.rst:4980
 msgid "Fix distinction between languages and translated languages (fixes #968)"
 msgstr ""
 
-#: ../../changelog.rst:4974
+#: ../../changelog.rst:4981
 msgid "Fix history tabs not being shown after upgrade to Django 1.6 (fixes #975)"
 msgstr ""
 
-#: ../../changelog.rst:4975
+#: ../../changelog.rst:4982
 msgid "Fix regression on land layer label colors (fixes #980)"
 msgstr ""
 
-#: ../../changelog.rst:4976
+#: ../../changelog.rst:4983
 msgid "Fix attached files not shown after file upload/delete (fixes #933)"
 msgstr ""
 
-#: ../../changelog.rst:4977
+#: ../../changelog.rst:4984
 msgid "Fix links being removed from trek descriptions (fixes #981)"
 msgstr ""
 
-#: ../../changelog.rst:4978
+#: ../../changelog.rst:4985
 msgid "Fix missing thumbnail in trek and POI detail pages"
 msgstr ""
 
-#: ../../changelog.rst:4979
+#: ../../changelog.rst:4986
 msgid "Fix black background on map captures (fixes #979)"
 msgstr ""
 
-#: ../../changelog.rst:4980
+#: ../../changelog.rst:4987
 msgid "Increased scale text size on map captures (fixes #850)"
 msgstr ""
 
-#: ../../changelog.rst:4981
+#: ../../changelog.rst:4988
 msgid "Show map attributions on map captures (fixes #852)"
 msgstr ""
 
-#: ../../changelog.rst:4982
+#: ../../changelog.rst:4989
 msgid "Fix aspect ratios of map in trek public documents (fixes #849)"
 msgstr ""
 
-#: ../../changelog.rst:4983
+#: ../../changelog.rst:4990
 msgid "Fix objects list not being filtered on map extent (fixes #982)"
 msgstr ""
 
-#: ../../changelog.rst:4984
+#: ../../changelog.rst:4991
 msgid "Fix coherence of map layer when text search in objects list (fixes #702)"
 msgstr ""
 
-#: ../../changelog.rst:4985
+#: ../../changelog.rst:4992
 msgid "Fix number of results not refresh on text search (fixes #865)"
 msgstr ""
 
-#: ../../changelog.rst:4987
+#: ../../changelog.rst:4994
 msgid "Added north arrow in map image exports (fixes #851)"
 msgstr ""
 
-#: ../../changelog.rst:4988
+#: ../../changelog.rst:4995
 msgid ""
 "Removed darker effect on backgrounds for map image exports, and added "
 "internal advanced setting ``MAPENTITY_CONFIG['MAP_BACKGROUND_FOGGED'] = "
 "True``"
 msgstr ""
 
-#: ../../changelog.rst:4993
+#: ../../changelog.rst:5000
 msgid "0.22.4 (2014-03-06)"
 msgstr ""
 
-#: ../../changelog.rst:4995
+#: ../../changelog.rst:5002
 msgid "Fix install.sh not compiling locale messages (fixes #965)"
 msgstr ""
 
-#: ../../changelog.rst:4996
+#: ../../changelog.rst:5003
 msgid ""
 "Moved trek completeness fields to setting `TREK_COMPLETENESS_FIELDS`. "
 "Duration and difficulty were added, arrival was removed (fixes #967)"
 msgstr ""
 
-#: ../../changelog.rst:4998
+#: ../../changelog.rst:5005
 msgid "Fix regression about source locale messages (fixes #970)"
 msgstr ""
 
-#: ../../changelog.rst:4999
+#: ../../changelog.rst:5006
 msgid "Fix regression link `Back to application` lost from adminsite (fixes #971)"
 msgstr ""
 
-#: ../../changelog.rst:5000
+#: ../../changelog.rst:5007
 msgid "Serve uploaded files as attachments (fixes #972)"
 msgstr ""
 
-#: ../../changelog.rst:5001
+#: ../../changelog.rst:5008
 msgid "Remove help texts being shown from filter forms (fixes #966)"
 msgstr ""
 
-#: ../../changelog.rst:5002
+#: ../../changelog.rst:5009
 msgid "Fix form pills for translated languages (fixes #968)"
 msgstr ""
 
-#: ../../changelog.rst:5005
+#: ../../changelog.rst:5012
 msgid "0.22.3 (2014-02-17)"
 msgstr ""
 
-#: ../../changelog.rst:5007
+#: ../../changelog.rst:5014
 msgid "Fix install.sh help not being shown"
 msgstr ""
 
-#: ../../changelog.rst:5008
+#: ../../changelog.rst:5015
 msgid ""
 "Fix screenshots being empty if deployed behind reverse proxy with rool "
 "url (fixes #687)"
 msgstr ""
 
-#: ../../changelog.rst:5009
+#: ../../changelog.rst:5016
 msgid "Fix GPX file layer circle marker size (fixes #930)"
 msgstr ""
 
-#: ../../changelog.rst:5010
+#: ../../changelog.rst:5017
 msgid "Remove JS libraries from login page"
 msgstr ""
 
-#: ../../changelog.rst:5011
+#: ../../changelog.rst:5018
 msgid "Fix install.log being removed during installation"
 msgstr ""
 
-#: ../../changelog.rst:5012
+#: ../../changelog.rst:5019
 msgid "Fix execution characters being shown during DB backup prompt"
 msgstr ""
 
-#: ../../changelog.rst:5013
+#: ../../changelog.rst:5020
 msgid "Fix PhantomJS and CasperJS installation and deployment"
 msgstr ""
 
-#: ../../changelog.rst:5014
+#: ../../changelog.rst:5021
 msgid "Added more automatic frontend tests"
 msgstr ""
 
-#: ../../changelog.rst:5015
+#: ../../changelog.rst:5022
 msgid "Default allowed hosts is now `*`"
 msgstr ""
 
-#: ../../changelog.rst:5018
+#: ../../changelog.rst:5025
 msgid "0.22.2 (2014-02-14)"
 msgstr ""
 
-#: ../../changelog.rst:5020
+#: ../../changelog.rst:5027
 msgid "Fix secured media URLs when using a non empty `rooturl` setting"
 msgstr ""
 
-#: ../../changelog.rst:5021
+#: ../../changelog.rst:5028
 msgid "Fix proxy errors by disabling keep-alive (fixes #906)"
 msgstr ""
 
-#: ../../changelog.rst:5024
+#: ../../changelog.rst:5031
 msgid "0.22.1 (2014-02-13)"
 msgstr ""
 
-#: ../../changelog.rst:5026
+#: ../../changelog.rst:5033
 msgid ""
 "Prevent install script to delete existing media files from disk in some "
 "situations."
 msgstr ""
 
-#: ../../changelog.rst:5030
+#: ../../changelog.rst:5037
 msgid "0.22 (2014-02-12)"
 msgstr ""
 
-#: ../../changelog.rst:5032
+#: ../../changelog.rst:5039
 msgid "**Before upgrade**"
 msgstr ""
 
-#: ../../changelog.rst:5034
+#: ../../changelog.rst:5041
 msgid "Backup your database."
 msgstr ""
 
-#: ../../changelog.rst:5035
+#: ../../changelog.rst:5042
 msgid ""
 "If you upgrade in the same application folder, first delete the `geotrek`"
 " sub-folder."
 msgstr ""
 
-#: ../../changelog.rst:5037
+#: ../../changelog.rst:5044
 msgid "Use `install.sh` to upgrade (`make deploy` won't be enough)"
 msgstr ""
 
-#: ../../changelog.rst:5038
+#: ../../changelog.rst:5045
 msgid "After upgrade, make sure the following query returns only ~23 results:"
 msgstr ""
 
-#: ../../changelog.rst:5040
+#: ../../changelog.rst:5047
 msgid "SELECT COUNT(*) FROM south_migrationhistory;"
 msgstr ""
 
-#: ../../changelog.rst:5043
+#: ../../changelog.rst:5050
 msgid "**BREAKING changes**"
 msgstr ""
 
-#: ../../changelog.rst:5045
+#: ../../changelog.rst:5052
 msgid "For upgrades, Geotrek 0.21 is required."
 msgstr ""
 
-#: ../../changelog.rst:5046
+#: ../../changelog.rst:5053
 msgid "Uploaded files are now restricted to authenticated users (fixes #729)"
 msgstr ""
 
-#: ../../changelog.rst:5050
+#: ../../changelog.rst:5057
 msgid "*Geotrek-rando* 1.23 or higher is required to synchronize content."
 msgstr ""
 
-#: ../../changelog.rst:5052
+#: ../../changelog.rst:5059
 msgid "**NEW features**"
 msgstr ""
 
-#: ../../changelog.rst:5054
+#: ../../changelog.rst:5061
 msgid ""
 "In list view, click on map brings to detail page, mouse over highlights "
 "in list."
 msgstr ""
 
-#: ../../changelog.rst:5055
+#: ../../changelog.rst:5062
 msgid "Show path icon if intervention is not on infrastructure (fixes #909)"
 msgstr ""
 
-#: ../../changelog.rst:5056
+#: ../../changelog.rst:5063
 msgid "Add spanish translation"
 msgstr ""
 
-#: ../../changelog.rst:5057
+#: ../../changelog.rst:5064
 msgid "Add photographie into default attachments filetype"
 msgstr ""
 
-#: ../../changelog.rst:5058
+#: ../../changelog.rst:5065
 msgid ""
 "Map location combobox (Cities, Districts, Areas) are not shown if empty "
 "or disabled."
 msgstr ""
 
-#: ../../changelog.rst:5059
+#: ../../changelog.rst:5066
 msgid "Several database views have been created (fixes #934)"
 msgstr ""
 
-#: ../../changelog.rst:5060
+#: ../../changelog.rst:5067
 msgid "Remove dots from path icon (fixes #939)"
 msgstr ""
 
-#: ../../changelog.rst:5061
+#: ../../changelog.rst:5068
 msgid ""
 "Intervention, infrastructure and project filters list of years is now "
 "dynamic (fixes #948)"
 msgstr ""
 
-#: ../../changelog.rst:5062
+#: ../../changelog.rst:5069
 msgid ""
 "Application available languages (*english*, *french*, *italian*, "
 "*spanish*) are now distinct from translated content languages "
 "(`languages` value in :file:`settings.ini`)"
 msgstr ""
 
-#: ../../changelog.rst:5065
+#: ../../changelog.rst:5072
 msgid "Minor changes"
 msgstr ""
 
-#: ../../changelog.rst:5067
+#: ../../changelog.rst:5074
 msgid "Improved apparence of map controls"
 msgstr ""
 
-#: ../../changelog.rst:5068
+#: ../../changelog.rst:5075
 msgid "Improved apparence of path intermediary points"
 msgstr ""
 
-#: ../../changelog.rst:5069
+#: ../../changelog.rst:5076
 msgid "Improved apparence of form validation buttons"
 msgstr ""
 
-#: ../../changelog.rst:5070
+#: ../../changelog.rst:5077
 msgid "Add auto-generated docs at /admin/doc/"
 msgstr ""
 
-#: ../../changelog.rst:5071
+#: ../../changelog.rst:5078
 msgid "Nicer installation script output"
 msgstr ""
 
-#: ../../changelog.rst:5073
+#: ../../changelog.rst:5080
 msgid "Installation script"
 msgstr ""
 
-#: ../../changelog.rst:5075
+#: ../../changelog.rst:5082
 msgid "Scan and ortho attributions can now be set using `scan_attributions` and"
 msgstr ""
 
-#: ../../changelog.rst:5076
+#: ../../changelog.rst:5083
 msgid "Propose to backup DB before Geotrek upgrade (fixes #804)"
 msgstr ""
 
-#: ../../changelog.rst:5077
+#: ../../changelog.rst:5084
 msgid ""
 "Settings edition prompt only happens at first install "
 "`ortho_attributions` in *settings.ini*."
 msgstr ""
 
-#: ../../changelog.rst:5082 ../../changelog.rst:5257
+#: ../../changelog.rst:5089 ../../changelog.rst:5264
 msgid "Fix convert urls behind reverse proxy with prefix"
 msgstr ""
 
-#: ../../changelog.rst:5083
+#: ../../changelog.rst:5090
 msgid ""
 "Fix deployment problem if ``layercolor_others`` not overidden in "
 "settings.ini"
 msgstr ""
 
-#: ../../changelog.rst:5084
+#: ../../changelog.rst:5091
 msgid ""
 "Fix topology kinds to be 'INTERVENTION' for intervention without "
 "signage/infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:5085
+#: ../../changelog.rst:5092
 msgid "Fix restricted areas types display in admin (fixes #943)"
 msgstr ""
 
-#: ../../changelog.rst:5086
+#: ../../changelog.rst:5093
 msgid "Fix list ordering of trek relationships and web links (fixes #929)"
 msgstr ""
 
-#: ../../changelog.rst:5087
+#: ../../changelog.rst:5094
 msgid "Fix nginx log files being already empty after logrotate (fixes #932)"
 msgstr ""
 
-#: ../../changelog.rst:5088
+#: ../../changelog.rst:5095
 msgid "Fix project add button when no permission"
 msgstr ""
 
-#: ../../changelog.rst:5092
+#: ../../changelog.rst:5099
 msgid ""
 "List of restricted areas is not shown on map by default anymore. Restore "
 "previous behaviour with advanced setting `LAND_BBOX_AREAS_ENABLED` as "
 "True."
 msgstr ""
 
-#: ../../changelog.rst:5097
+#: ../../changelog.rst:5104
 msgid "Upgrade to Django 1.6 (fixes #938)"
 msgstr ""
 
-#: ../../changelog.rst:5098
+#: ../../changelog.rst:5105
 msgid "Upgrade to Leaflet 0.7"
 msgstr ""
 
-#: ../../changelog.rst:5099
+#: ../../changelog.rst:5106
 msgid "Upgrade a great number to python and JavaScript libraries"
 msgstr ""
 
-#: ../../changelog.rst:5100
+#: ../../changelog.rst:5107
 msgid ""
 "An internal user (with login permission) is used to authenticate the "
 "Conversion and Capture services."
 msgstr ""
 
-#: ../../changelog.rst:5102
+#: ../../changelog.rst:5109
 msgid "Installation script is modular (standalone, geotrek only, ...)"
 msgstr ""
 
-#: ../../changelog.rst:5103
+#: ../../changelog.rst:5110
 msgid "Developement server now listens on all interfaces by default"
 msgstr ""
 
-#: ../../changelog.rst:5104
+#: ../../changelog.rst:5111
 msgid ""
 "Database migrations were resetted, no postgres `FATAL ERROR` message will"
 " be emitted on fresh install anymore (fixes #937). See *Troubleshooting* "
 "in documentation."
 msgstr ""
 
-#: ../../changelog.rst:5109
+#: ../../changelog.rst:5116
 msgid "0.21.2 (2014-02-04)"
 msgstr ""
 
-#: ../../changelog.rst:5113
+#: ../../changelog.rst:5120
 msgid ""
 "Warn on tiling landscape/portrait spatial extent only if map with local "
 "projection"
 msgstr ""
 
-#: ../../changelog.rst:5114
+#: ../../changelog.rst:5121
 msgid ""
 "Safety check on thumbnailing if images are missing from disk (*useful for"
 " troubleshooting, when importing existing dumps*)."
 msgstr ""
 
-#: ../../changelog.rst:5116
+#: ../../changelog.rst:5123
 msgid "Fix overlapping filter if no records present (fixes #931)"
 msgstr ""
 
-#: ../../changelog.rst:5120
+#: ../../changelog.rst:5127
 msgid "0.21.1 (2013-12-11)"
 msgstr ""
 
-#: ../../changelog.rst:5124
+#: ../../changelog.rst:5131
 msgid ""
 "Smooth DEM drapping, improving altimetric information and profiles (fixes"
 " #840, ref #776)"
 msgstr ""
 
-#: ../../changelog.rst:5128
+#: ../../changelog.rst:5135
 msgid "Signage forms are now restricted by structure (fixes #917)"
 msgstr ""
 
-#: ../../changelog.rst:5129
+#: ../../changelog.rst:5136
 msgid ""
 "Fix geometries computation when path split occurs on return topology "
 "(fixes #899)"
 msgstr ""
 
-#: ../../changelog.rst:5130
+#: ../../changelog.rst:5137
 msgid "Add title on links in list views (fixes #913)"
 msgstr ""
 
-#: ../../changelog.rst:5131
+#: ../../changelog.rst:5138
 msgid "Prevent horizontal scroll on forms, caused by textareas (fixes #914)"
 msgstr ""
 
-#: ../../changelog.rst:5132
+#: ../../changelog.rst:5139
 msgid "Fix empty 3d geometry of point topologies with offset (fixes #918)"
 msgstr ""
 
-#: ../../changelog.rst:5136
+#: ../../changelog.rst:5143
 msgid ""
 "In order to recompute all paths topologies altimetry information, you can"
 " perform the following queries:"
 msgstr ""
 
-#: ../../changelog.rst:5139
+#: ../../changelog.rst:5146
 msgid ""
 "``UPDATE l_t_troncon SET geom = geom;`` ``UPDATE e_t_evenement SET "
 "decallage = decallage;``"
 msgstr ""
 
-#: ../../changelog.rst:5142
+#: ../../changelog.rst:5149
 msgid ""
 "Reading information from rasters is costly. Be prepared to wait for a "
 "while."
 msgstr ""
 
-#: ../../changelog.rst:5146
+#: ../../changelog.rst:5153
 msgid "0.21 (2013-11-28)"
 msgstr ""
 
-#: ../../changelog.rst:5150
+#: ../../changelog.rst:5157
 msgid "Increase height of multiple select (fixes #891)"
 msgstr ""
 
-#: ../../changelog.rst:5151
+#: ../../changelog.rst:5158
 msgid "Add project field in intervention filter (fixes #896)"
 msgstr ""
 
-#: ../../changelog.rst:5152
+#: ../../changelog.rst:5159
 msgid "Many minor improvements for infrastructures in adminsite (fixes #886)"
 msgstr ""
 
-#: ../../changelog.rst:5153
+#: ../../changelog.rst:5160
 msgid "Add category in intervention filter (fixes #887)"
 msgstr ""
 
-#: ../../changelog.rst:5157
+#: ../../changelog.rst:5164
 msgid "Fix KML coordinates not being in 3D."
 msgstr ""
 
-#: ../../changelog.rst:5158
+#: ../../changelog.rst:5165
 msgid "GPX now has trek description (fixes #775)"
 msgstr ""
 
-#: ../../changelog.rst:5159
+#: ../../changelog.rst:5166
 msgid "Order overlapping topologies by order of progression (fixes #777)"
 msgstr ""
 
-#: ../../changelog.rst:5160
+#: ../../changelog.rst:5167
 msgid "Improved TinyMCE configuration, for resize and cleanup (fixes #351, #711)"
 msgstr ""
 
-#: ../../changelog.rst:5161
+#: ../../changelog.rst:5168
 msgid "Changed trek duration interval for notion of days (fixes #880)"
 msgstr ""
 
-#: ../../changelog.rst:5162
+#: ../../changelog.rst:5169
 msgid "Show city departure in trek public export (fixes #881)"
 msgstr ""
 
-#: ../../changelog.rst:5163
+#: ../../changelog.rst:5170
 msgid "Document customization of TinyMCE config (fixes #882)"
 msgstr ""
 
-#: ../../changelog.rst:5164
+#: ../../changelog.rst:5171
 msgid "Fix 404 error on path delete (fixes #900)"
 msgstr ""
 
-#: ../../changelog.rst:5165
+#: ../../changelog.rst:5172
 msgid "Fix project constraints not being displayed in details (fixes #893)"
 msgstr ""
 
-#: ../../changelog.rst:5166
+#: ../../changelog.rst:5173
 msgid "Fix organism translation in project form (fixes #892)"
 msgstr ""
 
-#: ../../changelog.rst:5167
+#: ../../changelog.rst:5174
 msgid "Fix apparence of forms on small screen (fixes #744, #902)"
 msgstr ""
 
-#: ../../changelog.rst:5168
+#: ../../changelog.rst:5175
 msgid "Fix modify button being hidden to editors (fixes #901)"
 msgstr ""
 
-#: ../../changelog.rst:5169
+#: ../../changelog.rst:5176
 msgid "Fix overlap between map controls and label (fixes #883)"
 msgstr ""
 
-#: ../../changelog.rst:5170
+#: ../../changelog.rst:5177
 msgid "Fix translation of district in list filters (fixes #890)"
 msgstr ""
 
-#: ../../changelog.rst:5171
+#: ../../changelog.rst:5178
 msgid "Fix integrity error on land intersection on path update (fixes #897)"
 msgstr ""
 
-#: ../../changelog.rst:5172
+#: ../../changelog.rst:5179
 msgid "Fix form layout problems (fixes #712, #879)"
 msgstr ""
 
-#: ../../changelog.rst:5175
+#: ../../changelog.rst:5182
 msgid "0.20.9 (2013-10-30)"
 msgstr ""
 
-#: ../../changelog.rst:5177
+#: ../../changelog.rst:5184
 msgid "Fix altimetric profile if topology geometry is wrong (fixes #875)"
 msgstr ""
 
-#: ../../changelog.rst:5178
+#: ../../changelog.rst:5185
 msgid "Fix apparence of creation button in intervention list (fixes #877)"
 msgstr ""
 
-#: ../../changelog.rst:5179
+#: ../../changelog.rst:5186
 msgid ""
 "Fix topology geometries that were sampled like paths 3D geometry (fixes "
 "#878)"
 msgstr ""
 
-#: ../../changelog.rst:5180
+#: ../../changelog.rst:5187
 msgid "Fix topology lines geometries join in some situations (ref #722)"
 msgstr ""
 
-#: ../../changelog.rst:5181
+#: ../../changelog.rst:5188
 msgid "Fix topology not well displayed if start/end on intersection (fixes #874)"
 msgstr ""
 
-#: ../../changelog.rst:5184
+#: ../../changelog.rst:5191
 msgid "0.20.8 (2013-10-22)"
 msgstr ""
 
-#: ../../changelog.rst:5186
+#: ../../changelog.rst:5193
 msgid "Public trek export : Fix various layout regressions (ref #848)"
 msgstr ""
 
-#: ../../changelog.rst:5187
+#: ../../changelog.rst:5194
 msgid "Public trek export : Show POI theme pictogram (fixes #858)"
 msgstr ""
 
-#: ../../changelog.rst:5188
+#: ../../changelog.rst:5195
 msgid "Public trek export : full width for information desk frame (fixes #856)"
 msgstr ""
 
-#: ../../changelog.rst:5189
+#: ../../changelog.rst:5196
 msgid ""
 "Public trek export : add footer with trek title and page numbers (fixes "
 "#861)"
 msgstr ""
 
-#: ../../changelog.rst:5190
+#: ../../changelog.rst:5197
 msgid "Public trek export : add floating picture in POI detail (fixes #860)"
 msgstr ""
 
-#: ../../changelog.rst:5191
+#: ../../changelog.rst:5198
 msgid "Public trek export : fix POI thumbnails missing (fixes #869)"
 msgstr ""
 
-#: ../../changelog.rst:5192
+#: ../../changelog.rst:5199
 msgid "Fix point offset lost on path update (fixes #867)"
 msgstr ""
 
-#: ../../changelog.rst:5193
+#: ../../changelog.rst:5200
 msgid "Fix reconnect point topologies with offset to closest path (fixes #868)"
 msgstr ""
 
-#: ../../changelog.rst:5196
+#: ../../changelog.rst:5203
 msgid "0.20.7 (2013-10-16)"
 msgstr ""
 
-#: ../../changelog.rst:5198
+#: ../../changelog.rst:5205
 msgid "Fix topology geometry 3D being draped twice (fixes #863)"
 msgstr ""
 
-#: ../../changelog.rst:5199
+#: ../../changelog.rst:5206
 msgid "Altimetric profile : Show max distance and round values (fixes #853)"
 msgstr ""
 
-#: ../../changelog.rst:5200
+#: ../../changelog.rst:5207
 msgid "Altimetric profile : Add settings for colors (fixes #854)"
 msgstr ""
 
-#: ../../changelog.rst:5201
+#: ../../changelog.rst:5208
 msgid "Public trek export : POIs list in two columns (fixes #855)"
 msgstr ""
 
-#: ../../changelog.rst:5202
+#: ../../changelog.rst:5209
 msgid "Public trek export : POIs details without column break (fixes #857)"
 msgstr ""
 
-#: ../../changelog.rst:5203
+#: ../../changelog.rst:5210
 msgid "Public trek export : Show pictures attributions (fixes #859)"
 msgstr ""
 
-#: ../../changelog.rst:5204
+#: ../../changelog.rst:5211
 msgid "Public trek export : Use 10pt fonts in every text blocks (fixes #848)"
 msgstr ""
 
-#: ../../changelog.rst:5208
+#: ../../changelog.rst:5215
 msgid "# Empty profiles cache rm -rf var/media/profiles/*"
 msgstr ""
 
-#: ../../changelog.rst:5213
+#: ../../changelog.rst:5220
 msgid "0.20.6 (2013-10-14)"
 msgstr ""
 
-#: ../../changelog.rst:5215
+#: ../../changelog.rst:5222
 msgid "Remove 3D from JS WKT serializer"
 msgstr ""
 
-#: ../../changelog.rst:5216
+#: ../../changelog.rst:5223
 msgid "Safety check if path is less than 1m"
 msgstr ""
 
-#: ../../changelog.rst:5217
+#: ../../changelog.rst:5224
 msgid "Remove mentions of 2154 projection in schema migrations"
 msgstr ""
 
-#: ../../changelog.rst:5218
+#: ../../changelog.rst:5225
 msgid "Fix performance issues in altimetric JSON (fixes #845)"
 msgstr ""
 
-#: ../../changelog.rst:5219
+#: ../../changelog.rst:5226
 msgid "Fix filter forms missing from Trek and POI lists (fixes #847)"
 msgstr ""
 
-#: ../../changelog.rst:5220
+#: ../../changelog.rst:5227
 msgid "Fix empty Nginx log files (fixes #846)"
 msgstr ""
 
-#: ../../changelog.rst:5224
+#: ../../changelog.rst:5231
 msgid "0.20.5 (2013-10-09)"
 msgstr ""
 
-#: ../../changelog.rst:5226
+#: ../../changelog.rst:5233
 msgid "Fix migration of draping utility function"
 msgstr ""
 
-#: ../../changelog.rst:5229
+#: ../../changelog.rst:5236
 msgid "0.20.4 (2013-10-09)"
 msgstr ""
 
-#: ../../changelog.rst:5231
+#: ../../changelog.rst:5238
 msgid "Fix sort stake by id (level) (fixes #835)"
 msgstr ""
 
-#: ../../changelog.rst:5232
+#: ../../changelog.rst:5239
 msgid "Rename stake to maintenance stake (fixes #834)"
 msgstr ""
 
-#: ../../changelog.rst:5233
+#: ../../changelog.rst:5240
 msgid "Add validity to path filter (fixes #836)"
 msgstr ""
 
-#: ../../changelog.rst:5234
+#: ../../changelog.rst:5241
 msgid "Do not redrape topology geometries, use path 3D geometry (fixes #832)"
 msgstr ""
 
-#: ../../changelog.rst:5235
+#: ../../changelog.rst:5242
 msgid "Fix document export of Trail objects (fixes #839)"
 msgstr ""
 
-#: ../../changelog.rst:5236
+#: ../../changelog.rst:5243
 msgid "Fix trail helpers for land layers (fixes #838, ref #842)"
 msgstr ""
 
-#: ../../changelog.rst:5237
+#: ../../changelog.rst:5244
 msgid "Fix install on fresh folder, missing folder ``lib/src`` (fixes #844)"
 msgstr ""
 
-#: ../../changelog.rst:5241
+#: ../../changelog.rst:5248
 msgid "0.20.3 (2013-09-30)"
 msgstr ""
 
-#: ../../changelog.rst:5245
+#: ../../changelog.rst:5252
 msgid "Fix typo in french translation of Properties (fixes #815)"
 msgstr ""
 
-#: ../../changelog.rst:5246
+#: ../../changelog.rst:5253
 msgid ""
 "Fix missing description from infrastructure/signage detail page (fixes "
 "#816)"
 msgstr ""
 
-#: ../../changelog.rst:5247
+#: ../../changelog.rst:5254
 msgid ""
 "Fix Cities / Districts / Restricted Areas in project detail page (fixes "
 "#817)"
 msgstr ""
 
-#: ../../changelog.rst:5248
+#: ../../changelog.rst:5255
 msgid "Fix only deleted topology can have geom = NULL (fixes #818)"
 msgstr ""
 
-#: ../../changelog.rst:5249
+#: ../../changelog.rst:5256
 msgid ""
 "Fix geometries not editable in QGis by switching path and topologies "
 "geometries to 2D (fixes #688)"
 msgstr ""
 
-#: ../../changelog.rst:5251
+#: ../../changelog.rst:5258
 msgid ""
 "Fix altimetric sampling precision setting not taken in account in SQL "
 "(ref #776)"
 msgstr ""
 
-#: ../../changelog.rst:5255
+#: ../../changelog.rst:5262
 msgid "0.20.2 (2013-08-27)"
 msgstr ""
 
-#: ../../changelog.rst:5258
+#: ../../changelog.rst:5265
 msgid "Fix Trek public print conversion"
 msgstr ""
 
-#: ../../changelog.rst:5259
+#: ../../changelog.rst:5266
 msgid "Fix display of trek length in public document (one decimal only)"
 msgstr ""
 
-#: ../../changelog.rst:5260
+#: ../../changelog.rst:5267
 msgid "Fix altimetric graph delaying map display in detail pages"
 msgstr ""
 
-#: ../../changelog.rst:5264
+#: ../../changelog.rst:5271
 msgid "# Empty maps captures cache rm -rf var/media/maps/trek-*"
 msgstr ""
 
-#: ../../changelog.rst:5269
+#: ../../changelog.rst:5276
 msgid "0.20.1 (2013-08-26)"
 msgstr ""
 
-#: ../../changelog.rst:5271
+#: ../../changelog.rst:5278
 msgid "Add DB index for start and end columns"
 msgstr ""
 
-#: ../../changelog.rst:5272
+#: ../../changelog.rst:5279
 msgid "Merge gunicorn logs with respective applications logs"
 msgstr ""
 
-#: ../../changelog.rst:5273
+#: ../../changelog.rst:5280
 msgid "Lower logging level in production (WARNING -> INFO)"
 msgstr ""
 
-#: ../../changelog.rst:5277
+#: ../../changelog.rst:5284
 msgid "Fix deployment error with application's TITLE"
 msgstr ""
 
-#: ../../changelog.rst:5278
+#: ../../changelog.rst:5285
 msgid "Fix deployment errors with mandatory external authent values"
 msgstr ""
 
-#: ../../changelog.rst:5279
+#: ../../changelog.rst:5286
 msgid "Fix trek export layout: fit map image and altimetric profile in one page."
 msgstr ""
 
-#: ../../changelog.rst:5283
+#: ../../changelog.rst:5290
 msgid "0.20 (2013-08-23)"
 msgstr ""
 
-#: ../../changelog.rst:5285
+#: ../../changelog.rst:5292
 msgid ""
 "Edit difficulty id in Admin site, mainly used to order difficulty levels "
 "(fixes #771)"
 msgstr ""
 
-#: ../../changelog.rst:5286
+#: ../../changelog.rst:5293
 msgid ""
 "Use explicit list of fields in forms, instead of excluding model fields "
 "(fixes #736). Issue #712 was closed too, since most suspected cause was "
 "field listings. Please re-open if problem re-appears."
 msgstr ""
 
-#: ../../changelog.rst:5289
+#: ../../changelog.rst:5296
 msgid "Fix timeout on POI Shapefile and CSV exports (fixes #672)"
 msgstr ""
 
-#: ../../changelog.rst:5290
+#: ../../changelog.rst:5297
 msgid "Altimetric profiles are now computed in PostGIS (fixes #778, #779)"
 msgstr ""
 
-#: ../../changelog.rst:5291
+#: ../../changelog.rst:5298
 msgid ""
 "Positive and negative ascents are now computed using more DEM resolution "
 "(fixes #776)"
 msgstr ""
 
-#: ../../changelog.rst:5295
+#: ../../changelog.rst:5302
 msgid ""
 "Setting ``PROFILE_MAXSIZE`` was replaced by "
 "``ALTIMETRIC_PROFILE_PRECISION`` which controls sampling precision in "
 "meters (default: 20 meters)"
 msgstr ""
 
-#: ../../changelog.rst:5298
+#: ../../changelog.rst:5305
 msgid "Altimetric profiles were removed from object map images"
 msgstr ""
 
-#: ../../changelog.rst:5299
+#: ../../changelog.rst:5306
 msgid "Altimetric profiles are now plotted using SVG"
 msgstr ""
 
-#: ../../changelog.rst:5300
+#: ../../changelog.rst:5307
 msgid ""
 "Altimetric profiles are now inserted into path documents and trek public "
 "printouts (ref #626)"
 msgstr ""
 
-#: ../../changelog.rst:5301
+#: ../../changelog.rst:5308
 msgid ""
 "Fix deletion of associated interventions when editing infrastructures "
 "(fixes #783)"
 msgstr ""
 
-#: ../../changelog.rst:5302
+#: ../../changelog.rst:5309
 msgid ""
 "Latest record is updated (*touch*) when a DELETE is performed on table "
 "(refreshs cache) (fixes #698)"
 msgstr ""
 
-#: ../../changelog.rst:5304
+#: ../../changelog.rst:5311
 msgid "Reworked settings mechanism to follow Django best practices"
 msgstr ""
 
-#: ../../changelog.rst:5308
+#: ../../changelog.rst:5315
 msgid ""
 "Replace all computed values from ``etc/settings.ini``. For example, "
 "replace \"60 * 60\" by 3600. (You can increase this value to several "
 "hours by the way)"
 msgstr ""
 
-#: ../../changelog.rst:5311
+#: ../../changelog.rst:5318
 msgid "Allow server host to capture pages (fixes #733)"
 msgstr ""
 
-#: ../../changelog.rst:5312
+#: ../../changelog.rst:5319
 msgid "Adjust map capture according to geometry aspect ratio (fixes #627)"
 msgstr ""
 
-#: ../../changelog.rst:5313
+#: ../../changelog.rst:5320
 msgid "Always show path layer in detail pages (fixes #781)"
 msgstr ""
 
-#: ../../changelog.rst:5314
+#: ../../changelog.rst:5321
 msgid "Fix restore of topology on loop paths (fixes #760)"
 msgstr ""
 
-#: ../../changelog.rst:5315
+#: ../../changelog.rst:5322
 msgid ""
 "Fix topology construction when loop is formed by two convergent paths "
 "(fixes #768)"
 msgstr ""
 
-#: ../../changelog.rst:5316
+#: ../../changelog.rst:5323
 msgid ""
 "Added small tool page at ``/tools/extents/`` to visualize configured "
 "extents (ref #732)"
 msgstr ""
 
-#: ../../changelog.rst:5317
+#: ../../changelog.rst:5324
 msgid ""
 "Removed setting ``spatial_extent_wgs84``, now computed automatically from"
 " ``spatial_extent``, with a padding of 10%."
 msgstr ""
 
-#: ../../changelog.rst:5322
+#: ../../changelog.rst:5329
 msgid ""
 "Have a look at ``conf/settings.ini.sample`` to clean-up unnecessary "
 "values from your settings file."
 msgstr ""
 
-#: ../../changelog.rst:5325
+#: ../../changelog.rst:5332
 msgid "Fix paths offset for portrait spatial extent (fixes #732)"
 msgstr ""
 
-#: ../../changelog.rst:5326
+#: ../../changelog.rst:5333
 msgid "Rely on Tilecache default max resolution formulae (fixes #732)"
 msgstr ""
 
-#: ../../changelog.rst:5327
+#: ../../changelog.rst:5334
 msgid ""
 "Due to bug in Leaflet/Proj4Leaflet "
 "(https://github.com/kartena/Proj4Leaflet/issues/37) landscape spatial "
@@ -9868,15 +9879,15 @@ msgid ""
 "or square, or application will raise *ImproperlyConfiguredError*."
 msgstr ""
 
-#: ../../changelog.rst:5330
+#: ../../changelog.rst:5337
 msgid "Reload map objects on zoom out too (fixes #435)"
 msgstr ""
 
-#: ../../changelog.rst:5331
+#: ../../changelog.rst:5338
 msgid "Fix computation of *min_elevation* for point topologies (fixes #808)"
 msgstr ""
 
-#: ../../changelog.rst:5335
+#: ../../changelog.rst:5342
 msgid ""
 "In order to recompute all paths topologies altimetry information, you can"
 " perform the following query: ``UPDATE e_t_evenement SET decallage = "
@@ -9884,212 +9895,212 @@ msgid ""
 "wait for a while."
 msgstr ""
 
-#: ../../changelog.rst:5341
+#: ../../changelog.rst:5348
 msgid "0.19.1 (2013-07-15)"
 msgstr ""
 
-#: ../../changelog.rst:5343
+#: ../../changelog.rst:5350
 msgid "Restore ``pk`` property in Trek GeoJSON layer"
 msgstr ""
 
-#: ../../changelog.rst:5347
+#: ../../changelog.rst:5354
 msgid "0.19 (2013-07-12)"
 msgstr ""
 
-#: ../../changelog.rst:5349
+#: ../../changelog.rst:5356
 msgid "Intervention length field (readonly if geometry is line)"
 msgstr ""
 
-#: ../../changelog.rst:5350
+#: ../../changelog.rst:5357
 msgid "Fix apparence bug if no rights to add treks and pois (fixes #713)"
 msgstr ""
 
-#: ../../changelog.rst:5351
+#: ../../changelog.rst:5358
 msgid "Fix extremities snapping (fixes #718)"
 msgstr ""
 
-#: ../../changelog.rst:5352
+#: ../../changelog.rst:5359
 msgid "Show information desk in trek detail page (fixes #719)"
 msgstr ""
 
-#: ../../changelog.rst:5353
+#: ../../changelog.rst:5360
 msgid "Fix topology adjustments after path split (fixes #720)"
 msgstr ""
 
-#: ../../changelog.rst:5354
+#: ../../changelog.rst:5361
 msgid ""
 "On edition show global line orientation instead of individual paths "
 "(fixes #679)"
 msgstr ""
 
-#: ../../changelog.rst:5355
+#: ../../changelog.rst:5362
 msgid "Fix invalid topology if trek goes twice on same path (fixes #671)"
 msgstr ""
 
-#: ../../changelog.rst:5356
+#: ../../changelog.rst:5363
 msgid "Overlapping is now more precise (fixes #710)"
 msgstr ""
 
-#: ../../changelog.rst:5357
+#: ../../changelog.rst:5364
 msgid "Reworked trek print layout"
 msgstr ""
 
-#: ../../changelog.rst:5358
+#: ../../changelog.rst:5365
 msgid "Fix topology building if paths are taken twice (fixes #722)"
 msgstr ""
 
-#: ../../changelog.rst:5359
+#: ../../changelog.rst:5366
 msgid "Fix tiling offset with horizontal bboxes"
 msgstr ""
 
-#: ../../changelog.rst:5360
+#: ../../changelog.rst:5367
 msgid "Fix display of POI layer by default on list (fixes #696)"
 msgstr ""
 
-#: ../../changelog.rst:5361
+#: ../../changelog.rst:5368
 msgid "Fix translation of not validated paths (fixes #730)"
 msgstr ""
 
-#: ../../changelog.rst:5362
+#: ../../changelog.rst:5369
 msgid "Fix error if topology is required and empty (fixes #745)"
 msgstr ""
 
-#: ../../changelog.rst:5363
+#: ../../changelog.rst:5370
 msgid "Fix duplication of N-N relations on path split (fixes #738)"
 msgstr ""
 
-#: ../../changelog.rst:5364
+#: ../../changelog.rst:5371
 msgid "Fix project map in detail page (fixes #734)"
 msgstr ""
 
-#: ../../changelog.rst:5365
+#: ../../changelog.rst:5372
 msgid "Fix project listed deleted interventions (fixes #739)"
 msgstr ""
 
-#: ../../changelog.rst:5366
+#: ../../changelog.rst:5373
 msgid "Fix project listed infrastructures through interventions (fixes #740)"
 msgstr ""
 
-#: ../../changelog.rst:5367
+#: ../../changelog.rst:5374
 msgid "Fix saving intervention form on infrastructure"
 msgstr ""
 
-#: ../../changelog.rst:5368
+#: ../../changelog.rst:5375
 msgid ""
 "Repair serializing of properties after upgrade of django-geojson (fixes "
 "#755)"
 msgstr ""
 
-#: ../../changelog.rst:5369
+#: ../../changelog.rst:5376
 msgid ""
 "Added ``public_transport`` and ``advised_parking`` to trek JSON detail "
 "API (fixes #758)"
 msgstr ""
 
-#: ../../changelog.rst:5370
+#: ../../changelog.rst:5377
 msgid "Repair land layers colors after upgrade of django-geojson"
 msgstr ""
 
-#: ../../changelog.rst:5371
+#: ../../changelog.rst:5378
 msgid "Upgraded to django-geojson 2.0"
 msgstr ""
 
-#: ../../changelog.rst:5372
+#: ../../changelog.rst:5379
 msgid "Upgraded to Django 1.5"
 msgstr ""
 
-#: ../../changelog.rst:5376
+#: ../../changelog.rst:5383
 msgid ""
 "Specify allowed host (server IP) in ``etc/settings.ini`` (*for example*):"
 " * ``host = 45.56.78.90`` Empty object caches: * ``sudo "
 "/etc/init.d/memcached restart`` * ``rm -rf ./var/cache/*``"
 msgstr ""
 
-#: ../../changelog.rst:5384
+#: ../../changelog.rst:5391
 msgid "0.18 (2013-06-06)"
 msgstr ""
 
-#: ../../changelog.rst:5386
+#: ../../changelog.rst:5393
 msgid "Add pretty trek duration in JSON"
 msgstr ""
 
-#: ../../changelog.rst:5387
+#: ../../changelog.rst:5394
 msgid "Add information desk field in Trek (fixes #624)"
 msgstr ""
 
-#: ../../changelog.rst:5391
+#: ../../changelog.rst:5398
 msgid "0.17 (2013-05-17)"
 msgstr ""
 
-#: ../../changelog.rst:5393
+#: ../../changelog.rst:5400
 msgid ""
 "Show trek duration as human readable in minutes, hours and days (fixes "
 "#471, #683)"
 msgstr ""
 
-#: ../../changelog.rst:5394
+#: ../../changelog.rst:5401
 msgid ""
 "Fix hover on paths that interfered with clic for topology creation (fixes"
 " #680)"
 msgstr ""
 
-#: ../../changelog.rst:5395
+#: ../../changelog.rst:5402
 msgid "Run API urls on different workers (ref #672)"
 msgstr ""
 
-#: ../../changelog.rst:5396
+#: ../../changelog.rst:5403
 msgid "Fix redirect to root url after logout (fixes #264)"
 msgstr ""
 
-#: ../../changelog.rst:5397
+#: ../../changelog.rst:5404
 msgid "Fix redirect to next after login (fixes #381)"
 msgstr ""
 
-#: ../../changelog.rst:5398
+#: ../../changelog.rst:5405
 msgid "Switch to Memcached instead of local memory in production"
 msgstr ""
 
-#: ../../changelog.rst:5399
+#: ../../changelog.rst:5406
 msgid "Move secret key to settings.ini"
 msgstr ""
 
-#: ../../changelog.rst:5400
+#: ../../changelog.rst:5407
 msgid "Relate paperclip FileType to Structure (fixes #256)"
 msgstr ""
 
-#: ../../changelog.rst:5401
+#: ../../changelog.rst:5408
 msgid "Relate PhysicalTypes to Structure (fixes #255)"
 msgstr ""
 
-#: ../../changelog.rst:5402
+#: ../../changelog.rst:5409
 msgid "Relate Organisms to Structure (fixes #263)"
 msgstr ""
 
-#: ../../changelog.rst:5403
+#: ../../changelog.rst:5410
 msgid "Compute max_resolution automatically"
 msgstr ""
 
-#: ../../changelog.rst:5404
+#: ../../changelog.rst:5411
 msgid "Fix creation and edition of interventions on infrastructures (fixes #678)"
 msgstr ""
 
-#: ../../changelog.rst:5405
+#: ../../changelog.rst:5412
 msgid "Change default objects color to yellow"
 msgstr ""
 
-#: ../../changelog.rst:5406
+#: ../../changelog.rst:5413
 msgid "Restored Italian translations"
 msgstr ""
 
-#: ../../changelog.rst:5407
+#: ../../changelog.rst:5414
 msgid "Fix regex for RAISE NOTICE (fixes #673)"
 msgstr ""
 
-#: ../../changelog.rst:5408
+#: ../../changelog.rst:5415
 msgid "Initial public version"
 msgstr ""
 
-#: ../../changelog.rst:5410
+#: ../../changelog.rst:5417
 msgid "See project history in `docs/history.rst` (French)."
 msgstr ""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was two sections related to the documentation. Now everything is in one place.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~New and existing unit tests pass locally with my changes~~
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
