### PR TITLE
🐛 [Bug fixes] fix UI bug when customizing intervention map style (#3800)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ CHANGELOG
 
 **Bug fixes**
 
+- Fix UI bug when customizing intervention map style (#3800)
 - Fix Aggregator fails when updating Tour steps order (#3793)
 - Fix services list display error (refs ##3795)
 

--- a/geotrek/maintenance/static/maintenance/main.js
+++ b/geotrek/maintenance/static/maintenance/main.js
@@ -10,10 +10,13 @@ $(window).on('entity:map', function (e, data) {
     var map = data.map;
 
     // Show infrastructure layer in application maps
-	var layer = new L.ObjectsLayer(null, {
-		modelname: modelname,
-		style: L.Util.extend(window.SETTINGS.map.styles[modelname] || {}, { clickable:false }),
-	});
+    var style = L.Util.extend({ clickable: false },
+        window.SETTINGS.map.styles[modelname] || {});
+
+    var layer = new L.ObjectsLayer(null, {
+        modelname: modelname,
+        style: style,
+    });
 
     if (data.modelname != modelname){
 	    map.layerscontrol.addOverlay(layer, tr('Intervention'), tr('Maintenance'));


### PR DESCRIPTION
## Description

The path style of an intervention can now be customized without affecting its behavior on the map.

<!--- Describe your changes in detail -->

## Related Issue

#3800

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~New and existing unit tests pass locally with my changes~~
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated
