### PR TITLE
Fix length filter on mobile

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,12 @@ CHANGELOG
 
 - Improve PostgreSQL upgrade documentation
 
+**Bug fixes**
+
+- Fix: 'length' filter can now be displayed on mobile apps
+- Fix: make 'duration' mobile filter consistent in doc
+
+
 2.107.0 (2024-06-07)
 ------------------------
 

--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -3215,7 +3215,7 @@ Settings for Geotrek-mobile
         'difficulty',
         'durations',
         'ascent',
-        'lengths',
+        'length',
         'themes',
         'route',
         'districts',

--- a/docs/install/advanced-configuration.rst
+++ b/docs/install/advanced-configuration.rst
@@ -3213,7 +3213,7 @@ Settings for Geotrek-mobile
         ENABLED_MOBILE_FILTERS = [
         'practice',
         'difficulty',
-        'durations',
+        'duration',
         'ascent',
         'length',
         'themes',

--- a/geotrek/api/mobile/views/common.py
+++ b/geotrek/api/mobile/views/common.py
@@ -71,7 +71,7 @@ class SettingsView(APIView):
                     "showAllLabel": _("Show all practices"),
                     "hideAllLabel": _("Hide all practices")
                 })
-            if filter == 'duration':
+            if filter == 'duration' or filter == 'durations':  # plural is for configuration retro-compatibility
                 filters.append({
                     "id": "duration",
                     "type": "interval",

--- a/geotrek/api/mobile/views/common.py
+++ b/geotrek/api/mobile/views/common.py
@@ -29,9 +29,9 @@ class SettingsView(APIView):
                     "showAllLabel": _("Show all difficulties"),
                     "hideAllLabel": _("Hide all difficulties")
                 })
-            if filter == 'lengths':
+            if filter == 'length' or filter == 'lengths':  # plural is for configuration retro-compatibility
                 filters.append({
-                    "id": "lengths",
+                    "id": "length",
                     "type": "interval",
                     "showAllLabel": _("Show all lengths"),
                     "hideAllLabel": _("Hide all lengths")

--- a/geotrek/settings/base.py
+++ b/geotrek/settings/base.py
@@ -795,7 +795,7 @@ ENABLED_MOBILE_FILTERS = [
     'difficulty',
     'duration',
     'ascent',
-    'lengths',
+    'length',
     'themes',
     'route',
     'districts',
@@ -925,4 +925,3 @@ MAPENTITY_CONFIG['TRANSLATED_LANGUAGES'] = [
 ]
 LEAFLET_CONFIG['TILES_EXTENT'] = SPATIAL_EXTENT
 LEAFLET_CONFIG['SPATIAL_EXTENT'] = api_bbox(SPATIAL_EXTENT, VIEWPORT_MARGIN)
-


### PR DESCRIPTION
Probablement à cause d'un refactoring partiellement appliqué il y avait une incohérence entre l'id du filtre "longueur" et l'id des valeurs du filtre dans l'API mobile. De ce fait le filtre "longueur" n'était jamais affiché dans les apps mobiles.

Également mis à jour la doc de `ENABLED_MOBILE_FILTERS` qui indiquait encore la valeur `lengths`.

L'implémentation continue de considérer la valeur `lengths` de `ENABLED_MOBILE_FILTERS` pour maintenir la compatibilité avec des settings custom.

Le filtre `duration` avait le même souci dans la doc et a eu le même traitement.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~~The title of my PR mentionned the issue associated~~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
