### PR TITLE
Set MenuItem `open_in_new_tab` to False when no target (#4093)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ CHANGELOG
 - Change label filter intervention contractors and filter null value on project contractors detail view (#3820)
 - Sort attachements in API V2 for OutdoorSites and TouristicContent objects (fixes #4071)
 - Expose missing Sources in APIv2 (fixes #4079)
+- MenuItem `open_in_new_tab` is now set to False when no target (#4093)
 
 **Documentation**
 

--- a/geotrek/flatpages/static/flatpages/js/menu_item_fieldsets.js
+++ b/geotrek/flatpages/static/flatpages/js/menu_item_fieldsets.js
@@ -78,6 +78,7 @@ function cleanSubmission() {
     } else {
         eraseLinkUrlFields();
         erasePageField();
+        uncheckOpenInNewTab();
     }
 }
 


### PR DESCRIPTION
- the default value is True because the main use case for the link target type is to show external links,
- but we need to expose `open_in_new_tab` = False in the API when the target type is None or "page".

## Related Issue

[Menu Items without target should have open_in_new_tab field to false](https://github.com/GeotrekCE/Geotrek-admin/issues/4093)

## Checklist

- ~~I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)~~
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated
