### PR TITLE
Make eid for OpenStreetMap object as type+id

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ CHANGELOG
 
 - Improve Overpass query for OpenStreetMap parsers
 
+**Bug fixes**
+
+- Make OpenStreetMap eid as type+id
+
 
 2.115.0    (2025-04-29)
 ----------------------------
@@ -23,7 +27,6 @@ CHANGELOG
 
 - Fix log book filters by updating mapentity (#4576)
 - Prevent trying to generate thumbnails for non-images (information desk's photo attribute)
-- Make OpenStreetMap eid as type+id
 
 **Improvements**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ CHANGELOG
 
 - Fix log book filters by updating mapentity (#4576)
 - Prevent trying to generate thumbnails for non-images (information desk's photo attribute)
+- Make OpenStreetMap eid as type+id
 
 **Improvements**
 

--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -2030,3 +2030,7 @@ class OpenStreetMapParser(Parser):
 
     def normalize_field_name(self, name):
         return name
+
+    def filter_eid(self, src, val):
+        type, id = val
+        return f"{type[0].upper()}{id}"

--- a/geotrek/tourism/parsers.py
+++ b/geotrek/tourism/parsers.py
@@ -1394,7 +1394,7 @@ class InformationDeskOpenStreetMapParser(OpenStreetMapParser):
     type = None
     model = InformationDesk
     fields = {
-        "eid": "id",
+        "eid": ("type", "id"),  # ids are unique only for object of the same type,
         "phone": ("tags.contact:phone", "tags.phone"),
         "email": ("tags.contact:email", "tags.email"),
         "website": ("tags.contact:website", "tags.website"),

--- a/geotrek/tourism/tests/test_parsers.py
+++ b/geotrek/tourism/tests/test_parsers.py
@@ -1441,47 +1441,52 @@ class OpenStreetMapParserTests(TestCase):
     def test_create_information_desk_OSM(self):
         self.assertEqual(self.objects.count(), 4)
 
+    def test_InformationDesk_eid_filter_OSM(self):
+        information_desks_eid = self.objects.all().values_list("eid", flat=True)
+        self.assertListEqual(list(information_desks_eid), ["N1", "N2", "W3", "R4"])
+        self.assertNotEqual(information_desks_eid, ["1", "2", "3", "4"])
+
     def test_get_tag_info_existing_tag_OSM(self):
-        information_desk = self.objects.get(eid="1")
+        information_desk = self.objects.get(eid="N1")
         self.assertEqual(information_desk.phone, "0754347899")
 
-        information_desk2 = self.objects.get(eid="2")
+        information_desk2 = self.objects.get(eid="N2")
         self.assertEqual(information_desk2.phone, "0754347899")
 
     def test_get_tag_info_no_tag_OSM(self):
-        information_desk = self.objects.get(eid="3")
+        information_desk = self.objects.get(eid="W3")
         self.assertEqual(information_desk.phone, None)
 
     def test_InformationDesk_street_filter_housenumber_and_street_OSM(self):
-        information_desk = self.objects.get(eid="1")
+        information_desk = self.objects.get(eid="N1")
         self.assertEqual(information_desk.street, "5 rue des chênes")
 
     def test_InformationDesk_street_filter_street_OSM(self):
-        information_desk = self.objects.get(eid="2")
+        information_desk = self.objects.get(eid="N2")
         self.assertEqual(information_desk.street, "rue des chênes")
 
     def test_InformationDesk_street_filter_None_OSM(self):
-        information_desk = self.objects.get(eid="3")
+        information_desk = self.objects.get(eid="W3")
         self.assertEqual(information_desk.street, None)
 
     def test_geom_point_to_point_OSM(self):
-        information_desk = self.objects.get(eid="1")
+        information_desk = self.objects.get(eid="N1")
         self.assertAlmostEqual(information_desk.geom.coords[0], 673775.5074406686)
         self.assertAlmostEqual(information_desk.geom.coords[1], 6260613.093389216)
 
     def test_geom_way_to_point_OSM(self):
-        information_desk = self.objects.get(eid="3")
+        information_desk = self.objects.get(eid="W3")
         self.assertAlmostEqual(information_desk.geom.coords[0], 639380.854410392)
         self.assertAlmostEqual(information_desk.geom.coords[1], 6256494.451055847)
 
     def test_geom_relation_to_point_OSM(self):
-        information_desk = self.objects.get(eid="4")
+        information_desk = self.objects.get(eid="R4")
         self.assertAlmostEqual(information_desk.geom.coords[0], -5898321.244682654)
         self.assertAlmostEqual(information_desk.geom.coords[1], 12807160.659235487)
 
     def test_flexible_fields(self):
-        information_desk = self.objects.get(eid="1")
+        information_desk = self.objects.get(eid="N1")
         self.assertEqual(information_desk.name, "test")
 
-        information_desk2 = self.objects.get(eid="4")
+        information_desk2 = self.objects.get(eid="R4")
         self.assertEqual(information_desk2.name, "test_flexible")

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -1637,7 +1637,7 @@ class OpenStreetMapPOIParser(OpenStreetMapParser):
     eid = "eid"
 
     fields = {
-        "eid": "id",
+        "eid": ("type", "id"),  # ids are unique only for object of the same type
         "name": "tags.name",
         "description": "tags.description",
         "geom": ("type", "lon", "lat", "geometry", "bounds"),

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -2433,18 +2433,23 @@ class OpenStreetMapPOIParser(TestCase):
     def test_create_POI_OSM(self):
         self.assertEqual(self.objects.count(), 4)
 
+    def test_POI_eid_filter_OSM(self):
+        poi_eid = self.objects.all().values_list("eid", flat=True)
+        self.assertListEqual(list(poi_eid), ["N1", "W2", "W3", "R4"])
+        self.assertNotEqual(poi_eid, ["1", "2", "3", "4"])
+
     def test_default_name(self):
-        poi1 = self.objects.get(eid="1")
+        poi1 = self.objects.get(eid="N1")
         self.assertEqual(poi1.name, "Grande Tête de l'Obiou")
 
-        poi3 = self.objects.get(eid="3")
+        poi3 = self.objects.get(eid="W3")
         self.assertEqual(poi3.name, "Test")
 
     @skipIf(
         not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only"
     )
     def test_topology_point(self):
-        poi = self.objects.get(eid="1")
+        poi = self.objects.get(eid="N1")
         self.assertAlmostEqual(poi.topo_object.offset, 6437.493262796821)
         self.assertEqual(poi.topo_object.paths.count(), 1)
         poi_path = poi.topo_object.paths.get()
@@ -2452,7 +2457,7 @@ class OpenStreetMapPOIParser(TestCase):
         self.assertEqual(poi.topo_object.kind, "POI")
 
     def test_topology_point_no_dynamic_segmentation(self):
-        poi = self.objects.get(eid="1")
+        poi = self.objects.get(eid="N1")
         self.assertAlmostEqual(poi.geom.x, 924596.692586552)
         self.assertAlmostEqual(poi.geom.y, 6412498.122749874)
 
@@ -2460,14 +2465,14 @@ class OpenStreetMapPOIParser(TestCase):
         not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only"
     )
     def test_topology_way(self):
-        poi = self.objects.get(eid="2")
+        poi = self.objects.get(eid="W2")
         self.assertAlmostEqual(poi.topo_object.offset, -1401.0373646193946)
         poi_path = poi.topo_object.paths.get()
         self.assertEqual(poi_path, self.path)
         self.assertEqual(poi.topo_object.kind, "POI")
 
     def test_topology_way_no_dynamic_segmentation(self):
-        poi = self.objects.get(eid="2")
+        poi = self.objects.get(eid="W2")
         self.assertAlmostEqual(poi.geom.x, 926882.1207550302)
         self.assertAlmostEqual(poi.geom.y, 6403317.111114113)
 
@@ -2475,14 +2480,14 @@ class OpenStreetMapPOIParser(TestCase):
         not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only"
     )
     def test_topology_polygon(self):
-        poi = self.objects.get(eid="3")
+        poi = self.objects.get(eid="W3")
         self.assertAlmostEqual(poi.topo_object.offset, -1398.870241563602)
         poi_path = poi.topo_object.paths.get()
         self.assertEqual(poi_path, self.path)
         self.assertEqual(poi.topo_object.kind, "POI")
 
     def test_topology_polygon_no_dynamic_segmentation(self):
-        poi = self.objects.get(eid="3")
+        poi = self.objects.get(eid="W3")
         self.assertAlmostEqual(poi.geom.x, 933501.2402840604)
         self.assertAlmostEqual(poi.geom.y, 6410680.482150642)
 
@@ -2490,13 +2495,13 @@ class OpenStreetMapPOIParser(TestCase):
         not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only"
     )
     def test_topology_relation(self):
-        poi = self.objects.get(eid="4")
+        poi = self.objects.get(eid="R4")
         self.assertAlmostEqual(poi.topo_object.offset, 2589.2357898722626)
         poi_path = poi.topo_object.paths.get()
         self.assertEqual(poi_path, self.path)
         self.assertEqual(poi.topo_object.kind, "POI")
 
     def test_topology_relation_no_dynamic_segmentation(self):
-        poi = self.objects.get(eid="4")
+        poi = self.objects.get(eid="R4")
         self.assertAlmostEqual(poi.geom.x, 930902.9339307954)
         self.assertAlmostEqual(poi.geom.y, 6406011.138417606)

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -2505,3 +2505,19 @@ class OpenStreetMapPOIParser(TestCase):
         poi = self.objects.get(eid="R4")
         self.assertAlmostEqual(poi.geom.x, 930902.9339307954)
         self.assertAlmostEqual(poi.geom.y, 6406011.138417606)
+
+    def test_multiple_import(self):
+        poi1 = self.objects.get(eid="N1")
+        poi2 = self.objects.get(eid="W2")
+
+        id1 = poi1.id
+        id2 = poi2.id
+
+        self.import_POI()
+
+        poi1_bis = self.objects.get(eid="N1")
+        poi2_bis = self.objects.get(eid="W2")
+
+        self.assertEqual(poi1_bis.id, id1)
+        self.assertEqual(poi2_bis.id, id2)
+        self.assertEqual(self.objects.count(), 4)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

OpenStreetMap IDs are unique only within their object type (e.g., node, way, relation). To clearly distinguish between different types, this PR prefixes each ID with the first letter of its type in uppercase (e.g., N for node, W for way, R for relation).
This formatting aligns with the convention used by Nominatim.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
