### PR TITLE
Improve popup to allow opening detail page in new tab (issue #4626) 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.124.5+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+- Update popup to allow opening detail page in new tab (issue #4626)
+
 
 2.124.5         (2026-06-09)
 ----------------------------

--- a/geotrek/core/tests/test_views.py
+++ b/geotrek/core/tests/test_views.py
@@ -118,7 +118,7 @@ class PathViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/path/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/path/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -2239,7 +2239,7 @@ class TrailViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/trail/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/trail/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/diving/tests/test_views.py
+++ b/geotrek/diving/tests/test_views.py
@@ -68,7 +68,7 @@ class DiveViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.practice)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/dive/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/dive/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/feedback/tests/test_views.py
+++ b/geotrek/feedback/tests/test_views.py
@@ -181,7 +181,7 @@ class ReportViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.category)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/report/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/report/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/infrastructure/tests/test_views.py
+++ b/geotrek/infrastructure/tests/test_views.py
@@ -74,7 +74,7 @@ class InfrastructureViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/infrastructure/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/infrastructure/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -127,7 +127,7 @@ class PointInfrastructureViewsTest(InfrastructureViewsTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/infrastructure/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/infrastructure/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/land/tests/test_views.py
+++ b/geotrek/land/tests/test_views.py
@@ -121,7 +121,7 @@ class PhysicalEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/physicaledge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/physicaledge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -168,7 +168,7 @@ class LandEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/landedge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/landedge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -217,7 +217,7 @@ class CirculationEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/circulationedge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/circulationedge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -264,7 +264,7 @@ class CompetenceEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/competenceedge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/competenceedge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -311,7 +311,7 @@ class WorkManagementEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/workmanagementedge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/workmanagementedge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -358,7 +358,7 @@ class SignageManagementEdgeViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/signagemanagementedge/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/signagemanagementedge/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/maintenance/tests/test_views.py
+++ b/geotrek/maintenance/tests/test_views.py
@@ -164,7 +164,7 @@ class InterventionViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/intervention/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/intervention/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -640,7 +640,7 @@ class ProjectViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/project/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/project/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/outdoor/tests/test_functional.py
+++ b/geotrek/outdoor/tests/test_functional.py
@@ -54,7 +54,7 @@ class SiteViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/site/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/site/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -134,7 +134,7 @@ class CourseViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/course/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/course/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/sensitivity/tests/test_functional.py
+++ b/geotrek/sensitivity/tests/test_functional.py
@@ -68,7 +68,7 @@ class SensitiveAreaViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.category_display)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/sensitivearea/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/sensitivearea/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/signage/tests/test_views.py
+++ b/geotrek/signage/tests/test_views.py
@@ -163,7 +163,7 @@ class BladeViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/blade/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/blade/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -414,7 +414,7 @@ class SignageViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/signage/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/signage/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/tourism/tests/test_functional.py
+++ b/geotrek/tourism/tests/test_functional.py
@@ -62,7 +62,7 @@ class TouristicContentViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.category)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/touristiccontent/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/touristiccontent/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -167,7 +167,7 @@ class TouristicEventViewsTests(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.type)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/touristicevent/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/touristicevent/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/geotrek/trekking/tests/test_views.py
+++ b/geotrek/trekking/tests/test_views.py
@@ -108,7 +108,7 @@ class POIViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/poi/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/poi/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -335,7 +335,7 @@ class TrekViewsTest(CommonTest):
             f'        <p class="m-0 p-1">\n'
             f"            {str(self.obj.practice)}<br>\n"
             f"        </p>\n    \n"
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/trek/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/trek/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 
@@ -998,7 +998,7 @@ class ServiceViewsTest(CommonTest):
         return (
             f'<div class="d-flex flex-column justify-content-center">\n'
             f'    <p class="text-center m-0 p-1"><strong>{str(self.obj)}</strong></p>\n    \n'
-            f'    <button id="detail-btn" class="btn btn-sm btn-info mt-2" onclick="window.location.href=\'/service/{self.obj.pk}/\'">Detail sheet</button>\n'
+            f'    <a id="detail-btn" href="/service/{self.obj.pk}/" class="btn btn-sm btn-info mt-2">Detail sheet</a>\n'
             f"</div>"
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,7 +254,7 @@ lxml==6.1.1
     # via
     #   mapentity
     #   svglib
-mapentity==8.17.1
+mapentity==8.17.2
     # via geotrek (setup.py)
 markdown==3.10.2
     # via geotrek (setup.py)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Integrate MapEntity PR https://github.com/makinacorpus/django-mapentity/pull/411 updating detail page button on popup

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) here: -->

## Checklist

- [x] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [x] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes
- [x] I added an entry in the changelog file
- [x] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [x] I added a label to the PR corresponding to the perimeter of my contribution
- [x] The title of my PR mentionned the issue associated


<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
