### PR TITLE
Remove unused volume in prod compose file

### DIFF
--- a/docker/install/docker-compose.yml
+++ b/docker/install/docker-compose.yml
@@ -53,5 +53,4 @@ services:
       - redis
 
 volumes:
-  postgres:
   redis:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix OptionalRangeFilter and CustomDateFromToRangeFilter labels translation (fixes #3852)
+- Remove unused `postgres` volume in docker compose file for production
 
 **Documentation**
 


### PR DESCRIPTION
Nettoyage : retire le volume `postgres` qui n'est pas utilisé dans le fichier docker compose pour env de production.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- ~~I have performed a self-review of my code~~
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~New and existing unit tests pass locally with my changes~~
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~
