### PR TITLE
Bump easy-thumbnails from 2.7 to 2.8.5

### DIFF
--- a/geotrek/api/v2/serializers.py
+++ b/geotrek/api/v2/serializers.py
@@ -10,6 +10,7 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from drf_dynamic_fields import DynamicFieldsMixin
 from easy_thumbnails.alias import aliases
+from easy_thumbnails.engine import NoSourceGenerator
 from easy_thumbnails.exceptions import InvalidImageFormatError
 from easy_thumbnails.files import get_thumbnailer
 from PIL.Image import DecompressionBombError
@@ -261,7 +262,7 @@ class AttachmentsSerializerMixin(serializers.ModelSerializer):
         thumbnailer = get_thumbnailer(self.get_attachment_file(obj))
         try:
             thumbnail = thumbnailer.get_thumbnail(aliases.get('apiv2'))
-        except (IOError, InvalidImageFormatError, DecompressionBombError):
+        except (IOError, InvalidImageFormatError, DecompressionBombError, NoSourceGenerator):
             return ""
         thumbnail.author = obj.author
         thumbnail.legend = obj.legend

--- a/requirements.txt
+++ b/requirements.txt
@@ -170,7 +170,7 @@ drf-yasg==1.21.5
     # via
     #   django-large-image
     #   geotrek (setup.py)
-easy-thumbnails==2.7
+easy-thumbnails==2.8.5
     # via
     #   mapentity
     #   paperclip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump easy-thumbnails to 2.8.5

## Related Issue

#3783 
