### PR TITLE
New menu items with page target open it in same tab

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ CHANGELOG
 2.104.1+dev (XXXX-XX-XX)
 ------------------------
 
+**Bug fix**
+
+- New menu items targeting static page now open it in the same tab
 
 
 2.104.1 (2024-04-03)

--- a/geotrek/flatpages/static/flatpages/js/menu_item_fieldsets.js
+++ b/geotrek/flatpages/static/flatpages/js/menu_item_fieldsets.js
@@ -59,6 +59,11 @@ function cleanSubmission() {
         });
     };
 
+    let uncheckOpenInNewTab = function() {
+        let checkbox = document.querySelector("input[name=open_in_new_tab]");
+        checkbox.checked = false;
+    }
+
     let erasePageField = function() {
         let page_select = document.querySelector("select[name=\"page\"]");
         page_select.value = undefined;
@@ -67,6 +72,7 @@ function cleanSubmission() {
     let targetType = document.getElementById("id_target_type").value;
     if (targetType === "page") {
         eraseLinkUrlFields();
+        uncheckOpenInNewTab();
     } else if (targetType === "link") {
         erasePageField();
     } else {


### PR DESCRIPTION
Suite à la version 2.104.0 la création d'un nouveau Élément Menu pointant vers une page statique résultait dans l'ouverture de celle-ci dans un nouvel onglet (mauvais d'un point de vue convention de navigation dans un site web). Cette PR corrige ce problème.

## Description

La checkbox « Ouvrir dans un nouvel onglet » est à True par défaut (car j'ai considéré que c'était le cas standard de pointer vers un lien externe).

Mais cette valeur True était aussi enregistrée même quand la cible était une page statique (interne). La checkbox est cachée dans le formulaire quand le type est "page".

Ce fix ajoute un effet dans le JS sur le submit du formulaire pour uncheck `open_in_new_tab` si le `target_type` est "page". (Je nettoyais déjà les autres champs du form sur cet event).

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~

