### PR TITLE
Fix mobile sync when no picto on themes (fixes #3814)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -108,7 +108,7 @@ Do not use - Causes bug in Geotrek-Rando-v3 exposing Outdoor data
 
 
 2.102.0 (2024-02-19)
---------------------This branch is out-of-date with the base branch
+--------------------
 
 **Minor changes**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix api crash when using an svg file for information desks (fixes #3860)
+- Fix mobile sync crash when a theme has no pictogram (fixes #3814)
 
 **Breaking changes**
 

--- a/geotrek/api/mobile/serializers/common.py
+++ b/geotrek/api/mobile/serializers/common.py
@@ -103,6 +103,8 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
         pictogram = serializers.SerializerMethodField()
 
         def get_pictogram(self, obj):
+            if not obj.pictogram:
+                return None
             file_name, file_extension = os.path.splitext(str(obj.pictogram.url))
             return '{file}.png'.format(file=file_name) if file_extension == '.svg' else obj.pictogram.url
 

--- a/geotrek/api/mobile/serializers/common.py
+++ b/geotrek/api/mobile/serializers/common.py
@@ -142,6 +142,8 @@ if 'geotrek.trekking' in settings.INSTALLED_APPS:
         pictogram = serializers.SerializerMethodField()
 
         def get_pictogram(self, obj):
+            if not obj.pictogram:
+                return None
             file_name, file_extension = os.path.splitext(str(obj.pictogram.url))
             return '{file}.png'.format(file=file_name) if file_extension == '.svg' else obj.pictogram.url
 

--- a/geotrek/api/tests/test_mobile/test_serializers.py
+++ b/geotrek/api/tests/test_mobile/test_serializers.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+from geotrek.api.mobile.serializers import common as api_serializers
+from geotrek.trekking.tests.factories import PracticeFactory
+from geotrek.common.tests.factories import ThemeFactory
+
+
+class PracticeSerializerTestCase(TestCase):
+
+    def test_practice_with_picto(self):
+        practice = PracticeFactory.create(pictogram='a/pictogram/path.png')
+        serialized_practice = api_serializers.PracticeSerializer(practice).data
+        self.assertEqual(serialized_practice['pictogram'], '/media/a/pictogram/path.png')
+
+    def test_practice_with_no_picto(self):
+        practice = PracticeFactory.create(pictogram=None)
+        serialized_practice = api_serializers.PracticeSerializer(practice).data
+        self.assertIsNone(serialized_practice['pictogram'])
+
+
+class ThemeSerializerTestCase(TestCase):
+
+    def test_theme_with_picto(self):
+        theme = ThemeFactory.create(pictogram='a/pictogram/path.png')
+        serialized_theme = api_serializers.ThemeSerializer(theme).data
+        self.assertEqual(serialized_theme['pictogram'], '/media/a/pictogram/path.png')
+
+    def test_theme_with_no_picto(self):
+        theme = ThemeFactory.create(pictogram=None)
+        serialized_theme = api_serializers.ThemeSerializer(theme).data
+        self.assertIsNone(serialized_theme['pictogram'])

--- a/geotrek/api/tests/test_mobile/test_sync_mobile.py
+++ b/geotrek/api/tests/test_mobile/test_sync_mobile.py
@@ -22,7 +22,8 @@ from PIL import Image
 from geotrek.common.tests import TranslationResetMixin
 from geotrek.common.tests.factories import (AttachmentFactory,
                                             RecordSourceFactory,
-                                            TargetPortalFactory)
+                                            TargetPortalFactory,
+                                            ThemeFactory)
 from geotrek.common.utils.testdata import (get_dummy_uploaded_file,
                                            get_dummy_uploaded_image,
                                            get_dummy_uploaded_image_svg)
@@ -573,6 +574,15 @@ class SyncMobileTreksTest(TranslationResetMixin, VarTmpTestCase):
 
     def test_sync_treks_informationdesk_photo_missing(self):
         os.remove(self.info_desk.photo.path)
+        output = StringIO()
+        management.call_command('sync_mobile', os.path.join(settings.TMP_DIR, 'sync_mobile', 'tmp_sync'), url='http://localhost:8000',
+                                skip_tiles=True, verbosity=2, stdout=output)
+        self.assertIn('Done', output.getvalue())
+
+    def test_sync_treks_theme_no_picto(self):
+        theme_no_picto = ThemeFactory.create(pictogram=None)
+        trek = TrekWithPublishedPOIsFactory.create()
+        trek.themes.add(theme_no_picto)
         output = StringIO()
         management.call_command('sync_mobile', os.path.join(settings.TMP_DIR, 'sync_mobile', 'tmp_sync'), url='http://localhost:8000',
                                 skip_tiles=True, verbosity=2, stdout=output)

--- a/geotrek/api/tests/test_mobile/test_sync_mobile.py
+++ b/geotrek/api/tests/test_mobile/test_sync_mobile.py
@@ -587,3 +587,11 @@ class SyncMobileTreksTest(TranslationResetMixin, VarTmpTestCase):
         management.call_command('sync_mobile', os.path.join(settings.TMP_DIR, 'sync_mobile', 'tmp_sync'), url='http://localhost:8000',
                                 skip_tiles=True, verbosity=2, stdout=output)
         self.assertIn('Done', output.getvalue())
+
+    def test_sync_treks_practice_no_picto(self):
+        practice_no_picto = PracticeFactory.create(pictogram=None)
+        TrekWithPublishedPOIsFactory.create(practice=practice_no_picto)
+        output = StringIO()
+        management.call_command('sync_mobile', os.path.join(settings.TMP_DIR, 'sync_mobile', 'tmp_sync'), url='http://localhost:8000',
+                                skip_tiles=True, verbosity=2, stdout=output)
+        self.assertIn('Done', output.getvalue())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds checks for pictogram existence in `PracticeSerializer` and `ThemeSerializer`
- Adds unit tests for mobile sync when a practice or a theme has no pictogram
- Adds unit tests for handling of pictograms in `PracticeSerializer` and `ThemeSerializer`

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->
- #3814

## Checklist

- [X] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/CONTRIBUTING.html)
- [X] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes
- [X] I added an entry in the changelog file
- [X] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [X] I added a label to the PR corresponding to the perimeter of my contribution
- [X] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
