### PR TITLE
🚑 [HotFix] Bump to mapentity 8.8.1 to get a fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.105.0+dev (XXXX-XX-XX)
 ------------------------
 
+**Hotfix**
+
+- Bump to mapentity 8.8.1 to get a fix
+
 
 2.105.0 (2024-05-07)
 --------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -227,7 +227,7 @@ lxml==4.9.3
     # via
     #   mapentity
     #   svglib
-mapentity==8.8.0
+mapentity==8.8.1
     # via geotrek (setup.py)
 markdown==3.4.4
     # via geotrek (setup.py)


### PR DESCRIPTION
Mise à jour pour prendre le correctif à un problème introduit par la refonte du cache pour `get_internal_user` dans mapentity (PR [Refactor media storage usage](https://github.com/makinacorpus/django-mapentity/pull/298/commits) et du commit [improve internal user cache](https://github.com/makinacorpus/django-mapentity/pull/298/commits/d98dd11fd2662ce0c5241fc93dccae3eef806bf8)).

Embarqué dans geotrek-admin avec [Improve test environment](https://github.com/GeotrekCE/Geotrek-admin/pull/4035)

**Symptôme :** le `update.sh` échoue sur une BD existante car la commande `update_geotrek_permissions` échoue. Ce n'est probablement pas la seule erreur à attendre : `get_internal_user` est notamment utilisée pour les appels au service screamshotter pour générer les cartes des fiches itinéraires PDF.