### PR TITLE
Fix trek practice merge

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 * Adapting TourInsoft parsers to the v3 API
+* Fix trek practice merge
 
 
 2.124.3         (2026-04-02)

--- a/geotrek/trekking/admin.py
+++ b/geotrek/trekking/admin.py
@@ -47,7 +47,7 @@ class TrekNetworkAdmin(MergeActionMixin, TabbedTranslationAdmin):
 class PracticeAdmin(MergeActionMixin, TabbedTranslationAdmin):
     list_display = ("id", "name", "order", "cirkwi", "distance", "pictogram_img")
     search_fields = ("name",)
-    merge_field = "network"
+    merge_field = "name"
 
 
 class AccessibilityAdmin(MergeActionMixin, TabbedTranslationAdmin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We encountered a 500 error when merging two Trek practices. This was because the field used for merging the trek practices was 'network' (a field that is not in the permitted list). This PR changed the field from 'network' to 'name'. 

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
