### PR TITLE
fix(docker): Handle gunicorn configuration override correctly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,7 +109,7 @@ CMD ["./manage.py", "runserver", "0.0.0.0:8000"]
 
 FROM base AS prod
 
-ENV GUNICORN_WORKERS=1
+ENV GUNICORN_CMD_ARGS="--workers=1"
 
 COPY --chown=geotrek:geotrek --from=build /opt/venv /opt/venv
 COPY --chown=geotrek:geotrek geotrek/ geotrek/
@@ -123,4 +123,4 @@ USER geotrek
 
 HEALTHCHECK CMD curl --fail http://127.0.0.1:8000/api/settings.json
 
-CMD ["sh", "-c", "gunicorn geotrek.wsgi:application --worker-class=gevent --workers=${GUNICORN_WORKERS} --bind=0.0.0.0:8000"]
+CMD ["gunicorn", "geotrek.wsgi:application", "--bind=0.0.0.0:8000", "--worker-class=gevent"]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,15 @@ CHANGELOG
 2.118.2+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Breaking changes**
+
+- Docker user : `GUNICORN_WORKERS` environment variable is now deprecated. Use `GUNICORN_CMD_ARGS` instead. (ex: `GUNICORN_CMD_ARGS=--workers=4` instead of `GUNICORN_WORKERS=4`)
+
+**Bug fixes**
+
+- Fix gunicorn configuration in Dockerfile
+
+
 
 2.118.2         (2025-09-23)
 ----------------------------


### PR DESCRIPTION
Since last gunicorn update, GUNICORN_CMD_ARGS has changed

BREAKING CHANGE: Docker user : `GUNICORN_WORKERS` environment variable is now deprecated. Use `GUNICORN_CMD_ARGS` instead. (ex: `GUNICORN_CMD_ARGS=--workers=4` instead of `GUNICORN_WORKERS=4`)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
