### PR TITLE
Fix ApidaeTrekParser duration import logic

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ CHANGELOG
 
 - ApidaeTrekParser now fallbacks on trace filename extension if no extension property
 - ApidaeTrekParser now ignores when no linestring in GPX
-
+- ApidaeTrekParser duration import is fixed for multiple-days treks
 
 2.109.1     (2024-08-22)
 ----------------------------

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -1111,12 +1111,19 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
 
     @staticmethod
     def _make_duration(duration_in_minutes=None, duration_in_days=None):
-        """Returns the duration in hours. The method expects one argument or the other, not both. If both arguments have
-         non-zero values the method only considers `duration_in_minutes` and discards `duration_in_days`."""
-        if duration_in_minutes:
-            return float((Decimal(duration_in_minutes) / Decimal(60)).quantize(Decimal('.01')))
-        elif duration_in_days:
+        """Returns the duration in hours. There are 2 use cases:
+
+        1. the parsed trek is a one-day trip: only the duration in minutes is provided from Apiade.
+        2. the parsed trek is a multiple-day trip: the duration_in_days is provided. The duration_in_minutes may be provided
+          as a crude indication of how long each step is. That second value does not fit in Geotrek model.
+
+        So the duration_in_days is used if provided (and duration_in_minutes discarded), it means we are in the use case 2.
+        Otherwise the duration_in_minutes is used, it means use case 1.
+        """
+        if duration_in_days:
             return float(duration_in_days * 24)
+        elif duration_in_minutes:
+            return float((Decimal(duration_in_minutes) / Decimal(60)).quantize(Decimal('.01')))
         else:
             return None
 

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1573,11 +1573,14 @@ class MakeDurationTests(SimpleTestCase):
     def test_it_returns_correct_duration_from_duration_in_days(self):
         self.assertAlmostEqual(ApidaeTrekParser._make_duration(duration_in_days=3), 72.0)
 
-    def test_giving_both_duration_arguments_only_duration_in_minutes_is_considered(self):
-        self.assertAlmostEqual(ApidaeTrekParser._make_duration(duration_in_minutes=90, duration_in_days=0.5), 1.5)
+    def test_giving_both_duration_arguments_only_duration_in_days_is_considered(self):
+        self.assertAlmostEqual(ApidaeTrekParser._make_duration(duration_in_minutes=90, duration_in_days=2), 48.0)
 
     def test_it_rounds_output_to_two_decimal_places(self):
         self.assertEqual(ApidaeTrekParser._make_duration(duration_in_minutes=20), 0.33)
+
+    def test_it_returns_none_when_no_duration_is_provided(self):
+        self.assertEqual(ApidaeTrekParser._make_duration(duration_in_minutes=None, duration_in_days=None), None)
 
 
 class TestApidaePOIParser(ApidaePOIParser):


### PR DESCRIPTION
Corrige la logique de l'import de la durée des itinéraires Apidae (faussée car je n'avais pas bien compris la signification des champs Apidae). Reste à mettre à jour les tests.

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
