### PR TITLE
Fix : Apidae Trek parser now ignores when no linestring in GPX

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ CHANGELOG
 **Bug fixes**
 
 - ApidaeTrekParser now fallbacks on trace filename extension if no extension property
+- ApidaeTrekParser now ignores when no linestring in GPX
 
 
 2.109.1     (2024-08-22)

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -939,6 +939,8 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
                 geos = ApidaeTrekParser._maybe_get_linestring_from_layer(layer)
                 if geos:
                     break
+            else:
+                raise RowImportError("No LineString feature found in GPX layers tracks or routes")
             geos.transform(settings.SRID)
             return geos
 

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_no_feature.gpx
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_no_feature.gpx
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="GDAL 3.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="http://www.topografix.com/GPX/1/1"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+</gpx>

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1491,6 +1491,12 @@ class GpxToGeomTests(SimpleTestCase):
         self.assertEqual(geom.geom_type, 'LineString')
         self.assertEqual(len(geom.coords), 13)
 
+    def test_it_raises_an_error_when_no_linestring(self):
+        gpx = self._get_gpx_from('geotrek/trekking/tests/data/apidae_trek_parser/trace_with_no_feature.gpx')
+
+        with self.assertRaises(RowImportError):
+            ApidaeTrekParser._get_geom_from_gpx(gpx)
+
 
 class KmlToGeomTests(SimpleTestCase):
 


### PR DESCRIPTION
Correction pour parser Trek Apidae. Reste à :

- prendre en compte dans les tests,
- ajouter la traduction.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) ~~and references associated issues~~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
