### PR TITLE
:bug: [Bug] Fix missing Dockerfile path on make build scripts (fix #4365)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ COLOR_DEBUG = \033[36m
 COLOR_RESET = \033[0m
 
 build:
-	docker build -t geotrek . --build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG)
+	docker build -t geotrek -f docker/Dockerfile . --build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG)
 
-build-no-cache:
-	docker build -t geotrek --no-cache .
+build_no_cache:
+	docker build -t geotrek -f docker/Dockerfile --no-cache .
 
 build_deb:
 	docker pull $(DISTRO)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,9 @@ CHANGELOG
 2.110.0+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+- Fix missing Dockerfile path on make build scripts
 
 
 2.110.0     (2024-11-13)


### PR DESCRIPTION
## Description

Fix `Makefile build scripts by adding missing `Dockerfile` path variable to `docker build`.

Command standardization by replacing dash with underscore. 

## Related Issue

#4365 

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
