### PR TITLE
🐛 [Bug fix] Fix error in `cities` cache key prefix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ CHANGELOG
 - Add `include_externals` filter to Cirkwi trek exports, to allow excluding treks with an external id (eid) (#3947)
 - Tourism : add price to TouristicEvent model - ref #3587
 
+**Bug fixes**
+
+- Fix cache key for zoning cities
+
+
 **Improvments**
 
 - Add popup button to add organizer in touristic event form

--- a/geotrek/core/tests/test_views.py
+++ b/geotrek/core/tests/test_views.py
@@ -797,7 +797,7 @@ class TrailViewsTest(CommonTest):
 
     def test_perfs_export_csv(self):
         self.modelfactory.create()
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             self.client.get(self.model.get_format_list_url() + '?format=csv')
 
 

--- a/geotrek/tourism/tests/test_functional.py
+++ b/geotrek/tourism/tests/test_functional.py
@@ -368,7 +368,7 @@ class TouristicEventViewsTests(GeotrekAPITestCase, CommonTest):
         total_count = sum(map(attrgetter('count'), counts))
         self.assertEqual(event.participants_total, total_count)
         self.assertEqual(event.participants_total_verbose_name, "Number of participants")
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(17):
             response = self.client.get(event.get_format_list_url())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get('Content-Type'), 'text/csv')

--- a/geotrek/zoning/mixins.py
+++ b/geotrek/zoning/mixins.py
@@ -59,7 +59,7 @@ class ZoningPropertiesMixin:
         last_update_iso_format = last_update_and_count['last_update'].isoformat() if last_update_and_count[
             'last_update'] else 'no-data'
         count = last_update_and_count['count']
-        cache_string = f"areas:{self.pk}:{self.date_update.isoformat()}:{last_update_iso_format}:{count}"
+        cache_string = f"cities:{self.pk}:{self.date_update.isoformat()}:{last_update_iso_format}:{count}"
         cache_key = hashlib.md5(cache_string.encode("utf-8")).hexdigest()
         data = cache.get(cache_key)
         if data:


### PR DESCRIPTION
It was harmless because the other parts of the cache key prevent retrieving the wrong content. No visible change for users excepted some slow requests to rebuild cached values.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [ ] ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [ ] ~~I have performed a self-review of my code~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] New and existing unit tests pass locally with my changes
- [ ] ~~I added an entry in the changelog file~~
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] ~~The title of my PR mentionned the issue associated~~
