### PR TITLE
fix: cities display on string  (refs #3585)

### DIFF
--- a/geotrek/infrastructure/models.py
+++ b/geotrek/infrastructure/models.py
@@ -148,7 +148,13 @@ class BaseInfrastructure(BasePublishableMixin, Topology, StructureRelated):
 
     @property
     def cities_display(self):
-        return [str(c) for c in self.cities] if hasattr(self, 'cities') else []
+        all_cities_name = []
+        if hasattr(self, 'cities'):
+            for city in self.cities:
+                all_cities_name.append(city.name)
+            return ", ".join(all_cities_name)
+        else:
+            return ""
 
     @classproperty
     def cities_verbose_name(cls):

--- a/geotrek/infrastructure/tests/test_views.py
+++ b/geotrek/infrastructure/tests/test_views.py
@@ -52,7 +52,7 @@ class InfrastructureViewsTest(GeotrekAPITestCase, CommonTest):
 
     def get_expected_datatables_attrs(self):
         return {
-            'cities': '[]',
+            'cities': '',
             'condition': self.obj.condition.label,
             'id': self.obj.pk,
             'name': self.obj.name_display,


### PR DESCRIPTION
Avant: La liste des "cities" était retournée dans un tableau.

Maintenant: Elle est retournée sous forme de "string" avec chaque ville / commune séparées par des virgules
