### PR TITLE
Prevent Pillow Decompressed Data Too Large Error from interrupting Parsers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix empty linetring in reorder_topology cmd (fixes #4092)
+- Prevent Pillow Decompressed Data Too Large Error from interrupting Parsers
 
 
 2.108.0     (2024-07-12)

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -802,6 +802,9 @@ class AttachmentParserMixin:
                         return False, updated
             except UnidentifiedImageError:
                 pass
+            except ValueError:
+                # We want to catch : https://github.com/python-pillow/Pillow/blob/22ef8df59abf461824e4672bba8c47137730ef57/src/PIL/PngImagePlugin.py#L143
+                return False, updated
             attachment.attachment_file.save(name, f, save=False)
             attachment.is_image = attachment.is_an_image()
         else:

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -355,6 +355,16 @@ class AttachmentParserTests(TestCase):
         self.assertTrue(os.path.exists(attachment.attachment_file.path), True)
 
     @mock.patch('requests.get')
+    @mock.patch('PIL.Image.open')
+    def test_catch_decompression_error(self, mocked_open, mocked_get):
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.content = b''
+        mocked_open.side_effect = ValueError("Decompressed Data Too Large")
+        filename = os.path.join(os.path.dirname(__file__), 'data', 'organism4.xls')
+        call_command('import', 'geotrek.common.tests.test_parsers.AttachmentLegendParser', filename, verbosity=0)
+        self.assertEqual(Attachment.objects.count(), 0)
+
+    @mock.patch('requests.get')
     def test_attachment_with_other_filetype_with_structure(self, mocked):
         """
         It will always take the one without structure first


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
We want to catch this error : 

https://github.com/python-pillow/Pillow/blob/e39ee95f56d9c385065ed2963e8144d0826bb13e/src/PIL/PngImagePlugin.py#L139

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
