### PR TITLE
Fix makefile's build_doc cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ serve_docs: purge_docs
     -c "sphinx-autobuild -b html --host 0.0.0.0 --port 8800 ./ ./_build/html"
 
 build_docs: purge_docs
-	$(docker_compose) run --rm -w /opt/geotrek-admin/docs web bash -c "make html SPHINXOPTS=\"-W\""
+	$(docker_compose) run --rm -w /opt/geotrek-admin/docs -v ./var/cache:/.cache web bash -c "make html SPHINXOPTS=\"-W\""
 
 build_doc_translations:
 	$(docker_compose) run -w /opt/geotrek-admin/docs --rm web bash -c "make gettext && sphinx-intl update -p _build/locale -l fr"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ CHANGELOG
 **Bug fixes**
 
 - Fix translations in Add buttons on lists. (refs #4963)
+- Fix Makefile's build_doc cache
 
 **Improvements**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~[ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~
- [x] I have performed a self-review of my code
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- ~[ ] My commits are all using prefix convention (emoji + tag name) and references associated issues~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- ~[ ] The title of my PR mentionned the issue associated~


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
