### PR TITLE
🐛 [Fix] Blockquote style in flat pages can be saved

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ CHANGELOG
 
 - New menu items targeting static page now open it in the same tab
 - Ensure migration steps for menu items can be run separately
+- Blockquote style in flat page content is now persistent on saving
 
 
 2.104.1 (2024-04-03)

--- a/geotrek/flatpages/widgets.py
+++ b/geotrek/flatpages/widgets.py
@@ -74,7 +74,7 @@ FLATPAGE_TINYMCE_CONFIG = {
                        'img[longdesc|usemap|src|border|alt=|title|hspace|vspace|width|height|align],'
                        'p,em/i,strong/b,div[align],br,ul,li,ol,span[style],'
                        'iframe[src|frameborder=0|alt|title|width|height|align|name],'
-                       'h2,h3,h4,h5,h6,figure,figcaption'),
+                       'h2,h3,h4,h5,h6,figure,figcaption,blockquote'),
     "setup": "tinyMceInit",
 }
 


### PR DESCRIPTION
Pour chaque balise HTML pouvant être créé par les styles/outils TinyMCE il faut autoriser l'élément dans la config tinymce. À voir pourquoi ça a été ajouté (vient de `django-mapentity`) et si on peut s'en passer.