### PR TITLE
Provides OpenStreetMap translations in the parser

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Improvements**
 
 - Improve Overpass query for OpenStreetMap parsers
+- OpenSteetMap parsers accept translations from OSM
 
 **Bug fixes**
 
@@ -45,7 +46,6 @@ CHANGELOG
 - Update instructions to regenerate UML diagrams of data model (#4594)
 - Update documentation about map settings and tourism/outdoor intersection margin (#4654)
 - Update documentation with missing parameters from base.py (#4676)
-
 
 2.114.0     (2025-03-13)
 ----------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,7 @@ CHANGELOG
 - Update documentation about map settings and tourism/outdoor intersection margin (#4654)
 - Update documentation with missing parameters from base.py (#4676)
 
+
 2.114.0     (2025-03-13)
 ----------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ CHANGELOG
 **Improvements**
 
 - Improve Overpass query for OpenStreetMap parsers
-- OpenSteetMap parsers accept translations from OSM
+- OpenStreetMap parsers accept translations from OSM
 
 **Bug fixes**
 

--- a/docs/import-data/import-touristic-data-systems.rst
+++ b/docs/import-data/import-touristic-data-systems.rst
@@ -312,6 +312,19 @@ For example:
 
 *means*: return objects that either have both ``boundary=administrative`` AND ``admin_level=4``, OR have ``highway=bus_stop``.
 
+
+OpenStreetMap supports multilingual fields using tags like ``name:fr``, following the ISO 639-1 standard.
+
+During import, the parser maps translated fields (e.g., ``name``, ``description``) based on the model and the languages defined in ``settings.MODELTRANSLATION_LANGUAGES``. For each language, it creates a mapping such as ``name_fr`` → ``name:fr``.
+
+For the default language (``settings.MODELTRANSLATION_DEFAULT_LANGUAGE``), a special mapping is applied: it includes a fallback to the base tag (e.g., ``name``) and maps it to the base Geotrek field name (e.g., ``name``). This allows for filtering operations without relying directly on the default language code.
+
+If a translation is missing, the field remains unset unless a fallback value is provided in ``default_fields_values`` using the pattern ``{field}_{lang}``.
+
+When no translation exists for the default language, the base OpenStreetMap tag (e.g., ``name``) is used. This can lead to incorrect language display if the OSM default does not match the Geotrek instance’s default language.
+
+Translation logic can be customized in custom parsers by overriding the ``translation_fields`` method.
+
 Import information desks
 -------------------------
 

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2048,7 +2048,7 @@ class OpenStreetMapParser(Parser):
             tags = [tags] if is_str else list(tags)
 
             # Protect the class from multiple translation mappings as field is a static attribute
-            is_translated = [tag for tag in tags if f":{default_lang}" in tag]
+            is_translated = [tag for tag in tags if tag.endswith(f":{default_lang}")]
             if is_translated:
                 continue
 

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -749,7 +749,7 @@ class ShapeParser(Parser):
             try:
                 ogrgeom = feature.geom
             except GDALException:
-                logger.warning("Invalid geometry pointer")
+                logger.warning(_("Invalid geometry pointer"), i)
                 geom = None
             else:
                 ogrgeom.coord_dim = 2  # Flatten to 2D

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2037,10 +2037,6 @@ class OpenStreetMapParser(Parser):
         return f"{type[0].upper()}{id}"
 
     def translation_fields(self):
-        if not self.model:
-            msg = "Model argument should be configured"
-            raise ImproperlyConfigured(msg)
-
         default_lang = settings.MODELTRANSLATION_DEFAULT_LANGUAGE
 
         for field in get_translated_fields(self.model):

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2036,7 +2036,7 @@ class OpenStreetMapParser(Parser):
         type, id = val
         return f"{type[0].upper()}{id}"
 
-    def translation_fields(self): 
+    def translation_fields(self):
         default_lang = settings.MODELTRANSLATION_DEFAULT_LANGUAGE
 
         for field in get_translated_fields(self.model):

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2072,7 +2072,5 @@ class OpenStreetMapParser(Parser):
     def get_val(self, row, dst, src):
         val = super().get_val(row, dst, src)
         if not hasattr(self, f"filter_{dst}") and isinstance(val, list):
-            for tag in val:
-                if tag or tag == 0:
-                    return tag
+            return next((item for item in val if item is not None), None)
         return val

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2038,7 +2038,7 @@ class OpenStreetMapParser(Parser):
 
     def translation_fields(self):
         if not self.model:
-            msg = "model argument should be configured"
+            msg = "Model argument should be configured"
             raise ImproperlyConfigured(msg)
 
         default_lang = settings.MODELTRANSLATION_DEFAULT_LANGUAGE

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2036,7 +2036,7 @@ class OpenStreetMapParser(Parser):
         type, id = val
         return f"{type[0].upper()}{id}"
 
-    def translation_fields(self):
+    def translation_fields(self): 
         default_lang = settings.MODELTRANSLATION_DEFAULT_LANGUAGE
 
         for field in get_translated_fields(self.model):

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -749,7 +749,7 @@ class ShapeParser(Parser):
             try:
                 ogrgeom = feature.geom
             except GDALException:
-                logger.warning(_("Invalid geometry pointer"), i)
+                logger.warning("Invalid geometry pointer")
                 geom = None
             else:
                 ogrgeom.coord_dim = 2  # Flatten to 2D

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -1508,6 +1508,13 @@ class OpenStreetMapInitialisationTest(OpenStreetMapParser):
     model = InformationDesk
 
 
+class OpenStreetMapInitialisationTranslationTest(OpenStreetMapParser):
+    tags = [
+        [{"boundary": "administrative"}, {"admin_level": "4"}],
+        {"boundary": "protected_area"},
+    ]
+
+
 class OpenStreetMapQueryTest(OpenStreetMapParser):
     model = InformationDesk
     tags = [
@@ -1531,6 +1538,16 @@ class OpenStreetMapTestParser(TestCase):
             call_command(
                 "import",
                 "geotrek.common.tests.test_parsers.OpenStreetMapInitialisationTest",
+                verbosity=2,
+            )
+
+    def test_model_improperly_configurated(self):
+        with self.assertRaisesRegex(
+            ImproperlyConfigured, "Model argument should be configured"
+        ):
+            call_command(
+                "import",
+                "geotrek.common.tests.test_parsers.OpenStreetMapInitialisationTranslationTest",
                 verbosity=2,
             )
 

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -1538,7 +1538,6 @@ class OpenStreetMapTestParser(TestCase):
         "geotrek.common.parsers.OpenStreetMapParser.get_bbox_str", return_value="test"
     )
     def test_query_settings(self, mocked):
-
         # default settings
         self.assertEqual(
             "[out:json][timeout:180][bbox:test];(nwr['boundary'='administrative']['admin_level'='4'];nwr['boundary'='protected_area'];);out geom;",

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -1602,7 +1602,7 @@ class OpenStreetMapTestParser(TestCase):
         self.assertIn("name_it", osm_parser.fields)
         self.assertEqual(osm_parser.fields.get("name_it"), "tags.name:it")
         self.assertIn("name_es", osm_parser.fields)
-        self.assertEqual(self.osm_class.fields.get("name_es"), "tags.name:es")
+        self.assertEqual(osm_parser.fields.get("name_es"), "tags.name:es")
 
         # translate tags that contains the default language code
         self.assertIn("description", osm_parser.fields)

--- a/geotrek/common/tests/test_parsers.py
+++ b/geotrek/common/tests/test_parsers.py
@@ -1508,13 +1508,6 @@ class OpenStreetMapInitialisationTest(OpenStreetMapParser):
     model = InformationDesk
 
 
-class OpenStreetMapInitialisationTranslationTest(OpenStreetMapParser):
-    tags = [
-        [{"boundary": "administrative"}, {"admin_level": "4"}],
-        {"boundary": "protected_area"},
-    ]
-
-
 class OpenStreetMapQueryTest(OpenStreetMapParser):
     model = InformationDesk
     tags = [
@@ -1538,16 +1531,6 @@ class OpenStreetMapTestParser(TestCase):
             call_command(
                 "import",
                 "geotrek.common.tests.test_parsers.OpenStreetMapInitialisationTest",
-                verbosity=2,
-            )
-
-    def test_model_improperly_configurated(self):
-        with self.assertRaisesRegex(
-            ImproperlyConfigured, "Model argument should be configured"
-        ):
-            call_command(
-                "import",
-                "geotrek.common.tests.test_parsers.OpenStreetMapInitialisationTranslationTest",
                 verbosity=2,
             )
 

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -1424,23 +1424,6 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
             return street
         return None
 
-    """
-    def filter_postal_code(self, src, val):
-        return self.get_tag_info(val)
-
-    def filter_municipality(self, src, val):
-        return self.get_tag_info(val)
-
-    def filter_phone(self, src, val):
-        return self.get_tag_info(val)
-
-    def filter_email(self, src, val):
-        return self.get_tag_info(val)
-
-    def filter_website(self, src, val):
-        return self.get_tag_info(val)
-    """
-
     def filter_geom(self, src, val):
         type, lng, lat, area, bbox = val
         if type == "node":

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -1414,6 +1414,7 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
         super().__init__(*args, **kwargs)
         if self.type:
             self.constant_fields["type"] = self.type
+        self.translation_fields()
 
     def filter_street(self, src, val):
         housenumber, street = val
@@ -1423,6 +1424,7 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
             return street
         return None
 
+    """
     def filter_postal_code(self, src, val):
         return self.get_tag_info(val)
 
@@ -1437,6 +1439,7 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
 
     def filter_website(self, src, val):
         return self.get_tag_info(val)
+    """
 
     def filter_geom(self, src, val):
         type, lng, lat, area, bbox = val

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -1414,7 +1414,6 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
         super().__init__(*args, **kwargs)
         if self.type:
             self.constant_fields["type"] = self.type
-        self.translation_fields()
 
     def filter_street(self, src, val):
         housenumber, street = val

--- a/geotrek/tourism/tests/data/information_desk_OSM.json
+++ b/geotrek/tourism/tests/data/information_desk_OSM.json
@@ -15,6 +15,8 @@
   "tags": {
     "amenity": "ranger_station",
     "name": "test",
+    "name:fr": "test:fr",
+    "name:en": "test:en",
     "contact:phone": "0754347899",
     "addr:housenumber": "5",
     "addr:street": "rue des chênes"
@@ -28,6 +30,7 @@
   "tags": {
     "amenity": "ranger_station",
     "name": "test",
+    "name:en": "test:en",
     "phone": "0754347899",
     "addr:street": "rue des chênes"
   }


### PR DESCRIPTION
## Description

OpenStreetMap supports multilingual fields. This PR adds automatic mapping of translated fields for the different languages supported. The translated field will then be filled with the correct translation when the information exists in OpenStreetMap.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentioned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
