### PR TITLE
Set MenuItem `open_in_new_tab` to False for page target

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ CHANGELOG
 2.104.0+dev (XXXX-XX-XX)
 ------------------------
 
+**Bug fixes**
+
+- Set MenuItem `open_in_new_tab` to False during migration when the target is a flat page
 
 
 2.104.0 (2024-04-03)

--- a/geotrek/flatpages/migrations/0015_set_open_in_new_tab_false_for_page_target.py
+++ b/geotrek/flatpages/migrations/0015_set_open_in_new_tab_false_for_page_target.py
@@ -1,0 +1,25 @@
+"""
+Fix migration 0012_change_flatpage_schema: MenuItem automatically created from an old FlatPage should have their
+`open_in_new_tab` value to False when their target type is "page".
+"""
+
+from django.db import migrations
+
+
+def update_open_in_new_tab(apps, schema_editor):
+    MenuItem = apps.get_model('flatpages', 'MenuItem')
+    for menu_item in MenuItem.objects.all():
+        if menu_item.target_type != "link":
+            menu_item.open_in_new_tab = False
+            menu_item.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('flatpages', '0014_alter_menu_item_title_max_length'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_open_in_new_tab, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Corrige un oubli dans la migration de données des anciennes Pages Statiques vers les Éléments Menu : la valeur de `open_in_new_tab` doit être False si le type de target de l'élément menu est None ou "page" (car une page statique est une page interne, donc ouverture dans le même onglet).

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~
