### PR TITLE
Hotfix CI: update E2E test to docker compose v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,10 +249,10 @@ jobs:
           echo 'POSTGRES_USER=ci_test' >> .env
           echo 'POSTGRES_PASSWORD=ci_test' >> .env
           echo 'POSTGRES_DB=ci_test' >> .env
-          docker-compose run web update.sh
+          docker compose run web update.sh
           make load_data
           make load_test_integration
-          docker-compose up -d
+          docker compose up -d
 
       - name: Prepare nginx
         run: |


### PR DESCRIPTION
Since April, 3rd 2024 `docker-compose` (v1) command is deprecated in github actions

see https://github.com/orgs/community/discussions/116610