### PR TITLE
💫 [IMPR] ApidaeTrekParser now imports `membreProprietaire` as structure

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.106.0+dev (XXXX-XX-XX)
 ------------------------
 
+**Improvements**
+
+- ApidaeTrekParser now imports field `membreProprietaire` as the structure
+
 **Documentation**
 
 - Improve information about upgrading geotrek-admin version with debian

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -435,6 +435,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
             'informationsEquipement.itineraire.referencesCartographiques',
             'informationsEquipement.itineraire.referencesTopoguides',
         ),
+        'structure': 'gestion.membreProprietaire.nom',
     }
     m2m_fields = {
         'source': 'gestion.membreProprietaire',
@@ -452,6 +453,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         'networks': 'network',
         'route': 'route',
         'accessibilities': 'name',
+        'structure': 'name',
     }
     field_options = {
         'source': {'create': True},
@@ -476,6 +478,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         },
         'accessibilities': {'create': True},
         'geom': {'required': True},
+        'structure': {'create': True},
     }
     non_fields = {
         'attachments': 'illustrations',

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -937,6 +937,7 @@ class ApidaeTrekParserTests(TestCase):
         self.assertEqual(len(trek.source.all()), 1)
         self.assertEqual(trek.source.first().name, 'Office de tourisme de Sallanches')
         self.assertEqual(trek.source.first().website, 'https://www.example.net/ot-sallanches')
+        self.assertEqual(trek.structure.name, 'Office de tourisme de Sallanches')
 
         self.assertTrue(trek.difficulty is not None)
         self.assertEqual(trek.difficulty.difficulty_en, 'Level red – hard')


### PR DESCRIPTION
Sur une demande de AURA Tourisme pour le ApidaeTrekParser : ajout du mapping du champ Apidae `gestion.membreProprietaire` vers la structure de l'itinéraire, qui est créée si elle n'existe pas.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) ~~and references associated issues~~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
