### PR TITLE
Add an image gallery tinyMCE plugin for flatpages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 **Improvements**
 
 - Change infrastructure condition field to ManyToMany field (#3970)
+- Add an image gallery tinyMCE plugin for flatpages
 
 **Bug fixes**
 

--- a/geotrek/api/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/api/locale/fr/LC_MESSAGES/django.po
@@ -525,7 +525,8 @@ msgid "Filter by one or more ratings id, comma-separated."
 msgstr "Filtrer par un ou plusieurs id de cotation, séparés par des virgules."
 
 msgid "Filter by one or more networks id, comma-separated."
-msgstr "Filtrer par un ou plusieurs réseaux d'itinéraire, séparés par des virgules."
+msgstr ""
+"Filtrer par un ou plusieurs réseaux d'itinéraire, séparés par des virgules."
 
 msgid "Root sites only"
 msgstr "Sites racine seulement"

--- a/geotrek/flatpages/admin.py
+++ b/geotrek/flatpages/admin.py
@@ -23,6 +23,7 @@ else:  # pragma: no cover
 
 
 class FlatPageAdmin(BaseAdmin):
+    change_form_template = 'flatpages/translations_js.html'
     list_display = ('title', 'published', 'publication_date', 'portals_for_display', )
     list_filter = (
         'published',

--- a/geotrek/flatpages/locale/de/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,40 @@ msgid "Menu item"
 msgstr ""
 
 msgid "Menu items"
+msgstr ""
+
+msgid "Button Link"
+msgstr ""
+
+msgid "Label"
+msgstr ""
+
+msgid "Open in a new tab"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Suggestions"
+msgstr ""
+
+msgid "Suggestions title"
+msgstr ""
+
+msgid "ID list (separated by comma)"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Manage the Image Gallery"
+msgstr ""
+
+msgid "Add gallery images"
+msgstr ""
+
+msgid "Add an image"
+msgstr ""
+
+msgid "Remove"
 msgstr ""

--- a/geotrek/flatpages/locale/en/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,40 @@ msgid "Menu item"
 msgstr ""
 
 msgid "Menu items"
+msgstr ""
+
+msgid "Button Link"
+msgstr ""
+
+msgid "Label"
+msgstr ""
+
+msgid "Open in a new tab"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Suggestions"
+msgstr ""
+
+msgid "Suggestions title"
+msgstr ""
+
+msgid "ID list (separated by comma)"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Manage the Image Gallery"
+msgstr ""
+
+msgid "Add gallery images"
+msgstr ""
+
+msgid "Add an image"
+msgstr ""
+
+msgid "Remove"
 msgstr ""

--- a/geotrek/flatpages/locale/es/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,40 @@ msgid "Menu item"
 msgstr ""
 
 msgid "Menu items"
+msgstr ""
+
+msgid "Button Link"
+msgstr ""
+
+msgid "Label"
+msgstr ""
+
+msgid "Open in a new tab"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Suggestions"
+msgstr ""
+
+msgid "Suggestions title"
+msgstr ""
+
+msgid "ID list (separated by comma)"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Manage the Image Gallery"
+msgstr ""
+
+msgid "Add gallery images"
+msgstr ""
+
+msgid "Add an image"
+msgstr ""
+
+msgid "Remove"
 msgstr ""

--- a/geotrek/flatpages/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,3 +82,39 @@ msgstr "Élément menu"
 
 msgid "Menu items"
 msgstr "Éléments menu"
+
+msgid "Button Link"
+msgstr "Lien bouton"
+
+msgid "Label"
+msgstr "Intitulé"
+
+msgid "Open in a new tab"
+msgstr "Ouvrir le lien dans un nouvel onglet"
+
+msgid "Cancel"
+msgstr "AnnulerFlatpage"
+
+msgid "Suggestions"
+msgstr "Suggestions"
+
+msgid "Suggestions title"
+msgstr "Intitulé de l'encart"
+
+msgid "ID list (separated by comma)"
+msgstr "Liste d'ID (séparés par des virgules)"
+
+msgid "Submit"
+msgstr "Enregistrer"
+
+msgid "Manage the Image Gallery"
+msgstr "Gérer la galerie d'image"
+
+msgid "Add gallery images"
+msgstr "Ajouter une galerie d'image"
+
+msgid "Add an image"
+msgstr "Ajouter une image"
+
+msgid "Remove"
+msgstr "Supprimer"

--- a/geotrek/flatpages/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/it/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,40 @@ msgid "Menu item"
 msgstr ""
 
 msgid "Menu items"
+msgstr ""
+
+msgid "Button Link"
+msgstr ""
+
+msgid "Label"
+msgstr ""
+
+msgid "Open in a new tab"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Suggestions"
+msgstr ""
+
+msgid "Suggestions title"
+msgstr ""
+
+msgid "ID list (separated by comma)"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Manage the Image Gallery"
+msgstr ""
+
+msgid "Add gallery images"
+msgstr ""
+
+msgid "Add an image"
+msgstr ""
+
+msgid "Remove"
 msgstr ""

--- a/geotrek/flatpages/locale/nl/LC_MESSAGES/django.po
+++ b/geotrek/flatpages/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-03 15:39+0000\n"
+"POT-Creation-Date: 2024-08-07 07:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,4 +82,40 @@ msgid "Menu item"
 msgstr ""
 
 msgid "Menu items"
+msgstr ""
+
+msgid "Button Link"
+msgstr ""
+
+msgid "Label"
+msgstr ""
+
+msgid "Open in a new tab"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Suggestions"
+msgstr ""
+
+msgid "Suggestions title"
+msgstr ""
+
+msgid "ID list (separated by comma)"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Manage the Image Gallery"
+msgstr ""
+
+msgid "Add gallery images"
+msgstr ""
+
+msgid "Add an image"
+msgstr ""
+
+msgid "Remove"
 msgstr ""

--- a/geotrek/flatpages/static/flatpages/tinymce/css/flatpage_custom_formats.css
+++ b/geotrek/flatpages/static/flatpages/tinymce/css/flatpage_custom_formats.css
@@ -28,6 +28,50 @@ h1, h2, h3 {
     background: lightgray;
 }
 
+.gallery-container {
+    position: relative;
+    clear: both;
+    color: blue;
+    padding: 2rem 0.5rem 0.5rem;
+    background: lightblue;
+    border: 1px dashed blue;
+    margin-bottom: 1rem;
+    display: flex;
+    gap: 1rem;
+}
+
+.gallery-container li {
+    width: 200px;
+    height: 200px;
+    background: lightcyan;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.gallery-container figure {
+    width: 100%;
+    height: 70%;
+    margin: 0;
+    text-align: center;
+    color: #555;
+    font-size: 0.8rem;
+}
+
+.gallery-container img {
+    object-fit: contain;
+    width: 100%;
+    height: 100%;
+}
+
+.gallery-container::before {
+    content: "Images gallery";
+    position: absolute;
+    top: .5rem;
+    left: .5rem;
+    font-size: 0.8rem;
+}
+
 .suggestions {
     position: relative;
     clear: both;

--- a/geotrek/flatpages/static/flatpages/tinymce/css/flatpage_custom_formats.css
+++ b/geotrek/flatpages/static/flatpages/tinymce/css/flatpage_custom_formats.css
@@ -29,23 +29,26 @@ h1, h2, h3 {
 }
 
 .suggestions {
+    position: relative;
     clear: both;
     display: block !important;
     background: lightgreen;
     color: green;
-    padding: 2rem;
-    border-radius: 1rem;
+    padding: 2rem 0.5rem 0.5rem;
+    border: 1px dashed green;
     box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-    clear: both;
+    margin-bottom: 1rem;
 }
 
 .suggestions::before {
+    position: absolute;
     content: '' attr(data-type) ' suggestions : ' attr(data-label) '';
-    font-size: 1.2rem;
-    display: block;
-    margin-bottom: .3rem;
+    top: .5rem;
+    left: .5rem;
+    font-size: 0.8rem;
 }
 
 .suggestions::after {
     content: 'Identifiants : ' attr(data-ids) '';
 }
+

--- a/geotrek/flatpages/static/flatpages/tinymce/css/flatpagetinymce_widget.css
+++ b/geotrek/flatpages/static/flatpages/tinymce/css/flatpagetinymce_widget.css
@@ -1,0 +1,35 @@
+/* Style the gallery image window manager */
+#image-preview {
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+#image-preview li {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#image-preview li span {
+  display: block;
+  width: 180px;
+  height: 180px;
+  background-color: lightgray;
+}
+
+#image-preview li figure {
+  width: 100%;
+  height: 80%;
+  text-align: center;
+}
+
+#image-preview li img {
+  object-fit: contain;
+  width: 100%;
+  height: 100%;
+}

--- a/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
+++ b/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
@@ -8,35 +8,35 @@ document.addEventListener("DOMContentLoaded", function () {
     tinymce.PluginManager.add('button-link', function (editor, url) {
         var openDialogButtonLink = function (defaultValues, element) {
             return editor.windowManager.open({
-                title: 'Lien bouton',
+                title: i18n.tinymce_Button_Link,
                 body: {
                     type: 'panel',
                     items: [
                         {
                             type: 'input',
                             name: 'label',
-                            label: 'Intitulé',
+                            label: i18n.tinymce_Label,
                         },
                         {
                             type: 'input',
                             name: 'link',
-                            label: 'Lien',
+                            label: i18n.tinymce_Link,
                         },
                         {
                             type: 'checkbox',
                             name: 'target',
-                            label: 'Ouvrir dans un nouvel onglet'
+                            label: i18n.tinymce_Open_link_in_a_new_tab
                         }
                     ]
                 },
                 buttons: [
                     {
                         type: 'cancel',
-                        text: 'Close'
+                        text: i18n.tinymce_Cancel
                     },
                     {
                         type: 'submit',
-                        text: 'Save',
+                        text: i18n.tinymce_Submit,
                         primary: true
                     }
                 ],
@@ -71,7 +71,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         var openDialogSuggestion = function (defaultValues, element) {
             return editor.windowManager.open({
-                title: 'Suggestions',
+                title: i18n.tinymce_Suggestions,
                 body: {
                     type: 'panel',
                     items: [
@@ -80,32 +80,32 @@ document.addEventListener("DOMContentLoaded", function () {
                             name: 'type',
                             label: 'Type',
                             items: [
-                                {value: 'trek', text: 'Trek'},
-                                {value: 'touristicContent', text: 'Touristic content'},
-                                {value: 'touristicEvent', text: 'Touristic event'},
-                                {value: 'outdoorSite', text: 'Outdoor site'},
+                                {value: 'trek', text: gettext('Trek')},
+                                {value: 'touristicContent', text: gettext('Touristic content')},
+                                {value: 'touristicEvent', text: gettext('Touristic event')},
+                                {value: 'outdoorSite', text: gettext('Outdoor site')},
                             ]
                         },
                         {
                             type: 'input',
                             name: 'label',
-                            label: "Intitulé de l'encart",
+                            label: i18n.tinymce_Suggestions_title,
                         },
                         {
                             type: 'input',
                             name: 'ids',
-                            label: "Liste d'ID (séparés par des virgules)",
+                            label: i18n.tinymce_Suggestions_ID_list,
                         }
                     ]
                 },
                 buttons: [
                     {
                         type: 'cancel',
-                        text: 'Close'
+                        text: i18n.tinymce_Cancel
                     },
                     {
                         type: 'submit',
-                        text: 'Save',
+                        text: i18n.tinymce_Submit,
                         primary: true
                     }
                 ],
@@ -142,7 +142,7 @@ document.addEventListener("DOMContentLoaded", function () {
                  imgDiv.className = 'image-preview';
                  imgDiv.innerHTML = `
                    <span>${image.outerHTML}</span>
-                   <button type="button" class="tox-button tox-button--secondary" data-index="${index}">${gettext('Remove')}</button>
+                   <button type="button" class="tox-button tox-button--secondary" data-index="${index}">${i18n.tinymce_Gallery_image_remove}</button>
                  `;
                  preview.appendChild(imgDiv);
                });
@@ -159,7 +159,7 @@ document.addEventListener("DOMContentLoaded", function () {
      
              // Ouvrir une fenêtre modale personnalisée pour la gestion des images
              editor.windowManager.open({
-               title: gettext('Manage the Image Gallery'),
+               title: i18n.tinymce_Gallery_title,
                width: "80%", 
                height: "80%",
                body: {
@@ -171,19 +171,19 @@ document.addEventListener("DOMContentLoaded", function () {
                    },
                    {
                      type: 'button',
-                     text: gettext('Add an image'),
+                     text: i18n.tinymce_Gallery_image_add,
                    }
                  ]
                },
                buttons: [
-                 {
-                   text: gettext('Submit'),
-                   type: 'submit',
-                   primary: true,
-                 },
-                 {
+                {
+                    text: i18n.tinymce_Submit,
+                    type: 'submit',
+                    primary: true,
+                },
+                {
                     type: 'cancel',
-                    text: gettext('Cancel'),
+                    text: i18n.tinymce_Cancel,
                     onClick: function (api) {
                         api.close();
                     }
@@ -224,7 +224,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         /* Add a button that opens a window */
         editor.ui.registry.addButton('button-link', {
-            text: 'Lien bouton',
+            text: i18n.tinymce_Button_Link,
             onAction: function () {
                 /* Open window */
                 openDialogButtonLink();
@@ -232,7 +232,7 @@ document.addEventListener("DOMContentLoaded", function () {
         });
         /* Add a button that opens a window */
         editor.ui.registry.addButton('suggestions', {
-            text: 'Suggestions',
+            text: i18n.tinymce_Suggestions,
             onAction: function () {
                 /* Open window */
                 openDialogSuggestion();
@@ -240,7 +240,7 @@ document.addEventListener("DOMContentLoaded", function () {
         });
 
         editor.ui.registry.addButton('imagesGallery', {
-            text: gettext('Add gallery images'),
+            text: i18n.tinymce_Gallery_add,
             icon: 'image',
             onAction: function () {
                 openDialogGalleryImages();

--- a/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
+++ b/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
@@ -122,7 +122,7 @@ document.addEventListener("DOMContentLoaded", function () {
                         element.dataset.type = data.type;
                         element.dataset.ids = data.ids;
                     } else {
-                        editor.insertContent('<div class="suggestions" data-label="' + data.label + '" data-type="' + data.type + '" data-ids="' + data.ids + '" style="display: none" contenteditable="false"></div>');
+                        editor.insertContent('<div class="suggestions" data-label="' + data.label + '" data-type="' + data.type + '" data-ids="' + data.ids + '" style="display: none" contenteditable="false"></div><p></p>');
                     }
                     api.close();
                 }

--- a/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
+++ b/geotrek/flatpages/static/flatpages/tinymce/js/additional_tinymce_plugins.js
@@ -128,6 +128,100 @@ document.addEventListener("DOMContentLoaded", function () {
                 }
             });
         };
+
+        var openDialogGalleryImages = function (defaultValues, element) {
+             // Stocker les images sélectionnées
+             let images = defaultValues || [];
+      
+             // Fonction pour mettre à jour la vue des images
+             function updateImagePreview() {
+               var preview = document.getElementById('image-preview');
+               preview.innerHTML = '';
+               images.forEach((image, index) => {
+                 var imgDiv = document.createElement('li');
+                 imgDiv.className = 'image-preview';
+                 imgDiv.innerHTML = `
+                   <span>${image.outerHTML}</span>
+                   <button type="button" class="tox-button tox-button--secondary" data-index="${index}">${gettext('Remove')}</button>
+                 `;
+                 preview.appendChild(imgDiv);
+               });
+     
+               // Ajouter des gestionnaires d'événements pour les boutons de suppression
+               document.querySelectorAll('.image-preview button').forEach(button => {
+                 button.addEventListener('click', function () {
+                   var index = this.getAttribute('data-index');
+                   images.splice(index, 1);
+                   updateImagePreview();
+                 });
+               });
+             }
+     
+             // Ouvrir une fenêtre modale personnalisée pour la gestion des images
+             editor.windowManager.open({
+               title: gettext('Manage the Image Gallery'),
+               width: "80%", 
+               height: "80%",
+               body: {
+                 type: 'panel',
+                 items: [
+                   {
+                     type: 'htmlpanel',
+                     html: '<ul id="image-preview"></ul>'
+                   },
+                   {
+                     type: 'button',
+                     text: gettext('Add an image'),
+                   }
+                 ]
+               },
+               buttons: [
+                 {
+                   text: gettext('Submit'),
+                   type: 'submit',
+                   primary: true,
+                 },
+                 {
+                    type: 'cancel',
+                    text: gettext('Cancel'),
+                    onClick: function (api) {
+                        api.close();
+                    }
+                 }
+               ],
+               onAction: function () {
+                    editor.selection.collapse()
+                    editor.execCommand('mceImage', false);
+                    editor.once('change', function () {
+                        const imgElement = editor.selection.getNode();
+                        if (imgElement) {
+                            images.push(imgElement);
+                            editor.dom.remove(imgElement);
+                            updateImagePreview();
+                        }
+                    });
+               },
+               onSubmit: function (api) {
+                   let galleryHtml = '<ul class="gallery-container">';
+                   if (element) {
+                    element.remove();
+                    }
+                   if (images.length === 0) {
+                    api.close();
+                    return;
+                   }
+                   images.forEach(image => {
+                     galleryHtml += '<li>' + image.outerHTML + '</li>';
+                   });
+                   galleryHtml += '</ul><p></p>';
+                   editor.insertContent(galleryHtml);
+                   api.close();
+                 }
+             });
+     
+             updateImagePreview(); // Initialiser la vue des images
+        };
+
         /* Add a button that opens a window */
         editor.ui.registry.addButton('button-link', {
             text: 'Lien bouton',
@@ -145,6 +239,14 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         });
 
+        editor.ui.registry.addButton('imagesGallery', {
+            text: gettext('Add gallery images'),
+            icon: 'image',
+            onAction: function () {
+                openDialogGalleryImages();
+            }
+          });
+
         /* Edit button-link/suggestions block when clicking on it */
         editor.on('click', function (e) {
             const element = e.target;
@@ -155,7 +257,39 @@ document.addEventListener("DOMContentLoaded", function () {
                 const data = element.dataset;
                 openDialogSuggestion({ type: data.type, label: data.label, ids: data.ids }, element)
             }
+            if (element.classList.contains('gallery-container')) {
+                const images = Array.from(element.querySelectorAll('img')) ;
+                openDialogGalleryImages(images, element)
+            }
         });
+
+        /* Suppr suggestions and gallery sections properly */
+        editor.on('keydown', function (event) {
+            var backspaceKeyCode = 8;
+            var supprKeyCode = 46;
+            if (![backspaceKeyCode, supprKeyCode].includes(event.keyCode)) {
+                return;
+            }
+
+            var selectedNode = editor.selection.getNode();
+
+            var nodeToDelete = event.keyCode === backspaceKeyCode 
+                ? selectedNode.previousElementSibling ?? selectedNode.parentNode.previousElementSibling
+                : selectedNode.nextElementSibling ?? selectedNode.parentNode.nextElementSibling;
+
+            var isOffsetPositionMatchToDelete = event.keyCode === backspaceKeyCode 
+                ? editor.selection.getRng().startOffset === 0
+                : editor.selection.getRng().startOffset === editor.selection.getRng().startContainer.length;
+            
+            if (
+                isOffsetPositionMatchToDelete
+                && nodeToDelete && nodeToDelete.classList
+                && ['suggestions', 'gallery-container'].some(className => nodeToDelete.classList.contains(className))
+            ) {
+                event.preventDefault();
+                editor.dom.remove(nodeToDelete);
+            }
+          }, true);
     })
 
 }); // end of document DOMContentLoaded event handler

--- a/geotrek/flatpages/templates/flatpages/translations_js.html
+++ b/geotrek/flatpages/templates/flatpages/translations_js.html
@@ -1,0 +1,23 @@
+{% extends 'admin/change_form.html' %}
+{% load i18n %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script>
+    window.i18n = {
+      tinymce_Button_Link: "{% trans "Button Link" %}",
+      tinymce_Label: "{% trans "Label" %}",
+      tinymce_Link: "{% trans "Link" %}",
+      tinymce_Open_link_in_a_new_tab: "{% trans "Open in a new tab" %}",
+      tinymce_Cancel: "{% trans "Cancel" %}",
+      tinymce_Suggestions: "{% trans "Suggestions" %}",
+      tinymce_Suggestions_title: "{% trans "Suggestions title" %}",
+      tinymce_Suggestions_ID_list: "{% trans "ID list (separated by comma)" %}",
+      tinymce_Submit: "{% trans "Submit" %}",
+      tinymce_Gallery_title: "{% trans "Manage the Image Gallery" %}",
+      tinymce_Gallery_add: "{% trans "Add gallery images" %}",
+      tinymce_Gallery_image_add: "{% trans "Add an image" %}",
+      tinymce_Gallery_image_remove: "{% trans "Remove" %}",
+    }
+  </script>
+{% endblock %}

--- a/geotrek/flatpages/widgets.py
+++ b/geotrek/flatpages/widgets.py
@@ -26,7 +26,7 @@ FLATPAGE_TINYMCE_CONFIG = {
     'file_picker_types': "image media",
     'images_upload_url': "/flatpages/tinymce/upload/",
     "toolbar": 'undo redo | styleselect | blockquote | bold italic forecolor |'
-               'alignleft aligncenter alignright alignjustify | bullist numlist | link image media |'
+               'alignleft aligncenter alignright alignjustify | bullist numlist | link imagesGallery image media |'
                'button-link suggestions | removeformat visualblocks code | wordcount | help',
     "formats": {
         "informationFormat": {
@@ -89,3 +89,6 @@ class FlatPageTinyMCE(TinyMCE):
 
     class Media:
         js = ('flatpages/tinymce/js/additional_tinymce_plugins.js',)
+        css = {
+             'all': ('flatpages/tinymce/css/flatpagetinymce_widget.css', )
+        }

--- a/geotrek/flatpages/widgets.py
+++ b/geotrek/flatpages/widgets.py
@@ -1,5 +1,5 @@
 from django.templatetags.static import static
-from tinymce.widgets import TinyMCE
+from tinymce.widgets import AdminTinyMCE
 
 FLATPAGE_TINYMCE_CONFIG = {
     "height": 500,
@@ -79,7 +79,8 @@ FLATPAGE_TINYMCE_CONFIG = {
 }
 
 
-class FlatPageTinyMCE(TinyMCE):
+class FlatPageTinyMCE(AdminTinyMCE):
+    template_name = 'flatpages/translations_js.html' 
 
     def __init__(self, *args, **kwargs):
         mce_attrs = FLATPAGE_TINYMCE_CONFIG.copy()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

:warning: I'm not comfortable with `.py` files, so I didn't test it, I need someone to test it.

This feature allows the user to create an image gallery in flatPage content.

## ScreenShots
![image](https://github.com/user-attachments/assets/6aeaec3a-4b18-4d2e-a90f-26aea18bcdb3)
![image](https://github.com/user-attachments/assets/f8ca2f89-a014-47fc-a03e-a72247f07796)
![image](https://github.com/user-attachments/assets/1fa3c7e2-2955-482f-bccc-6b044f11b316)

@camillemonchicourt maybe we could add an input field to the popin in order to define some classnames to the gallery, or a select with predefined classes (for example: "default,  thumbnails, large"). What do you think?


## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
