### PR TITLE
Fix interventions url on project detail map (#3498)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 **Bug fixes**
 
+- Fix interventions url on project detail map (#3498)
 - Fix `sync_rando` admin command failure if Trek has SVG attachment (#3803)
 
 

--- a/geotrek/maintenance/templates/maintenance/project_detail.html
+++ b/geotrek/maintenance/templates/maintenance/project_detail.html
@@ -122,8 +122,10 @@
             }
 
             function interventionUrl(properties, layer) {
-                return window.SETTINGS.urls.detail.replace(new RegExp('modelname', 'g'), 'intervention')
-                                      .replace('0', properties.pk);
+                var fake_detail_url = "{% url 'maintenance:intervention_detail' '0' %}";
+                id_pos = fake_detail_url.lastIndexOf('0');
+                // replace the last occurence of the fake id "0" in the intervention detail url
+                return fake_detail_url.slice(0, id_pos) + properties.id + fake_detail_url.slice(id_pos + 1);
             };
         });
     </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR solves the related issue by changing the intervention url on the project detail map.

## Related Issue

 #3498

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation]()https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
