### PR TITLE
Add conf to use Makefile.perso.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 /.vscode/
 geotrek/settings/custom.py
 geotrek/cypress/node_modules
+Makefile.perso.mk
 # buildout stuff
 .mr.developer.cfg
 .installed.cfg

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ else
   docker_compose=docker-compose
 endif
 
+-include Makefile.perso.mk
+
 ###########################
 #          colors         #
 ###########################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mettre dans la conf la possibilité de créer un fichier `Makefile.perso.mk` pour voir des règles perso sur chaque projets

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
