### PR TITLE
Introduce distinctions into ApidaeTrekParser

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ CHANGELOG
 2.124.4+dev     (XXXX-XX-XX)
 ----------------------------
 
-**Bug fixes**
+**Improvements**
 
 * Adapting ApidaeTrekParser to distinctions (#5180)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.124.4+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+* Adapting ApidaeTrekParser to distinctions (#5180)
+
 
 2.124.4         (2026-05-11)
 ----------------------------

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -524,7 +524,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         "labels": [
             "presentation.typologiesPromoSitra.*",
             "localisation.environnements.*",
-            "distinctions"
+            "distinctions",
         ],
         "networks": "informationsEquipement.activites",
         "accessibilities": "informationsEquipement.itineraire.naturesTerrain.*",

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -484,6 +484,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         "informationsEquipement",
         "illustrations",
         "informations",
+        "distinctions",
     ]
     locales = ["fr", "en"]
 
@@ -523,6 +524,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
         "labels": [
             "presentation.typologiesPromoSitra.*",
             "localisation.environnements.*",
+            "distinctions"
         ],
         "networks": "informationsEquipement.activites",
         "accessibilities": "informationsEquipement.itineraire.naturesTerrain.*",
@@ -610,18 +612,20 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
     typologies_sitra_ids_as_labels = [
         1599,  # Déconseillé par mauvais temps
         1676,  # En plein air
+        3845,  # Itinéraire France vélo
         4639,  # Conseillé par forte chaleur
         4819,  # Paysages
-        5022,  # Respirando
-        4971,  # Inscrit au PDIPR
-        3845,  # Itinéraire France vélo
-        6566,  # Label Espace Cyclosport
-        6049,  # Label Vélo et Fromages
-        1582,  # Label VTT - FFC
-        5538,  # Label VTT - FFCT
-        6825,  # Station de Trail®
         6608,  # Site sur-fréquenté
         1602,  # Circuits de France
+    ]
+    distinctions_ids_as_labels = [
+        8644,  # Respirando
+        8607,  # Inscrit au PDIPR
+        8671,  # Label Espace Cyclosport
+        8673,  # Label Vélo et Fromages
+        8674,  # Label VTT - FFC
+        8675,  # Label VTT - FFCT
+        8690,  # Station de Trail®
     ]
     typologies_sitra_ids_as_themes = [
         6155,  # Adrénaline
@@ -746,7 +750,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
             raise RowImportError(str(e))
 
     def filter_labels(self, src, val):
-        typologies, environnements = val
+        typologies, environnements, distinctions = val
         translation_src = self._get_default_translation_src()
         filtered_val = []
         if typologies:
@@ -760,6 +764,12 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
                 e[translation_src]
                 for e in environnements
                 if e["id"] in self.environnements_ids_as_labels
+            ]
+        if distinctions:
+            filtered_val += [
+                d[translation_src]
+                for d in distinctions
+                if d["nom"]["id"] in self.distinctions_ids_as_labels
             ]
         return self.apply_filter(dst="labels", src=src, val=filtered_val)
 
@@ -1215,6 +1225,7 @@ class ApidaeTrekLabelParser(ApidaeReferenceElementParser):
     element_reference_ids = (
         ApidaeTrekParser.typologies_sitra_ids_as_labels
         + ApidaeTrekParser.environnements_ids_as_labels
+        + ApidaeTrekParser.distinctions_ids_as_labels
     )
     name_field = "name"
 

--- a/geotrek/trekking/parsers.py
+++ b/geotrek/trekking/parsers.py
@@ -767,7 +767,7 @@ class ApidaeTrekParser(AttachmentParserMixin, ApidaeBaseTrekkingParser):
             ]
         if distinctions:
             filtered_val += [
-                d[translation_src]
+                d["nom"][translation_src]
                 for d in distinctions
                 if d["nom"]["id"] in self.distinctions_ids_as_labels
             ]

--- a/geotrek/trekking/tests/data/apidae_trek_parser/a_trek.json
+++ b/geotrek/trekking/tests/data/apidae_trek_parser/a_trek.json
@@ -159,6 +159,19 @@
           "libelleEn": "Ski lift ticket office: 2 shops - Frastaz and Bois Noir ski lifts."
         }
       },
+      "distinctions": [
+        {
+          "id": 6,
+          "nom": {
+            "elementReferenceType": "DistinctionNom",
+            "id": 8607,
+            "libelleFr": "Inscrit au PDIPR",
+            "libelleEn": "Listed PDIPR",
+            "libelleEs": "Listado en el PDIPR",
+            "libelleIt": "Elencato nel PDIPR"
+          }
+        }
+      ],
       "presentation": {
         "descriptifCourt": {
           "libelleFr": "La description courte en français.",
@@ -203,14 +216,6 @@
             "libelleEn": "Not recommended in bad weather",
             "libelleEs": "Desaconsejado en época de mal tiempo",
             "libelleIt": "Sconsigliato con cattivo tempo"
-          },
-          {
-            "elementReferenceType": "TypologiePromoSitra",
-            "id": 4971,
-            "libelleFr": "Inscrit au PDIPR",
-            "libelleEn": "Listed PDIPR",
-            "libelleEs": "Listado en el PDIPR",
-            "libelleIt": "Elencato nel PDIPR"
           }
         ]
       },

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1306,7 +1306,6 @@ class ApidaeTrekParserTests(TestCase):
 
     @mock.patch("requests.get")
     def test_trek_is_imported(self, mocked_get):
-        print("test_trek_is_imported")
         RouteFactory(route="Boucle")
         mocked_get.side_effect = self.make_dummy_get("a_trek.json")
 

--- a/geotrek/trekking/tests/test_parsers.py
+++ b/geotrek/trekking/tests/test_parsers.py
@@ -1306,6 +1306,7 @@ class ApidaeTrekParserTests(TestCase):
 
     @mock.patch("requests.get")
     def test_trek_is_imported(self, mocked_get):
+        print("test_trek_is_imported")
         RouteFactory(route="Boucle")
         mocked_get.side_effect = self.make_dummy_get("a_trek.json")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Apidae change there API by introdusing the distinctions field. It replace multiple fields whose presentation.typologiesPromoSitra used in ApidaeTrekParser.

## Related Issue

- https://github.com/GeotrekCE/Geotrek-admin/issues/5180

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
