### PR TITLE
🐛 [BUG] Fix SchemaRandonneeParser url update (refs #4022)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix missing Dockerfile path on make build scripts
+- Fix SchemaRandonneeParser url update when description is null or was not updated (#4022)
 
 **Documentation**
 

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/description_and_url.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/description_and_url.geojson
@@ -1,0 +1,24 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 1",
+                "url": "https://test.com"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/description_no_url.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/description_no_url.geojson
@@ -1,0 +1,24 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 1",
+                "url": null
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/find_url_in_description.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/find_url_in_description.geojson
@@ -1,0 +1,40 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "url": "https://test.com",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 1"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "2",
+                "producteur": "Producer 1",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 2"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/no_description_no_url.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/no_description_no_url.geojson
@@ -1,0 +1,24 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": null,
+                "url": null
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/update_url_after.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/update_url_after.geojson
@@ -8,11 +8,29 @@
             "properties": {
                 "id_local": "1",
                 "producteur": "Producer 1",
+                "url": "https://test.com",
                 "nom_itineraire": "Trek 1",
                 "pratique": "pédestre",
                 "depart": "Departure 1",
                 "arrivee": "Arrival 1",
-                "instructions": "Instructions 1"
+                "instructions": null
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "2",
+                "producteur": "Producer 1",
+                "url": "https://test2.com",
+                "nom_itineraire": "Trek 2",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 2"
             },
             "geometry": {
                 "type": "LineString",

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/update_url_before.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/update_url_before.geojson
@@ -1,0 +1,41 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "url": "https://test.com",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 1"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "2",
+                "producteur": "Producer 1",
+                "url": "https://test1.com",
+                "nom_itineraire": "Trek 2",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": "Instructions 2"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/data/schema_randonnee_parser/url_no_description.geojson
+++ b/geotrek/trekking/tests/data/schema_randonnee_parser/url_no_description.geojson
@@ -1,0 +1,24 @@
+{
+    "type": "FeatureCollection",
+    "name": "sql_statement",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "id_local": "1",
+                "producteur": "Producer 1",
+                "nom_itineraire": "Trek 1",
+                "pratique": "pédestre",
+                "depart": "Departure 1",
+                "arrivee": "Arrival 1",
+                "instructions": null,
+                "url": "https://test.com"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [ [ 6.449592517966364, 44.733424655086957 ], [ 6.449539623508488, 44.733394939411369 ] ]
+            }
+        }
+    ]
+}

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -2030,8 +2030,34 @@ class SchemaRandonneeParserTests(TestCase):
         self.assertIsNone(trek.parking_location)
         self.assertIn("Bad value for parking geometry: should be a Point", output.getvalue())
 
-    def test_no_url(self):
-        self.call_import_command_with_file('no_url.geojson')
+    def test_description_and_url(self):
+        self.call_import_command_with_file('description_and_url.geojson')
+        self.assertEqual(Trek.objects.count(), 1)
+        trek = Trek.objects.get()
+        self.assertEqual(trek.description, 'Instructions 1\n\n<a href=https://test.com>https://test.com</a>')
+
+    def test_description_no_url(self):
+        self.call_import_command_with_file('description_no_url.geojson')
         self.assertEqual(Trek.objects.count(), 1)
         trek = Trek.objects.get()
         self.assertEqual(trek.description, 'Instructions 1')
+
+    def test_url_no_description(self):
+        self.call_import_command_with_file('url_no_description.geojson')
+        self.assertEqual(Trek.objects.count(), 1)
+        trek = Trek.objects.get()
+        self.assertEqual(trek.description, '<a href=https://test.com>https://test.com</a>')
+
+    def test_no_description_no_url(self):
+        self.call_import_command_with_file('no_description_no_url.geojson')
+        self.assertEqual(Trek.objects.count(), 1)
+        trek = Trek.objects.get()
+        self.assertEqual(trek.description, '')
+
+    def test_update_url(self):
+        self.call_import_command_with_file('update_url_before.geojson')
+        self.call_import_command_with_file('update_url_after.geojson')
+        trek1 = Trek.objects.get(eid="1")
+        self.assertEqual(trek1.description, "<a href=https://test.com>https://test.com</a>")
+        trek2 = Trek.objects.get(eid="2")
+        self.assertEqual(trek2.description, "Instructions 2\n\n<a href=https://test2.com>https://test2.com</a>")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix: a `Trek`'s URL being duplicated during a new import when the new `Trek`'s description was `null` or the same as the old description
- Mod : description and url are now parsed in a `filter_description` method rather than in the `end` method
- #4022 

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
