### PR TITLE
Fix language bug in several detail pages (#3577)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 **Bug fixes**
 
+- Fix language bug in several detail pages (#3577)
 - Fix `sync_rando` admin command failure if Trek has SVG attachment (#3803)
 
 

--- a/geotrek/diving/tests/test_views.py
+++ b/geotrek/diving/tests/test_views.py
@@ -130,6 +130,17 @@ class DiveViewsTests(GeotrekAPITestCase, CommonTest):
         response = self.client.get(reverse('diving:dive_poi_geojson', kwargs={'lang': translation.get_language(), 'pk': dive.pk}))
         self.assertEqual(response.status_code, 404)
 
+    def test_lang_in_detail_page(self):
+        dive = self.modelfactory.create(name_fr='une plongée', name_en='a dive')
+
+        response = self.client.get(dive.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'une plongée')
+        self.assertNotContains(response, 'a dive')
+
+        response = self.client.get(dive.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a dive')
+        self.assertNotContains(response, 'une plongée')
+
 
 class DiveViewsLiveTests(CommonLiveTest):
     model = Dive

--- a/geotrek/infrastructure/tests/test_views.py
+++ b/geotrek/infrastructure/tests/test_views.py
@@ -80,6 +80,17 @@ class InfrastructureViewsTest(GeotrekAPITestCase, CommonTest):
         response = self.client.get(infra.get_detail_url())
         self.assertContains(response, "<b>Beautiful !</b>")
 
+    def test_lang_in_detail_page(self):
+        infra = InfrastructureFactory.create(name_fr='une infra', name_en='an infra')
+
+        response = self.client.get(infra.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'une infra')
+        self.assertNotContains(response, 'an infra')
+
+        response = self.client.get(infra.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'an infra')
+        self.assertNotContains(response, 'une infra')
+
     def test_check_structure_or_none_related_are_visible(self):
         infratype = InfrastructureTypeFactory.create(type=INFRASTRUCTURE_TYPES.BUILDING, structure=None)
         response = self.client.get(self.model.get_add_url())

--- a/geotrek/infrastructure/views.py
+++ b/geotrek/infrastructure/views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils import translation
 from django.contrib.gis.db.models.functions import Transform
 from mapentity.views import (MapEntityList, MapEntityFormat, MapEntityDetail, MapEntityDocument,
                              MapEntityCreate, MapEntityUpdate, MapEntityDelete)
@@ -36,6 +37,13 @@ class InfrastructureFormatList(MapEntityFormat, InfrastructureList):
 
 class InfrastructureDetail(MapEntityDetail):
     queryset = Infrastructure.objects.existing()
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/geotrek/outdoor/tests/test_views.py
+++ b/geotrek/outdoor/tests/test_views.py
@@ -74,6 +74,18 @@ class SiteCustomViewTests(TestCase):
         selected = f"<option value=\"{parent.pk}\" selected> {parent.name}</option>"
         self.assertContains(response, selected)
 
+    def test_lang_in_detail_page(self):
+        site = SiteFactory.create(name_fr='un site', name_en='a site')
+        self.client.force_login(SuperUserFactory())
+
+        response = self.client.get(site.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un site')
+        self.assertNotContains(response, 'a site')
+
+        response = self.client.get(site.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a site')
+        self.assertNotContains(response, 'un site')
+
 
 class CourseCustomViewTests(TestCase):
     @mock.patch('mapentity.helpers.requests.get')
@@ -131,6 +143,18 @@ class CourseCustomViewTests(TestCase):
         self.assertEqual(response.json()[0]['name'], 'course_with_ref_points')
         data = "{'type': 'MultiPoint', 'coordinates': [[12.0, 12.0]]}"
         self.assertEqual(str(response.json()[0]['points_reference']), data)
+
+    def test_lang_in_detail_page(self):
+        course = CourseFactory.create(name_fr='un parcours', name_en='a course', published=True)
+        self.client.force_login(SuperUserFactory())
+
+        response = self.client.get(course.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un parcours')
+        self.assertNotContains(response, 'a course')
+
+        response = self.client.get(course.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a course')
+        self.assertNotContains(response, 'un parcours')
 
 
 class SiteDeleteTest(TestCase):

--- a/geotrek/outdoor/views.py
+++ b/geotrek/outdoor/views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils import translation
 from django.contrib.gis.db.models.functions import Transform
 from django.db.models import Q, Prefetch
 from geotrek.common.models import HDViewPoint
@@ -32,6 +33,13 @@ class SiteDetail(CompletenessMixin, MapEntityDetail):
         Prefetch('view_points',
                  queryset=HDViewPoint.objects.select_related('content_type', 'license'))
     )
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -155,6 +163,13 @@ class CourseList(CustomColumnsMixin, MapEntityList):
 
 class CourseDetail(CompletenessMixin, MapEntityDetail):
     queryset = Course.objects.prefetch_related('type').all()
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/geotrek/sensitivity/tests/test_views.py
+++ b/geotrek/sensitivity/tests/test_views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User, Permission
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from mapentity.tests.factories import SuperUserFactory
 
 from geotrek.authent.tests.factories import StructureFactory, UserProfileFactory
 from geotrek.authent.tests.base import AuthentFixturesTest
@@ -159,6 +160,18 @@ class APIv2Test(TranslationResetMixin, TrekkingManagerTest):
         params = {'format': 'json', 'period': 'ignore', 'language': 'en'}
         response = self.client.get(url, params)
         self.assertIsNone(response.json()['species_id'])
+
+    def test_lang_in_detail_page(self):
+        sensitivearea = SensitiveAreaFactory.create(description_fr='une zone sensible', description_en='a sentive area')
+        self.client.force_login(SuperUserFactory())
+
+        response = self.client.get(sensitivearea.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'une zone sensible')
+        self.assertNotContains(response, 'a sentive area')
+
+        response = self.client.get(sensitivearea.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a sentive area')
+        self.assertNotContains(response, 'une zone sensible')
 
     @override_settings(SENSITIVITY_OPENAIR_SPORT_PRACTICES=['Practice1', ])
     def test_list_sensitivearea(self):

--- a/geotrek/sensitivity/views.py
+++ b/geotrek/sensitivity/views.py
@@ -7,6 +7,7 @@ from django.contrib.gis.db.models.functions import Transform
 from django.db.models import F, Case, When
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
+from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView
 from django.views.generic.detail import BaseDetailView
@@ -52,6 +53,13 @@ class SensitiveAreaFormatList(MapEntityFormat, SensitiveAreaList):
 
 class SensitiveAreaDetail(MapEntityDetail):
     queryset = SensitiveArea.objects.existing()
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/geotrek/signage/tests/test_views.py
+++ b/geotrek/signage/tests/test_views.py
@@ -407,6 +407,17 @@ class SignageViewsTest(GeotrekAPITestCase, CommonTest):
         self.assertContains(response, "<b>Beautiful !</b>")
         self.assertContains(response, "(WGS 84 / Pseudo-Mercator)")
 
+    def test_lang_in_detail_page(self):
+        signage = SignageFactory.create(name_fr='une signalétique', name_en='a signage')
+
+        response = self.client.get(signage.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'une signalétique')
+        self.assertNotContains(response, 'a signage')
+
+        response = self.client.get(signage.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a signage')
+        self.assertNotContains(response, 'une signalétique')
+
     def test_check_structure_or_none_related_are_visible(self):
         signagetype = SignageTypeFactory.create(structure=None)
         response = self.client.get(self.model.get_add_url())

--- a/geotrek/signage/views.py
+++ b/geotrek/signage/views.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 from django.contrib.gis.db.models.functions import Transform
 from django.http import HttpResponse
+from django.utils import translation
 from django.utils.functional import classproperty
 from mapentity.views import (MapEntityList, MapEntityFormat, MapEntityDetail,
                              MapEntityDocument, MapEntityCreate, MapEntityUpdate, MapEntityDelete)
@@ -49,6 +50,13 @@ class SignageFormatList(MapEntityFormat, SignageList):
 
 class SignageDetail(MapEntityDetail):
     queryset = Signage.objects.existing()
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/geotrek/tourism/tests/test_views.py
+++ b/geotrek/tourism/tests/test_views.py
@@ -14,6 +14,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from embed_video.backends import detect_backend
 from paperclip.models import random_suffix_regexp
+from mapentity.tests.factories import SuperUserFactory
 
 from geotrek.authent.tests.base import AuthentFixturesTest
 from geotrek.authent.tests.factories import (StructureFactory, UserFactory,
@@ -360,6 +361,18 @@ class TouristicContentAPITest(BasicJSONAPITest, TrekkingManagerTest):
             "type2_label": self.content.type2_label,
             "pictogram": os.path.join(settings.MEDIA_URL, self.category.pictogram.name)})
 
+    def test_lang_in_detail_page(self):
+        touristic_content = TouristicContentFactory.create(name_fr='un contenu touristique', name_en='a touristic content')
+        self.client.force_login(SuperUserFactory())
+
+        response = self.client.get(touristic_content.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un contenu touristique')
+        self.assertNotContains(response, 'a touristic content')
+
+        response = self.client.get(touristic_content.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a touristic content')
+        self.assertNotContains(response, 'un contenu touristique')
+
 
 class TouristicEventAPITest(BasicJSONAPITest, TrekkingManagerTest):
     factory = TouristicEventFactory
@@ -397,6 +410,18 @@ class TouristicEventAPITest(BasicJSONAPITest, TrekkingManagerTest):
                               "slug": "touristic-event",
                               "type1_label": "Type",
                               "pictogram": "/static/tourism/touristicevent.svg"})
+
+    def test_lang_in_detail_page(self):
+        touristic_event = TouristicContentFactory.create(name_fr='un évenement touristique', name_en='a touristic event')
+        self.client.force_login(SuperUserFactory())
+
+        response = self.client.get(touristic_event.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un évenement touristique')
+        self.assertNotContains(response, 'a touristic event')
+
+        response = self.client.get(touristic_event.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a touristic event')
+        self.assertNotContains(response, 'un évenement touristique')
 
 
 class TouristicEventViewsSameStructureTests(AuthentFixturesTest):

--- a/geotrek/tourism/views.py
+++ b/geotrek/tourism/views.py
@@ -6,6 +6,7 @@ from django.contrib.gis.db.models.functions import Transform
 from django.db.models import Q, Sum
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils import translation
 from django.utils.translation import gettext as _
 from django.views.generic import DetailView
 from django_filters.rest_framework import DjangoFilterBackend
@@ -64,6 +65,13 @@ class TouristicContentFormatList(MapEntityFormat, TouristicContentList):
 
 class TouristicContentDetail(CompletenessMixin, MapEntityDetail):
     queryset = TouristicContent.objects.existing()
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -216,6 +224,13 @@ class TouristicEventFormatList(MapEntityFormat, TouristicEventList):
 
 class TouristicEventDetail(CompletenessMixin, MapEntityDetail):
     queryset = TouristicEvent.objects.existing().select_related('place', 'cancellation_reason').prefetch_related('participants')
+
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -223,6 +223,17 @@ class POIViewsTest(GeotrekAPITestCase, CommonTest):
             reverse('trekking:trek_poi_geojson', kwargs={'lang': translation.get_language(), 'pk': trek.pk}))
         self.assertEqual(response.status_code, 404)
 
+    def test_lang_in_detail_page(self):
+        poi = POIFactory.create(name_fr='un POI', name_en='a POI')
+
+        response = self.client.get(poi.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un POI')
+        self.assertNotContains(response, 'a POI')
+
+        response = self.client.get(poi.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a POI')
+        self.assertNotContains(response, 'un POI')
+
 
 class TrekViewsTest(GeotrekAPITestCase, CommonTest):
     model = Trek
@@ -483,6 +494,17 @@ class TrekViewsTest(GeotrekAPITestCase, CommonTest):
         self.assertEqual(response.status_code, 200)
         form = self.get_form(response)
         self.assertEqual(form.data['parking_location'], bad_data['parking_location'])
+
+    def test_lang_in_detail_page(self):
+        trek = TrekFactory.create(name_fr='un itinéraire', name_en='a trek')
+
+        response = self.client.get(trek.get_detail_url() + '?lang=fr')
+        self.assertContains(response, 'un itinéraire')
+        self.assertNotContains(response, 'a trek')
+
+        response = self.client.get(trek.get_detail_url() + '?lang=en')
+        self.assertContains(response, 'a trek')
+        self.assertNotContains(response, 'un itinéraire')
 
     def test_list_in_csv(self):
         if self.model is None:

--- a/geotrek/trekking/views.py
+++ b/geotrek/trekking/views.py
@@ -337,6 +337,13 @@ class POIDetail(CompletenessMixin, MapEntityDetail):
                  queryset=HDViewPoint.objects.select_related('content_type', 'license'))
     )
 
+    def dispatch(self, *args, **kwargs):
+        lang = self.request.GET.get('lang')
+        if lang:
+            translation.activate(lang)
+            self.request.LANGUAGE_CODE = lang
+        return super().dispatch(*args, **kwargs)
+
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context['can_edit'] = self.get_object().same_structure(self.request.user)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR allows to change language directly in several detail pages. The related issue reports the bug in Sensitivity, but a similar bug also appears in signage, outdoor sites, outdoor courses, infrastructure, POI, touristic content, and touristic events, so the PR also fix those.

## Related Issue

#3577

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
