### PR TITLE
fix: allows to add/edit trek despite missing service type pictogram

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 * Fix fetching published steps of parent treks with aggregator parser
+* Allows to add/edit trek despite missing service type pictogram
 
 
 2.123.0         (2026-01-15)

--- a/geotrek/trekking/forms.py
+++ b/geotrek/trekking/forms.py
@@ -157,18 +157,21 @@ class TrekForm(BaseTrekForm):
     ]
 
     def __init__(self, *args, **kwargs):
-        label = _("Insert service:")
-        pictogram_links = "".join(
-            [
-                f'<a class="servicetype" data-url="{t.pictogram.url}" data-name={t.name}">'
-                f'<img src="{t.pictogram.url}"></a>'
-                for t in ServiceType.objects.all()
-            ]
-        )
         self.fieldslayout = deepcopy(self.base_fieldslayout)
-        self.fieldslayout[0][1][0].append(
-            HTML(f'<div class="controls">{label}{pictogram_links}</div>')
-        )
+        service_types = ServiceType.objects.all()
+        if any(st.pictogram for st in service_types):
+            label = _("Insert service:")
+            pictogram_links = "".join(
+                [
+                    f'<a class="servicetype" data-url="{t.pictogram.url}" data-name={t.name}">'
+                    f'<img src="{t.pictogram.url}"></a>'
+                    for t in service_types
+                    if t.pictogram
+                ]
+            )
+            self.fieldslayout[0][1][0].append(
+                HTML(f'<div class="controls">{label}{pictogram_links}</div>')
+            )
         super().__init__(*args, **kwargs)
         if self.fields.get("structure"):
             self.fieldslayout[0][1][0].insert(0, "structure")


### PR DESCRIPTION
La création/édition d'itinéraire est impossible si un type de service sans pictogramme est présent sur l'instance Geotrek.

## Description

Le champ pictogramme est obligatoire dans le formulaire admin de création/édition d'un type de service. Néanmoins la création d'un type de service par un import n'est pas soumise à cette contrainte et l'agrégateur n'importe pas d'autres informations que le libellé pour les catégories (thèmes, étiquettes, ..., types de service). On se retrouve donc avec des types de services importés qui n'ont pas de pictogramme.

Les pictogrammes des types de service sont affichés sur la page de création/édition d'un itinéraire pour générer des boutons permettant d'insérer les pictogrammes de service dans le champ description de l'itinéraire.

Sur une instance Geotrek Admin avec des types de service sans pictogramme la création/édition d'itinéraire est impossible. Visite la page échoue avec l'erreur suivante : 

```
Exception Type: ValueError at /trek/edit/587/
Exception Value: The 'pictogram' attribute has no file associated with it.
```

<details><summary>stacktrace</summary>

```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/opt/venv/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/base.py", line 105, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/geotrek-admin/geotrek/authent/decorators.py", line 19, in _wrapped_view
    result = view_func(self, request, *args, **kwargs)
  File "/opt/geotrek-admin/geotrek/trekking/views.py", line 295, in dispatch
    return super().dispatch(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/mapentity/decorators.py", line 66, in _wrapped_view
    return decorated(self, request, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/contrib/auth/decorators.py", line 59, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/mapentity/decorators.py", line 64, in decorated
    return view_func(self, request, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/mapentity/views/generic.py", line 561, in dispatch
    return super().dispatch(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/base.py", line 144, in dispatch
    return handler(request, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/edit.py", line 202, in get
    return super().get(request, *args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/edit.py", line 142, in get
    return self.render_to_response(self.get_context_data())
  File "/opt/venv/lib/python3.10/site-packages/mapentity/views/mixins.py", line 87, in get_context_data
    context = super().get_context_data(**kwargs)
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/edit.py", line 72, in get_context_data
    kwargs["form"] = self.get_form()
  File "/opt/venv/lib/python3.10/site-packages/django/views/generic/edit.py", line 37, in get_form
    return form_class(**self.get_form_kwargs())
  File "/opt/geotrek-admin/geotrek/trekking/forms.py", line 166, in __init__
    [
  File "/opt/geotrek-admin/geotrek/trekking/forms.py", line 167, in <listcomp>
    f'<a class="servicetype" data-url="{t.pictogram.url}" data-name={t.name}">'
  File "/opt/venv/lib/python3.10/site-packages/django/db/models/fields/files.py", line 69, in url
    self._require_file()
  File "/opt/venv/lib/python3.10/site-packages/django/db/models/fields/files.py", line 44, in _require_file
    raise ValueError(

Exception Type: ValueError at /trek/edit/587/
Exception Value: The 'pictogram' attribute has no file associated with it.
```

</details>

La correction consiste à ne pas générer de bouton pour les types de service sans pictogramme.

**absence de test et code coverage**

Étant donné qu'il n'y a actuellement aucun setup pour créer des entités secondaires pour les tests frontend je propose de ne pas ajouter de test.

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] ~~My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [ ] ~~My commits are all using prefix convention (emoji + tag name) and references associated issues~~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] ~~The title of my PR mentionned the issue associated~~

