### PR TITLE
Impr: Allows user to edit WYSIWYG button-link and suggestion block

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.107.0+dev (XXXX-XX-XX)
 ------------------------
 
+**Improvements**
+
+- Allows user to edit flatpage WYSIWYG button-link and suggestion block
+
 **Documentation**
 
 - Improve PostgreSQL upgrade documentation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The button-link and suggestion blocks in FlatPage's WYSIWYG could not be modified. The only way was to delete them and recreate another.
Now they can be edited simply by clicking on them.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/orgs/GeotrekCE/projects/7/views/1?pane=issue&itemId=64559194

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
