### PR TITLE
🐛 [FIX] Empty linetring in reorder_topology cmd (#4092)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.108.0+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+- Fix empty linetring in reorder_topology cmd (fixes #4092)
+
 
 2.108.0     (2024-07-12)
 ------------------------

--- a/geotrek/core/management/commands/reorder_topologies.py
+++ b/geotrek/core/management/commands/reorder_topologies.py
@@ -42,12 +42,12 @@ class Command(BaseCommand):
             geom_lines = self.get_geom_lines(topology)
 
             new_order = self.get_new_order(geom_lines)
-            if new_order == []:
+            if new_order == [] or (len(geom_lines) >= 2 and geom_lines[1][1] == 'LINESTRING EMPTY'):
                 for field in topology._meta.get_fields():
                     if isinstance(field, OneToOneRel) and hasattr(topology, field.name):
                         failed_topologies.append(str(f'{getattr(topology, field.name).kind} id: {topology.pk}'))
 
-            if len(new_order) <= 2:
+            if len(new_order) <= 2 or (len(geom_lines) >= 2 and geom_lines[1][1] == 'LINESTRING EMPTY'):
                 continue
             order_maked_lines = new_order[1:]
             orders = [result - 1 for result in order_maked_lines]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
