### PR TITLE
Fix the inversion of latitude/longitude columns in signage during CSV export. (refs #4116)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.124.4+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+* Fix the inversion of latitude/longitude columns in signage during CSV export. (refs #4116)
+
 **Cleanup**
 
 * Delete outdated settings related to categories and pictures (refs #4482) 

--- a/geotrek/signage/models.py
+++ b/geotrek/signage/models.py
@@ -194,11 +194,11 @@ class Signage(GeotrekMapEntityMixin, BaseInfrastructure):
 
     @property
     def lat_value(self):
-        return self.geomtransform.x
+        return self.geomtransform.y
 
     @property
     def lng_value(self):
-        return self.geomtransform.y
+        return self.geomtransform.x
 
     @property
     def conditions_display(self):

--- a/geotrek/signage/tests/test_models.py
+++ b/geotrek/signage/tests/test_models.py
@@ -1,9 +1,11 @@
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+from django.contrib.gis.geos import LineString, Point
 from django.templatetags.static import static
 from django.test import TestCase
-
+from geotrek.core.tests.factories import PathFactory
 from geotrek.authent.tests.factories import StructureFactory, UserFactory
 from geotrek.signage.models import Blade
 from geotrek.signage.tests.factories import (
@@ -92,6 +94,16 @@ class SignageModelTest(TestCase):
         signagecondition = SignageConditionFactory(label="condition", structure=None)
         self.assertEqual(str(signagecondition), "condition")
 
+    def test_lat_and_lng_value(self):
+        lat = 48.0
+        lng = 2.0
+        if settings.TREKKING_TOPOLOGY_ENABLED:
+            p_signage = PathFactory.create(geom = LineString(Point(lng, lat), Point( lng, lat), srid=settings.API_SRID))
+            signage = SignageFactory.create(paths=[p_signage])
+        else:
+            signage = SignageFactory.create(geom=Point(lng, lat, srid=settings.API_SRID))
+        self.assertAlmostEqual(signage.lat_value, lat , places=4)
+        self.assertAlmostEqual(signage.lng_value, lng, places=4)
 
 class LinePictogramModelTest(TestCase):
     def test_str_linepictogram(self):

--- a/geotrek/signage/tests/test_models.py
+++ b/geotrek/signage/tests/test_models.py
@@ -1,12 +1,13 @@
+from django.conf import settings
 from django.contrib.admin.models import DELETION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
-from django.conf import settings
 from django.contrib.gis.geos import LineString, Point
 from django.templatetags.static import static
 from django.test import TestCase
-from geotrek.core.tests.factories import PathFactory
+
 from geotrek.authent.tests.factories import StructureFactory, UserFactory
+from geotrek.core.tests.factories import PathFactory
 from geotrek.signage.models import Blade
 from geotrek.signage.tests.factories import (
     BladeConditionFactory,
@@ -98,12 +99,19 @@ class SignageModelTest(TestCase):
         lat = 48.0
         lng = 2.0
         if settings.TREKKING_TOPOLOGY_ENABLED:
-            p_signage = PathFactory.create(geom = LineString(Point(lng, lat), Point( lng, lat), srid=settings.API_SRID))
+            p_signage = PathFactory.create(
+                geom=LineString(
+                    Point(lng, lat), Point(lng + 1, lat + 1), srid=settings.API_SRID
+                )
+            )
             signage = SignageFactory.create(paths=[p_signage])
         else:
-            signage = SignageFactory.create(geom=Point(lng, lat, srid=settings.API_SRID))
-        self.assertAlmostEqual(signage.lat_value, lat , places=4)
+            signage = SignageFactory.create(
+                geom=Point(lng, lat, srid=settings.API_SRID)
+            )
+        self.assertAlmostEqual(signage.lat_value, lat, places=4)
         self.assertAlmostEqual(signage.lng_value, lng, places=4)
+
 
 class LinePictogramModelTest(TestCase):
     def test_str_linepictogram(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

- https://github.com/GeotrekCE/Geotrek-admin/issues/4116

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- ~~[ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)~~
- [x] I have performed a self-review of my code
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works.~~
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- ~~[ ] My commits are all using prefix convention (emoji + tag name) and references associated issues~~
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
