### PR TITLE
fix: cities display on string  (refs #3585)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ CHANGELOG
 - Fix missing update rights for Infrastructure Condition and Infrastructure Type with no structure in Admin Site (#3747)
 - Allow to load a signage with the year set to None, raise error if set to NaN (#3611)
 - Fix filters on Intervention exports (resolve #3749)
+- Fix cities display on string (refs #3585)
 
 **Improvements**
 

--- a/geotrek/infrastructure/models.py
+++ b/geotrek/infrastructure/models.py
@@ -148,7 +148,7 @@ class BaseInfrastructure(BasePublishableMixin, Topology, StructureRelated):
 
     @property
     def cities_display(self):
-        return [str(c) for c in self.cities] if hasattr(self, 'cities') else []
+        return ", ".join([str(c) for c in getattr(self, "cities", [])])
 
     @classproperty
     def cities_verbose_name(cls):

--- a/geotrek/infrastructure/tests/test_models.py
+++ b/geotrek/infrastructure/tests/test_models.py
@@ -1,11 +1,27 @@
 from django.conf import settings
 from django.test import TestCase
+from unittest import skipIf
 
 from geotrek.core.tests.factories import PathFactory
 from geotrek.infrastructure.tests.factories import InfrastructureFactory
+from geotrek.zoning.tests import factories as zoning_factory
 
 
 class InfrastructureTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.city1 = zoning_factory.CityFactory(code='01000', name="city1", geom='SRID=2154;MULTIPOLYGON(((-1 -1, -1 1, 1 1, 1 -1, -1 -1)))')
+        cls.city2 = zoning_factory.CityFactory(code='02000', name="city2", geom='SRID=2154;MULTIPOLYGON(((-1 -1, -1 1, 1 1, 1 -1, -1 -1)))')
+        cls.city3 = zoning_factory.CityFactory(code='03000', name="city3", geom='SRID=2154;MULTIPOLYGON(((1 1, 1 3, 3 3, 3 1, 1 1)))')
+
+        cls.infra_cities1_2 = InfrastructureFactory.create()
+        cls.infra_cities1_2.geom = 'SRID=2154;POINT(0 0)'
+        cls.infra_cities1_2.save()
+
+        cls.infra_cities3 = InfrastructureFactory.create()
+        cls.infra_cities3.geom = 'SRID=2154;POINT(2 2)'
+        cls.infra_cities3.save()
+
     def test_helpers(self):
         p = PathFactory.create()
 
@@ -15,3 +31,19 @@ class InfrastructureTest(TestCase):
             infra = InfrastructureFactory.create(geom=p.geom)
 
         self.assertCountEqual(p.infrastructures, [infra])
+
+    @skipIf(settings.TREKKING_TOPOLOGY_ENABLED, 'Test without dynamic segmentation only')
+    def test_display_cities(self):
+        # Case : return 2 cities (not city3, is out of zone)
+        self.assertEqual(self.infra_cities1_2.cities_display, "city1, city2")
+
+        # Case : return 1 city (not city3, is out of zone)
+        self.city2.delete()
+        self.assertEqual(self.infra_cities1_2.cities_display, "city1")
+
+        # Case : return 0 city (not city3, is out of zone)
+        self.city1.delete()
+        self.assertEqual(self.infra_cities1_2.cities_display, "")
+
+        # Case : return only city3
+        self.assertEqual(self.infra_cities3.cities_display, "city3")

--- a/geotrek/infrastructure/tests/test_views.py
+++ b/geotrek/infrastructure/tests/test_views.py
@@ -52,7 +52,7 @@ class InfrastructureViewsTest(GeotrekAPITestCase, CommonTest):
 
     def get_expected_datatables_attrs(self):
         return {
-            'cities': '[]',
+            'cities': '',
             'condition': self.obj.condition.label,
             'id': self.obj.pk,
             'name': self.obj.name_display,


### PR DESCRIPTION
## Description

Avant: La liste des "cities" était retournée dans un tableau.

Maintenant: Elle est retournée sous forme de "string" avec chaque ville / commune séparées par des virgules

## Related Issue

[link to the issue](https://github.com/GeotrekCE/Geotrek-admin/issues/3585)

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated
