### PR TITLE
Ensure migration steps for menu items can be run separately

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fix**
 
 - New menu items targeting static page now open it in the same tab
+- Ensure migration steps for menu items can be run separately
 
 
 2.104.1 (2024-04-03)

--- a/geotrek/flatpages/migrations/0011_migrate_flatpage_data.py
+++ b/geotrek/flatpages/migrations/0011_migrate_flatpage_data.py
@@ -9,7 +9,7 @@ otherwise translation fields (from the Python objects side) would be missing.
 from django.conf import settings
 from django.db import migrations
 from django.utils import translation
-from modeltranslation.translator import translator, TranslationOptions
+from modeltranslation.translator import translator, TranslationOptions, AlreadyRegistered
 from modeltranslation.utils import build_localized_fieldname
 
 from treebeard.mp_tree import MP_Node
@@ -94,8 +94,12 @@ def create_menu_items_from_flatpages(apps, schema_editor):
     # modeltranslation registration is not run on historical models available during migrations.
     # We register FlatPage for translations now so `title_fr`, `title_es`, etc are defined.
     translator.register(FlatPage, FlatPageTO)
-    # MenuItem is already translation-registered from the previous migration
+    # MenuItem is already translation-registered from the previous migration so we cautiously try
     # (it will be needed to copy values in translation fields)
+    try:
+        translator.register(MenuItem, MenuItemTO)
+    except AlreadyRegistered:
+        pass
 
     # Those fields are copied from FlatPage to MenuItem.
     # Dict keys are FlatPage's fieldnames, dict values are MenuItem's fieldnames.


### PR DESCRIPTION
Je fais des manips délicates avec `modeltranslation.translator` dans les migrations pour pouvoir déclarer et copier les valeurs des _translation fields_.

Les scripts de migration `0010`, `0011` et `0012` du module flatpages sont censés être exécutés dans la même commande `migrate` pour une mise à jour.

Mais pour se protéger contre l'issue #4046 et permettre de jouer les étapes de migration séparèment j'ai ajouté une clause `try...except`.

## Related Issue

#4046
