### PR TITLE
Introduced Safer FTP Alternative: Added `FTP_TLS`

### DIFF
--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -17,7 +17,7 @@ from collections import Iterable
 from time import sleep
 from PIL import Image, UnidentifiedImageError
 
-from ftplib import FTP
+from ftplib import FTP, FTP_TLS
 from os.path import dirname
 from urllib.parse import urlparse
 
@@ -696,6 +696,16 @@ class AttachmentParserMixin:
 
             ftp = FTP(parsed_url.hostname)
             ftp.login(user=parsed_url.username, passwd=parsed_url.password)
+            ftp.cwd(directory)
+            size = ftp.size(parsed_url.path.split('/')[-1:][0])
+            return size != attachment.attachment_file.size
+
+        if parsed_url.scheme == 'ftps':
+            directory = dirname(parsed_url.path)
+
+            ftp = FTP_TLS(parsed_url.hostname)
+            ftp.login(user=parsed_url.username, passwd=parsed_url.password)
+            ftp.prot_p()
             ftp.cwd(directory)
             size = ftp.size(parsed_url.path.split('/')[-1:][0])
             return size != attachment.attachment_file.size


### PR DESCRIPTION

## Related Issue
Do I need to create an issue? If yes, please let me know.
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->


## Details
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [parsers.py](https://github.com/GeotrekCE/Geotrek-admin/blob/master/geotrek/common/parsers.py#L697), method: has_size_changed, a clear-text protocol such as FTP, Telnet or SMTP is used. These protocols transfer data without any encryption, which expose applications to a large range of risks. iCR suggested that data should be transferred over only secure transport channels.


## Changes
- Added FTP_TLS as an option to AttachmentParserMixin


## Previously Found & Fixed
- https://www.github.com/jschneier/django-storages/pull/1320
- https://www.github.com/geopython/pycsw/pull/918


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.

