### PR TITLE
🐛 [BUG] Change default CORS configuration to 'always'

### DIFF
--- a/conf/nginx.conf.in
+++ b/conf/nginx.conf.in
@@ -74,7 +74,7 @@ server {
         location ~ ^/api {
             proxy_pass http://api_server;
             proxy_read_timeout ${TIMEOUT}s;
-            add_header Access-Control-Allow-Origin ${DOLLAR}allow_origin;
+            add_header Access-Control-Allow-Origin ${DOLLAR}allow_origin always;
         }
 
         proxy_pass http://ui_server;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ CHANGELOG
 - ApidaeTrekParser now handles missing source website
 - Fix Aggregator does not retrieve unpublished Tour Steps (#3569)"
 - Fix missing Annotation Categories in APIv2 for annotations other than Points (#4032)"
+- Change default CORS configuration to 'always' : see https://github.com/GeotrekCE/Geotrek-rando-v3/issues/1257
+
 
 **Documentation**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

L'option `always` de la directive nginx `add_header` permet à Geotrek-rando de bien recevoir la cause de l'erreur (à afficher sur la page) en cas de problème avec l'enregistrement d'un signalement. Sans `always`, Geotrek-rando affiche une erreur réseau générique due à la config CORS

See https://github.com/GeotrekCE/Geotrek-rando-v3/issues/1257

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
