### PR TITLE
🐛 [Bug fixes] handle case where year is none when loading signage - #3611

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,10 +5,6 @@ CHANGELOG
 2.100.2+dev (XXXX-XX-XX)
 ------------------------
 
-**Bug fixes**
-
-- Allow to load a signage with the year set to None
-
 **Maintenance**
 
 - Upgrade `django-mapentity` to 8.6.1. New authentication system for screamshotter and convertit by token instead of IP detection.
@@ -17,6 +13,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix missing update rights for Infrastructure Condition and Infrastructure Type with no structure in Admin Site (#3747)
+- Allow to load a signage with the year set to None, raise error if set to NaN (#3611)
 
 
 2.100.2 (2023-09-12)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.100.2+dev (XXXX-XX-XX)
 ------------------------
 
+**Bug fixes**
+
+- Allow to load a signage with the year set to None
+
 **Maintenance**
 
 - Upgrade `django-mapentity` to 8.6.1. New authentication system for screamshotter and convertit by token instead of IP detection.

--- a/geotrek/common/tests/utils.py
+++ b/geotrek/common/tests/utils.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+import fiona
+
+
+def update_gis(input_file_path: str, output_file_path: str, new_properties: Dict):
+    '''
+    Utility function that reads a GIS file (GeoPackage or Shapefile), update some properties,
+    then write a new shapefile (typically in /tmp). Useful to test specific property values.
+    '''
+
+    with fiona.open(input_file_path) as source:
+        with fiona.open(output_file_path,
+                        mode='w',
+                        crs=source.crs,
+                        driver=source.driver,
+                        schema=source.schema) as dest:
+            for feat in source:
+                dest.write(fiona.Feature(
+                    geometry=feat.geometry,
+                    properties={**feat.properties, **new_properties}
+                ))

--- a/geotrek/signage/management/commands/loadsignage.py
+++ b/geotrek/signage/management/commands/loadsignage.py
@@ -16,7 +16,7 @@ from django.conf import settings
 
 
 class Command(BaseCommand):
-    help = 'Load a layer with point geometries in te structure model\n'
+    help = 'Load a layer with point geometries in the structure model\n'
     can_import_settings = True
     counter = 0
 
@@ -178,7 +178,13 @@ class Command(BaseCommand):
 
                     structure = Structure.objects.get(name=feature.get(field_structure_type)) if field_structure_type in available_fields else structure
                     description = feature.get(field_description) if field_description in available_fields else default_description
-                    year = int(feature.get(field_implantation_year)) if field_implantation_year in available_fields and feature.get(field_implantation_year).isdigit() else default_year
+
+                    year = feature.get(field_implantation_year) if field_implantation_year in available_fields else default_year
+                    if year:
+                        year = int(year) if str(year).isdigit() else default_year
+                    else:
+                        year = None
+
                     eid = feature.get(field_eid) if field_eid in available_fields else None
                     code = feature.get(field_code) if field_code in available_fields else default_code
 

--- a/geotrek/signage/management/commands/loadsignage.py
+++ b/geotrek/signage/management/commands/loadsignage.py
@@ -181,7 +181,10 @@ class Command(BaseCommand):
 
                     year = feature.get(field_implantation_year) if field_implantation_year in available_fields else default_year
                     if year:
-                        year = int(year) if str(year).isdigit() else default_year
+                        if str(year).isdigit():
+                            year = int(year)
+                        else:
+                            raise CommandError('Invalid year: "%s" is not a number.' % year)
                     else:
                         year = None
 


### PR DESCRIPTION
This PR handles the case where the year is None when loading a signage.

## Description

I also added a utility function in the tests in order to allow to use a modified version of the ShapeFile used for tests.

## Related Issue

#3611

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file **-> where is it?**
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated