### PR TITLE
ApidaeTrekParser now fallbacks on trace filename extension if no extension property

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ CHANGELOG
 - Fix swapped plural and singular translations for Annotation Categories (#4032)
 - Filter out deleted services in API responses (#4284)
 
+**Bug fixes**
+
+- ApidaeTrekParser now fallbacks on trace filename extension if no extension property
+
+
 2.109.1     (2024-08-22)
 ----------------------------
 

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trek_with_plan_with_no_extension_at_all.json
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trek_with_plan_with_no_extension_at_all.json
@@ -1,0 +1,21 @@
+{
+  "numFound": 1,
+  "objetsTouristiques": [
+    {
+      "id": 123123,
+      "multimedias": [
+        {
+          "type": "PLAN",
+          "traductionFichiers": [
+            {
+              "url": "https://example.net/trace"
+            }
+          ]
+        }
+      ],
+      "nom": {
+        "libelleFr": "Une belle randonnée de test mais le plan n'a aucune info d'extension de format de fichier"
+      }
+    }
+  ]
+}

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trek_with_plan_without_extension_prop.json
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trek_with_plan_without_extension_prop.json
@@ -1,0 +1,21 @@
+{
+  "numFound": 1,
+  "objetsTouristiques": [
+    {
+      "id": 123123,
+      "multimedias": [
+        {
+          "type": "PLAN",
+          "traductionFichiers": [
+            {
+              "url": "https://example.net/trace.kml"
+            }
+          ]
+        }
+      ],
+      "nom": {
+        "libelleFr": "Une belle randonnée de test avec un plan sans extension (déduite du filename)"
+      }
+    }
+  ]
+}

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1067,6 +1067,30 @@ class ApidaeTrekParserTests(TestCase):
         self.assertIn('has no attached "PLAN" in a supported format', output_stdout.getvalue())
 
     @mock.patch('requests.get')
+    def test_trek_plan_without_extension_property(self, mocked_get):
+        output_stdout = StringIO()
+        mocked_get.side_effect = self.make_dummy_get('trek_with_plan_without_extension_prop.json')
+
+        call_command('import', 'geotrek.trekking.tests.test_parsers.TestApidaeTrekParser', verbosity=2,
+                     stdout=output_stdout)
+
+        self.assertEqual(Trek.objects.count(), 1)
+        trek = Trek.objects.all().first()
+        self.assertEqual(trek.geom.srid, 2154)
+        self.assertEqual(len(trek.geom.coords), 61)
+
+    @mock.patch('requests.get')
+    def test_trek_plan_with_no_extension_at_all(self, mocked_get):
+        output_stdout = StringIO()
+        mocked_get.side_effect = self.make_dummy_get('trek_with_plan_with_no_extension_at_all.json')
+
+        call_command('import', 'geotrek.trekking.tests.test_parsers.TestApidaeTrekParser', verbosity=2,
+                     stdout=output_stdout)
+
+        self.assertEqual(Trek.objects.count(), 0)
+        self.assertIn('has no attached "PLAN" in a supported format', output_stdout.getvalue())
+
+    @mock.patch('requests.get')
     def test_trek_not_imported_when_no_plan_attached(self, mocked_get):
         output_stdout = StringIO()
         mocked_get.side_effect = self.make_dummy_get('trek_no_plan_error.json')


### PR DESCRIPTION
Une petite correction pour le parser d'itinéraire Apidae. Il me reste à le prendre en compte dans un test.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) ~~and references associated issues~~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
