### PR TITLE
Fix `sync_rando` failure with SVG attachment (#3803)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,11 @@ CHANGELOG
 2.101.2+dev (XXXX-XX-XX)
 ------------------------
 
+**Bug fixes**
+
+- Fix `sync_rando` admin command failure if Trek has SVG attachment (#3803)
+
+
 2.101.2 (2023-10-17)
 ------------------------
 

--- a/geotrek/common/mixins/models.py
+++ b/geotrek/common/mixins/models.py
@@ -16,6 +16,7 @@ from django.utils.formats import date_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from easy_thumbnails.alias import aliases
+from easy_thumbnails.engine import NoSourceGenerator
 from easy_thumbnails.exceptions import InvalidImageFormatError
 from easy_thumbnails.files import get_thumbnailer
 from embed_video.backends import detect_backend, VideoDoesntExistException
@@ -153,7 +154,7 @@ class PicturesMixin:
                                                })
 
                 thdetail = thumbnailer.get_thumbnail(ali)
-            except (IOError, InvalidImageFormatError, DecompressionBombError) as e:
+            except (IOError, InvalidImageFormatError, DecompressionBombError, NoSourceGenerator) as e:
                 logger.info(_("Image {} invalid or missing from disk: {}.").format(picture.attachment_file, e))
             else:
                 resized.append((picture, thdetail))
@@ -445,7 +446,7 @@ def get_uuid_duplication(uid_field):
 class GeotrekMapEntityMixin(MapEntityMixin):
     elements_duplication = {
         "attachments": {"uuid": get_uuid_duplication},
-        "avoid_fields": ["aggregations", "children",],
+        "avoid_fields": ["aggregations", "children"],
         "uuid": get_uuid_duplication,
     }
 


### PR DESCRIPTION
One line fix following upgrade of `easy_thumbnails`. It was not covered by tests, I have not made the effort to add it since this command may be deprecated/removed. 

## Related Issue

Issue: Regression: GeotrekRandoV2 synchronization command fails due to SVG attachment #3803

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated
