### PR TITLE
Fix postgis scripts availability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Check DEM scripts are available in docker image
         run: |
-          docker-compose run --rm web sh -c 'command -v raster2pgsql >/dev/null 2>&1 || { echo >&2 "raster2pgsql command not found."; exit 1; }'
+          docker compose run --rm web sh -c 'command -v raster2pgsql >/dev/null 2>&1 || { echo >&2 "raster2pgsql command not found."; exit 1; }'
 
       - name: E2E test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -392,13 +392,6 @@ jobs:
           sudo apt-get install --no-install-recommends /home/runner/work/Geotrek-admin/Geotrek-admin/*.deb || exit 0;
           sudo systemctl restart nginx
 
-      - name: Check raster2pgsql command
-        run: |
-          if ! command -v raster2pgsql &> /dev/null; then
-            echo "raster2pgsql could not be found"
-            exit 1
-          fi
-
       - name: Load Data
         run: |
           sudo geotrek loaddata minimal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,6 +316,10 @@ jobs:
             sleep 0.1
           done
 
+      - name: Check DEM scripts are available in docker image
+        run: |
+          docker-compose run --rm web sh -c 'command -v raster2pgsql >/dev/null 2>&1 || { echo >&2 "raster2pgsql command not found."; exit 1; }'
+
       - name: E2E test
         run: |
           /home/runner/work/Geotrek-admin/Geotrek-admin/cypress/node_modules/.bin/cypress run -P /home/runner/work/Geotrek-admin/Geotrek-admin/cypress --record --key 64a5a9b3-9869-4a2f-91e4-e3cd27c2f564
@@ -387,6 +391,13 @@ jobs:
           sudo unlink /etc/nginx/sites-enabled/default
           sudo apt-get install --no-install-recommends /home/runner/work/Geotrek-admin/Geotrek-admin/*.deb || exit 0;
           sudo systemctl restart nginx
+
+      - name: Check raster2pgsql command
+        run: |
+          if ! command -v raster2pgsql &> /dev/null; then
+            echo "raster2pgsql could not be found"
+            exit 1
+          fi
 
       - name: Load Data
         run: |

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
  ${shlibs:Depends},
  nginx,
  postgis,
+ postgresql-client,
  libcairo2,
  memcached,
  gettext,

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
  nginx,
- postgis,
  postgresql-client,
  libcairo2,
  memcached,

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends:
  ${misc:Depends},
  ${shlibs:Depends},
  nginx,
+ postgis,
  libcairo2,
  memcached,
  gettext,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ CHANGELOG
 
 This version drop support for Ubuntu Bionic 18.04 debian package. Please update or migrate your server to Ubuntu 24.04.
 
+**Bug fixes**
+
+- Fix `loaddem` command after debian fresh install which requires to install postgis package.
+
 **Improvements**
 
 - Officially support Ubuntu 24.04 debian package.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 CHANGELOG
 =========
 
-2.113.1+dev    (XXXX-XX-XX)
+2.113.1+dev     (XXXX-XX-XX)
 ----------------------------
 
 **Breaking changes**
@@ -29,7 +29,7 @@ This version drop support for Ubuntu Bionic 18.04 debian package. Please update 
 - Update documentation for sensitivity fixtures (#4492)
 - Update database restore process with PGRouting extension
 
-2.113.1    (2025-02-17)
+2.113.1         (2025-02-17)
 ----------------------------
 
 **Improvements**
@@ -53,7 +53,7 @@ This version drop support for Ubuntu Bionic 18.04 debian package. Please update 
 - Fix typo in docs
 
 
-2.113.0    (2025-01-30)
+2.113.0         (2025-01-30)
 ----------------------------
 
 **Breaking changes**
@@ -80,7 +80,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Fix editing of topology-based linear objects via the interface: objects are no longer automatically rerouted (#4070)
 
 
-2.112.0     (2025-01-14)
+2.112.0         (2025-01-14)
 ----------------------------
 
 **Performances**
@@ -105,7 +105,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Update and homogenize README.rst
 
 
-2.111.0     (2024-12-05)
+2.111.0         (2024-12-05)
 ----------------------------
 
 **Features**
@@ -129,7 +129,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Add note about certbot ssl configuration in nginx
 
 
-2.110.0     (2024-11-13)
+2.110.0         (2024-11-13)
 ----------------------------
 
 **New features**
@@ -137,7 +137,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Add parser for schema_randonnee-compliant files (#4022)
 
 
-2.109.3     (2024-10-29)
+2.109.3         (2024-10-29)
 ----------------------------
 
 **Improvements**
@@ -162,7 +162,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Improve development quickstart documentation
 
 
-2.109.2     (2024-09-19)
+2.109.2         (2024-09-19)
 ----------------------------
 
 **Warning**
@@ -196,7 +196,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Add command line examples and templates for importing data
 
 
-2.109.1     (2024-08-22)
+2.109.1         (2024-08-22)
 ----------------------------
 
 **Improvements**
@@ -218,7 +218,7 @@ https://geotrek.readthedocs.io/en/latest/installation-and-configuration/upgrade.
 - Optimize some backend queries for performances
 
 
-2.109.0     (2024-08-08)
+2.109.0         (2024-08-08)
 ----------------------------
 
 **New features**

--- a/tools/install-dev.sh
+++ b/tools/install-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script is used to install Geotrek-admin >= 2.33, dev mode
+# This script is used to install Geotrek-admin >= 2.33
 
 set -e
 
@@ -11,7 +11,7 @@ else
 	exit 1
 fi
 
-if [ "`locale charmap`" != "UTF-8" ]; then
+if [ "$(locale charmap)" != "UTF-8" ]; then
 	echo "ERROR! Your user locale charmap is not UTF-8"
 	exit 1
 fi
@@ -21,18 +21,18 @@ if ! `localectl status | grep -q "System Locale: LANG=.*UTF-8"`; then
 	exit 1
 fi
 
-if [ "$*" == "--nodb" ]; then
+if [ "$NODB" == "true" ]; then
 	postgis_and_routing=""
-elif [ -n "$*" ]; then
-	echo "Usage: $0 [--nodb]"
-	exit 1
 else
 	postgis_and_routing="postgresql-pgrouting"
 fi
 
 sudo apt update
-sudo apt install -y $postgis_and_routing wget software-properties-common
-echo "deb [arch=amd64] https://packages.geotrek.fr/ubuntu $(lsb_release -sc) dev" | sudo tee /etc/apt/sources.list.d/geotrek.list
-wget -O- "https://packages.geotrek.fr/geotrek.gpg.key" | sudo apt-key add -
+sudo apt install -y $postgis_and_routing curl ca-certificates software-properties-common
+sudo install -d /usr/share/geotrek
+sudo curl -o /usr/share/geotrek/apt.geotrek.org.key --fail https://packages.geotrek.fr/geotrek.gpg.key
+sudo rm -f /etc/apt/sources.list.d/geotrek.list
+echo "deb [signed-by=/usr/share/geotrek/apt.geotrek.org.key] https://packages.geotrek.fr/ubuntu $(lsb_release -cs) dev" | sudo tee /etc/apt/sources.list.d/geotrek.list
 sudo apt update
-sudo apt install -y geotrek-admin
+sudo apt install --no-install-recommends -y postgis  # force install postgis scripts only to use loaddem command, even if script does not manage database installation
+sudo apt install --no-install-recommends -y geotrek-admin

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,4 +34,5 @@ sudo curl -o /usr/share/geotrek/apt.geotrek.org.key --fail https://packages.geot
 sudo rm -f /etc/apt/sources.list.d/geotrek.list
 echo "deb [signed-by=/usr/share/geotrek/apt.geotrek.org.key] https://packages.geotrek.fr/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/geotrek.list
 sudo apt update
+sudo apt install --no-install-recommends -y postgis  # force install postgis scripts only to use loaddem command, even if script does not manage database installation
 sudo apt install --no-install-recommends -y geotrek-admin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we changed installation scripts to install pgrouting, `raster2pgsql`, used by `loaddem` command, is not available anymore.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
