### PR TITLE
Bump mapentity to 8.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -qq && apt-get install -y -qq  \
     nano \
     curl \
     git \
-    iproute2 \
     software-properties-common \
     shared-mime-info \
     fonts-liberation \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update -qq && apt-get install -y -qq  \
     nano \
     curl \
     git \
+    iproute2 \
     software-properties-common \
     shared-mime-info \
     fonts-liberation \
@@ -58,6 +59,6 @@ COPY --chown=geotrek:geotrek docker/* /usr/local/bin/
 ENTRYPOINT ["/bin/sh", "-e", "/usr/local/bin/entrypoint.sh"]
 EXPOSE 8000
 
-RUN ENV=dev CONVERSION_HOST=localhost CAPTURE_HOST=localhost CUSTOM_SETTINGS_FILE= SECRET_KEY=tmp /opt/venv/bin/python ./manage.py compilemessages
+RUN ENV=dev CUSTOM_SETTINGS_FILE= SECRET_KEY=tmp /opt/venv/bin/python ./manage.py compilemessages
 
 CMD ["gunicorn", "geotrek.wsgi:application", "--bind=0.0.0.0:8000"]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ CHANGELOG
 
 **Maintenance**
 
-- Upgrade `django-mapentity` to 8.6.0. New authentication system for screamshotter and convertit by token instead of IP detection.
+- Upgrade `django-mapentity` to 8.6.1. New authentication system for screamshotter and convertit by token instead of IP detection.
 
 
 2.100.2 (2023-09-12)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ CHANGELOG
 2.100.2+dev (XXXX-XX-XX)
 ------------------------
 
+**Maintenance**
+
+- Upgrade `django-mapentity` to 8.6.0. New authentication system for screamshotter and convertit by token instead of IP detection.
 
 
 2.100.2 (2023-09-12)

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -696,8 +696,6 @@ FACEBOOK_IMAGE = '/images/logo-geotrek.png'
 FACEBOOK_IMAGE_WIDTH = 200
 FACEBOOK_IMAGE_HEIGHT = 200
 
-CAPTURE_AUTOLOGIN_TOKEN = os.getenv('CAPTURE_AUTOLOGIN_TOKEN', None)
-
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.

--- a/requirements.txt
+++ b/requirements.txt
@@ -214,7 +214,7 @@ large-image-source-vips==1.17.2
     # via geotrek (setup.py)
 lxml==4.9.1
     # via mapentity
-mapentity==8.5.6
+mapentity==8.6.0
     # via geotrek (setup.py)
 markdown==3.4.4
     # via geotrek (setup.py)
@@ -340,6 +340,7 @@ tzdata==2023.3
     # via
     #   backports-zoneinfo
     #   celery
+    #   mapentity
 uritemplate==4.1.1
     # via
     #   coreapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -214,7 +214,7 @@ large-image-source-vips==1.17.2
     # via geotrek (setup.py)
 lxml==4.9.1
     # via mapentity
-mapentity==8.6.0
+mapentity==8.6.1
     # via geotrek (setup.py)
 markdown==3.4.4
     # via geotrek (setup.py)
@@ -224,8 +224,6 @@ mbutil==0.3.0
     # via landez
 munch==2.5.0
     # via fiona
-netifaces==0.11.0
-    # via mapentity
 numpy==1.23.4
     # via
     #   large-image


### PR DESCRIPTION
## Description

Bump mapentity to [8.6.1](https://github.com/makinacorpus/django-mapentity/releases/tag/8.6.1).
New authentication system for screamshotter and convertit
