### PR TITLE
🐛 [Fix] Fix crash on migrate when db username or dbname contains dash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix OptionalRangeFilter and CustomDateFromToRangeFilter labels translation (fixes #3852)
+- Fix crash on migrate when db username or dbname contains dash
 
 **Documentation**
 

--- a/geotrek/common/utils/postgresql.py
+++ b/geotrek/common/utils/postgresql.py
@@ -124,5 +124,5 @@ def move_models_to_schemas(app):
         dbname = settings.DATABASES['default']['NAME']
         dbuser = settings.DATABASES['default']['USER']
         search_path = ', '.join(('public', ) + tuple(set(settings.DATABASE_SCHEMAS.values())))
-        sql = "ALTER ROLE %s IN DATABASE %s SET search_path=%s;" % (dbuser, dbname, search_path)
+        sql = "ALTER ROLE \"%s\" IN DATABASE \"%s\" SET search_path=%s;" % (dbuser, dbname, search_path)
         cursor.execute(sql)


### PR DESCRIPTION
Corrige un crash de la commande `migrate` si DB username ou dbname contient un tiret (_dash_).

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
