### PR TITLE
📝 Fix doc URL in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,7 +48,7 @@ This version drop support for Ubuntu Bionic 18.04 debian package. Please update 
 
 This version uses pgRouting. You need to install this extension in your database before upgrading to this version. See :
 
-https://geotrek.readthedocs.io/en/latest/install/upgrade.html#from-geotrek-admin-2-113-0
+https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.html#from-geotrek-admin-2-113-0
 
 **Warnings**
 
@@ -271,7 +271,7 @@ https://geotrek.readthedocs.io/en/latest/install/upgrade.html#from-geotrek-admin
 
 - This version use django 4.2, the latest LTS version. You need to upgrade your database to PostgreSQL 12 or higher before upgrading to this version.
 
-https://geotrek.readthedocs.io/en/latest/install/upgrade.html#postgresql
+https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.html#postgresql
 
 **New features**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The documentation organisation has changed, which modify some URL that were broken in Changelog.

Some older links in older versions are not working anymore too but have been totally removed from documentation, so I couldn't update these older links.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
