### PR TITLE
[FIX] Exclude deleted areas from OpenAir export (#4140)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Improvements**
 
 - ApidaeTrekParser now imports field `membreProprietaire` as the structure
+- Exclude deleted areas from OpenAir export (fixes #4140)
 
 **Documentation**
 

--- a/geotrek/sensitivity/views.py
+++ b/geotrek/sensitivity/views.py
@@ -138,7 +138,7 @@ class SensitiveAreaOpenAirList(PublicOrReadPermMixin, ListView):
     def get_queryset(self):
         aerial_practice = SportPractice.objects.filter(name__in=settings.SENSITIVITY_OPENAIR_SPORT_PRACTICES)
         return SensitiveArea.objects.filter(
-            species__practices__in=aerial_practice, published=True
+            species__practices__in=aerial_practice, published=True, deleted=False
         ).select_related('species')
 
     def render_to_response(self, context):

--- a/geotrek/sensitivity/views.py
+++ b/geotrek/sensitivity/views.py
@@ -137,8 +137,8 @@ class SensitiveAreaOpenAirList(PublicOrReadPermMixin, ListView):
 
     def get_queryset(self):
         aerial_practice = SportPractice.objects.filter(name__in=settings.SENSITIVITY_OPENAIR_SPORT_PRACTICES)
-        return SensitiveArea.objects.filter(
-            species__practices__in=aerial_practice, published=True, deleted=False
+        return SensitiveArea.objects.existing().filter(
+            species__practices__in=aerial_practice, published=True
         ).select_related('species')
 
     def render_to_response(self, context):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #4140 by using `existing model manager` on OpenAir queryset to exclude deleted areas. 

<!--- Describe your changes in detail -->

## Related Issue

issue #4140
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
