### PR TITLE
🐛 [BUG] Fix gpx and kml parsing: geom is an empty GeometryCollection

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix path pcture in intervention form (#4450)
+- Fix gpx and kml parsing: geom is an empty GeometryCollection after invalid MultiLineString merge
 
 
 2.113.0    (2025-01-30)

--- a/geotrek/common/tests/test_utils.py
+++ b/geotrek/common/tests/test_utils.py
@@ -188,6 +188,11 @@ class GpxToGeomTests(SimpleTestCase):
         with self.assertRaises(GeomValueError):
             get_geom_from_gpx(gpx)
 
+    def test_it_raises_error_on_invalid_multilinestring_merge(self):
+        gpx = self._get_gpx_from('geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_track_points.gpx')
+        with self.assertRaises(GeomValueError):
+            get_geom_from_gpx(gpx)
+
 
 class KmlToGeomTests(SimpleTestCase):
 
@@ -211,6 +216,12 @@ class KmlToGeomTests(SimpleTestCase):
 
     def test_it_raises_exception_when_no_linear_data(self):
         kml = self._get_kml_from('geotrek/trekking/tests/data/apidae_trek_parser/trace_with_no_line.kml')
+
+        with self.assertRaises(GeomValueError):
+            get_geom_from_kml(kml)
+
+    def test_it_raises_exception_on_invalid_multilinestring_merge(self):
+        kml = self._get_kml_from('geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_coordinates.kml')
 
         with self.assertRaises(GeomValueError):
             get_geom_from_kml(kml)

--- a/geotrek/common/utils/parsers.py
+++ b/geotrek/common/utils/parsers.py
@@ -67,7 +67,7 @@ def get_geom_from_gpx(data):
             geos = convert_to_geos(feat.geom)
             if geos.geom_type == 'MultiLineString':
                 geos = geos.merged  # If possible we merge the MultiLineString into a LineString
-                if geos.geom_type == 'MultiLineString':
+                if geos.geom_type != 'LineString':
                     raise GeomValueError(
                         _("Feature geometry cannot be converted to a single continuous LineString feature"))
             geoms.append(geos)
@@ -75,7 +75,7 @@ def get_geom_from_gpx(data):
         full_geom = MultiLineString(geoms)
         full_geom.srid = geoms[0].srid
         full_geom = full_geom.merged  # If possible we merge the MultiLineString into a LineString
-        if full_geom.geom_type == 'MultiLineString':
+        if full_geom.geom_type != 'LineString':
             raise GeomValueError(
                 _("Geometries from various features cannot be converted to a single continuous LineString feature"))
 
@@ -109,7 +109,10 @@ def get_geom_from_kml(data):
         geom.coord_dim = 2
         geos = geom.geos
         if geos.geom_type == 'MultiLineString':
-            geos = geos.merged
+            geos = geos.merged  # If possible we merge the MultiLineString into a LineString
+            if geos.geom_type != 'LineString':
+                raise GeomValueError(
+                    _("Feature geometry cannot be converted to a single continuous LineString feature"))
         return geos
 
     def get_first_geom_with_type_in(types, geoms):

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_coordinates.kml
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_coordinates.kml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<kml xmlns="http://earth.google.com/kml/2.0">
+    <Document>
+        <name>A test trace in KML format</name>
+        <Style id="roadStyle">
+            <LineStyle>
+                <color>9F0000FF</color>
+                <width>4</width>
+            </LineStyle>
+
+        </Style>
+        <Placemark>
+            <name>A trace for my test trek</name>
+            <LookAt>
+                <longitude>6.51847</longitude>
+                <latitude>45.80873</latitude>
+            </LookAt>
+            <Point>
+                <coordinates>6.51847,45.80873,0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark>
+            <name>route</name>
+            <styleUrl>#roadStyle</styleUrl>
+            <MultiGeometry>
+                <LineString>
+                    <coordinates>6.51847,45.80873,0 6.51847,45.80873,0
+                    </coordinates>
+                </LineString>
+            </MultiGeometry>
+        </Placemark>
+    </Document>
+</kml>

--- a/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_track_points.gpx
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/trace_with_only_two_duplicate_track_points.gpx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="GDAL 3.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="http://www.topografix.com/GPX/1/1"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+
+     <trk>
+          <trkseg>
+               <trkpt lat="45.660127" lon="4.987793">
+               </trkpt>
+               <trkpt lat="45.660127" lon="4.987793">
+               </trkpt>
+          </trkseg>
+     </trk>
+
+</gpx>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Merging a `MultiLineString` that contains only two duplicate points returns an empty `GeometryCollection`.
This PR adds handling of this error case when parsing `.kml` and `.gpx` files.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [X] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] ~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~
- [X] I have performed a self-review of my code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes
- [X] I added an entry in the changelog file
- [X] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] ~The title of my PR mentionned the issue associated~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
