### PR TITLE
fix Directionnelle typo in signage fixtures

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 **Bug fixes**
 
 - Make OpenStreetMap eid as type+id
+- Fix signage fixture typo
 
 **Documentation**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,11 +12,13 @@ CHANGELOG
 **Bug fixes**
 
 - Make OpenStreetMap eid as type+id
-- Fix signage fixture typo
 
 **Documentation**
 
 - Add missing parameters from base.py (#4690)
+
+**Minor fix**
+- Fix signage fixture typo
 
 
 2.115.0    (2025-04-29)

--- a/geotrek/signage/fixtures/basic.json
+++ b/geotrek/signage/fixtures/basic.json
@@ -12,7 +12,7 @@
         "pk": 2,
         "model": "signage.signagetype",
         "fields": {
-            "label": "Directionelle",
+            "label": "Directionnelle",
             "date_update": "2014-02-12T11:21:48.961Z",
             "date_insert": "2014-02-12T11:21:48.961Z"
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modify signage fixture "Directionelle" for "Directionnelle"

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
