### PR TITLE
Fix MenuItem title max length in flatpages migration 0010 (#4095)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ CHANGELOG
 - Sort attachements in API V2 for OutdoorSites and TouristicContent objects (fixes #4071)
 - Expose missing Sources in APIv2 (fixes #4079)
 - MenuItem `open_in_new_tab` is now set to False when no target (#4093)
+- Fix MenuItem title max length in flatpages migration 0010 (#4095)
 
 **Documentation**
 

--- a/geotrek/flatpages/migrations/0010_create_model_MenuItem.py
+++ b/geotrek/flatpages/migrations/0010_create_model_MenuItem.py
@@ -93,7 +93,7 @@ class Migration(migrations.Migration):
                 ('path', models.CharField(max_length=255, unique=True)),
                 ('depth', models.PositiveIntegerField()),
                 ('numchild', models.PositiveIntegerField(default=0)),
-                ('title', models.CharField(max_length=50, verbose_name='Title')),
+                ('title', models.CharField(max_length=200, verbose_name='Title')),
                 ('target_type',
                  models.CharField(
                      blank=True, choices=[('page', 'Page'), ('link', 'Link')], max_length=10,


### PR DESCRIPTION
I have missed a spot when providing the fix on title length at e59cc897cedf42d3c4dac5acd22f031497d9b774

## Related Issue

[Error with migration to MenuItem: value too long for type character varying(50)](https://github.com/GeotrekCE/Geotrek-admin/issues/4095)

## Checklist

- ~~I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)~~
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated
