### PR TITLE
🐛 fix: Prevent trek map screenshot error if type of associated information desk have not pictogram

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ CHANGELOG
 
 **Bug fixes**
 - Fix view `v_treks` (fixes #4099)
-- Prevent trek map screenshot if information desk type have not pictogram
+- Prevent trek map screenshot error if type of associated information desk have not pictogram
 
 2.106.0 (2024-05-15)
 --------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ CHANGELOG
 
 **Bug fixes**
 - Fix view `v_treks` (fixes #4099)
+- Prevent trek map screenshot if information desk type have not pictogram
 
 2.106.0 (2024-05-15)
 --------------------

--- a/geotrek/trekking/templates/trekking/trek_detail.html
+++ b/geotrek/trekking/templates/trekking/trek_detail.html
@@ -177,7 +177,7 @@
                             iconSize: [{{ view.icon_sizes.information_desk }}, {{ view.icon_sizes.information_desk }}],
                             iconAnchor: [{{ view.icon_sizes.information_desk }}/2, {{ view.icon_sizes.information_desk }}/2],
                         });
-                        return L.marker(latlng, {icon: infoDeskIcon});
+                        return L.marker(latlng, feature.properties.type.pictogram ? {icon: infoDeskIcon} : {});
                     }
                 }).addTo(map);
                 $('.map-panel').addClass('info_desks_loaded');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Si dans la fiche detail d'un itinéraire,
la propriété information_desks type n'avait pas de pictogram défini,
la classe css `info_desks_loaded` ne se positionnait pas ce qui empêchait dans certains cas
de faire des captures d'écrans des cartes pour la génération des pdf.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
