### PR TITLE
Fix geographic filter causing false-by-1 count of deleted objects

### DIFF
--- a/geotrek/common/parsers.py
+++ b/geotrek/common/parsers.py
@@ -823,7 +823,7 @@ class Parser:
         * object_filter: {"field_name": "object_name"} with field_name, the name of the field in the model that define the name of the object
         """
         if self._ref_geom and not self._ref_geom.intersects(geom):
-            if self.delete:
+            if self.delete and self.obj.pk:
                 self.to_delete.add(self.obj.pk)
             msg = (
                 f"Object geometry does not intersect with reference geometry "


### PR DESCRIPTION
Le filtre géographique de `Parser` basé sur `intersection_geom` ajoutait `None` à `self.to_delete` dans le cas d'un nouvel objet (car `self.obj.pk` vaut `None` tant que l'objet n'a pas été saved, ce qui intervient plus tard dans le processus d'import).

En conséquence le compte d'objets supprimés dans le rapport d'import pouvait être faux de +1 si un ou plusieurs nouveaux objets se trouvant en-dehors de `intersection_geom` avaient été parsés.

En particulier la sortie d'un import avec un parser n'ayant pas encore été exécuté indiquait toujours « Enregistrement supprimé : 1 » ce qui est impossible.

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
