### PR TITLE
Fix api crash when using an svg file for information desks (fixes #3860)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,7 @@ override_dh_virtualenv:
 	--python /usr/bin/python3.8 \
 	--upgrade-pip \
 	--preinstall wheel \
-	--preinstall setuptools \
+	--preinstall setuptools==69.2.0 \
 	--builtin-venv \
 	--extra-pip-arg --no-cache-dir \
 	--extra-pip-arg --quiet

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.103.2+dev (XXXX-XX-XX)
 ------------------------
 
+**Bug fixes**
+
+- Fix api crash when using an svg file for information desks (fixes #3860)
+
 **Breaking changes**
 
 - Geotrek-rando v2 support is deprecated, `sync_rando` command and Sync rando menu view are removed.

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -2156,9 +2156,29 @@ class APIAccessAnonymousTestCase(BaseApiTest):
             tourism_models.InformationDesk
         )
 
+    def test_informationdesk_list_with_svg(self):
+        info_desk = tourism_factory.InformationDeskFactory(
+            photo=get_dummy_uploaded_image_svg(), name='test!')
+        info_desk.save()
+        self.treks[0].information_desks.add(info_desk)
+        self.check_number_elems_response(
+            self.get_informationdesk_list(),
+            tourism_models.InformationDesk
+        )
+
     def test_informationdesk_detail(self):
         self.check_structure_response(
             self.get_informationdesk_detail(self.info_desk.pk),
+            INFORMATION_DESK_PROPERTIES_JSON_STRUCTURE
+        )
+
+    def test_informationdesk_detail_with_svg(self):
+        info_desk = tourism_factory.InformationDeskFactory(
+            photo=get_dummy_uploaded_image_svg())
+        info_desk.save()
+        self.treks[0].information_desks.add(info_desk)
+        self.check_structure_response(
+            self.get_informationdesk_detail(info_desk.pk),
             INFORMATION_DESK_PROPERTIES_JSON_STRUCTURE
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,9 @@ cffi==1.16.0
     #   pyvips
     #   weasyprint
 chardet==5.2.0
-    # via geotrek (setup.py)
+    # via
+    #   geotrek (setup.py)
+    #   reportlab
 charset-normalizer==3.2.0
     # via requests
 click==8.1.3
@@ -85,6 +87,7 @@ coreschema==0.0.4
 cssselect2==0.7.0
     # via
     #   cairosvg
+    #   svglib
     #   weasyprint
 datetime==5.2
     # via appy
@@ -172,8 +175,9 @@ drf-yasg==1.21.5
     # via
     #   django-large-image
     #   geotrek (setup.py)
-easy-thumbnails==2.8.5
+easy-thumbnails[svg]==2.8.5
     # via
+    #   geotrek (setup.py)
     #   mapentity
     #   paperclip
 env-file==2020.12.3
@@ -217,7 +221,9 @@ large-image==1.20.3
 large-image-source-vips==1.17.2
     # via geotrek (setup.py)
 lxml==4.9.3
-    # via mapentity
+    # via
+    #   mapentity
+    #   svglib
 mapentity==8.7.2
     # via geotrek (setup.py)
 markdown==3.4.4
@@ -258,6 +264,7 @@ pillow==10.2.0
     #   geotrek (setup.py)
     #   large-image
     #   paperclip
+    #   reportlab
     #   weasyprint
 prompt-toolkit==3.0.39
     # via click-repl
@@ -297,6 +304,10 @@ rcssmin==1.1.1
     # via django-compressor
 redis==4.5.4
     # via geotrek (setup.py)
+reportlab==4.1.0
+    # via
+    #   easy-thumbnails
+    #   svglib
 requests==2.31.0
     # via
     #   coreapi
@@ -326,12 +337,15 @@ soupsieve==2.5
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
+svglib==1.5.1
+    # via easy-thumbnails
 tif2geojson==0.1.3
     # via geotrek (setup.py)
 tinycss2==1.2.1
     # via
     #   cairosvg
     #   cssselect2
+    #   svglib
     #   weasyprint
 transaction==3.1.0
     # via zodb

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         # prod,
         'gunicorn',
         'sentry-sdk',
+        'easy-thumbnails[svg]',
     ],
     cmdclass={"build": BuildCommand},
     include_package_data=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- The `easy_thumbnails` dependency is now installed with the `[svg]` extra: information desks svg pictures can now be made into thumbnails without the api crashing.
- Unit tests using svg files have been added for views related to information desks.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->
- #3860

## Checklist

- [X] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [X] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes
- [X] I added an entry in the changelog file
- [X] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [X] I added a label to the PR corresponding to the perimeter of my contribution
- [X] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
