### PR TITLE
🐛 [BUG] Prevent objects from being returned several times in APIv2 by filtering on ManyToMany (refs #4448)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ CHANGELOG
 - Move Treks' accessibility pictures into the attached files tab (refs #2967)
 - Removes the display of an object's structure in its properties tab title
 
+**Bug fixes**
+
+- Prevent objects from being returned several times in APIv2 by filtering on ManyToMany (#4448)
+
 **Documentation**
 
 - Update theme color

--- a/geotrek/api/tests/test_v2.py
+++ b/geotrek/api/tests/test_v2.py
@@ -1031,6 +1031,13 @@ class APIAccessAnonymousTestCase(BaseApiTest):
         json_response = response.json()
         self.assertEqual(len(json_response.get('results')), 0)
 
+        # Test result is not duplicated
+        self.parent.themes.add(self.theme3)
+        response = self.get_trek_list({'themes': f"{self.theme2.pk},{self.theme3.pk}"})
+        self.assertEqual(response.status_code, 200)
+        json_response = response.json()
+        self.assertEqual(len(json_response.get('results')), 1)
+
     def test_trek_portal_filter(self):
         response = self.get_trek_list({'portals': self.portal.pk})
         #  test response code

--- a/geotrek/api/v2/filters.py
+++ b/geotrek/api/v2/filters.py
@@ -743,7 +743,7 @@ class GeotrekTrekQueryParamsFilter(BaseFilterBackend):
                 Q(name__icontains=q) | Q(description__icontains=q)
                 | Q(description_teaser__icontains=q) | Q(ambiance__icontains=q)
             )
-        return qs
+        return qs.distinct()
 
     def get_schema_fields(self, view):
         return (


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->
https://github.com/GeotrekCE/Geotrek-admin/issues/4448
## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
