### PR TITLE
Allow to add/edit multiple blades from signage form with a formset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Improvements**
 
 * Remove ``deleted`` attribute from blade model
+* Allow to add multiple blades from signage form
 
 **Documentation**
 

--- a/geotrek/signage/forms.py
+++ b/geotrek/signage/forms.py
@@ -12,7 +12,33 @@ from django.utils.translation import gettext_lazy as _
 from geotrek.common.forms import CommonForm
 from geotrek.core.widgets import PointTopologyWidget
 from geotrek.infrastructure.forms import BaseInfrastructureForm
-from geotrek.signage.models import Blade, Line, LinePictogram, Signage
+from geotrek.signage.models import Blade, BladeCondition, Line, LinePictogram, Signage
+
+
+class CleanDuplicatedNumbersMixin:
+    duplication_error_message = None
+
+    def clean(self):
+        """Checks that no objects have the same number."""
+        if any(self.errors):
+            # Don't bother validating the formset unless each form is valid on its own
+            return
+
+        numbers = {}
+
+        for form in self.forms:
+            if self.can_delete and self._should_delete_form(form):
+                continue
+            number = form.cleaned_data.get("number")
+            numbers.setdefault(number, []).append(form)
+
+        duplicates = {n: forms for n, forms in numbers.items() if len(forms) > 1}
+
+        if duplicates:
+            for forms in duplicates.values():
+                for form in forms:
+                    form.add_error("number", self.duplication_error_message)
+            raise ValidationError(self.duplication_error_message)
 
 
 class LineForm(forms.ModelForm):
@@ -54,29 +80,8 @@ class LineForm(forms.ModelForm):
         )
 
 
-class BaseLineFormSet(BaseInlineFormSet):
-    def clean(self):
-        """Checks that no two lines have the same number."""
-        if any(self.errors):
-            # Don't bother validating the formset unless each form is valid on its own
-            return
-
-        msg = _("This order number is already used by another line.")
-        numbers = {}
-
-        for form in self.forms:
-            if self.can_delete and self._should_delete_form(form):
-                continue
-            number = form.cleaned_data.get("number")
-            numbers.setdefault(number, []).append(form)
-
-        duplicates = {n: forms for n, forms in numbers.items() if len(forms) > 1}
-
-        if duplicates:
-            for forms in duplicates.values():
-                for form in forms:
-                    form.add_error("number", msg)
-            raise ValidationError(msg)
+class BaseLineFormSet(CleanDuplicatedNumbersMixin, BaseInlineFormSet):
+    duplication_error_message = _("This order number is already used by another line.")
 
 
 LineFormset = inlineformset_factory(
@@ -172,6 +177,35 @@ class BladeForm(CommonForm):
         fields = ["id", "number", "direction", "type", "conditions", "color"]
 
 
+class BladeFormsetForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        fields_for_layout = Div(
+            "id", "number", "direction", "type", "conditions", "color"
+        )
+
+        self.helper = FormHelper()
+        self.helper.form_tag = False
+        self.helper.layout = Layout(*fields_for_layout)
+        self.fields["conditions"].widget = autocomplete.Select2Multiple(
+            attrs={"data-theme": "bootstrap4"},
+        )
+        self.fields["conditions"].queryset = BladeCondition.objects.all()
+
+    class Meta:
+        fields = ["id", "number", "direction", "type", "conditions", "color"]
+
+
+class BaseBladeFormSet(CleanDuplicatedNumbersMixin, BaseInlineFormSet):
+    duplication_error_message = _("This order number is already used by another blade.")
+
+
+BladeFormset = inlineformset_factory(
+    Signage, Blade, form=BladeFormsetForm, formset=BaseBladeFormSet, extra=1
+)
+
+
 if settings.TREKKING_TOPOLOGY_ENABLED:
 
     class BaseSignageForm(BaseInfrastructureForm):
@@ -207,6 +241,7 @@ class SignageForm(BaseSignageForm):
             "manager",
             "sealing",
             "access",
+            Fieldset(_("Blades")),
         )
     ]
 

--- a/geotrek/signage/locale/de/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: 2025-10-22 09:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://weblate.makina-corpus.net/projects/geotrek-admin/signage/de/>\n"
@@ -52,6 +52,12 @@ msgid "Lines"
 msgstr ""
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
+msgstr ""
+
+msgid "This order number is already used by another blade."
+msgstr ""
+
+msgid "Blades"
 msgstr ""
 
 msgid "Sealing"
@@ -141,9 +147,6 @@ msgstr ""
 msgid "Blade"
 msgstr ""
 
-msgid "Blades"
-msgstr ""
-
 msgid "Text"
 msgstr ""
 
@@ -191,9 +194,6 @@ msgid "Add a new blade"
 msgstr ""
 
 msgid "Add a new signage"
-msgstr ""
-
-msgid "Edit"
 msgstr ""
 
 msgid "Add"

--- a/geotrek/signage/locale/en/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,6 +52,12 @@ msgid "Lines"
 msgstr ""
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
+msgstr ""
+
+msgid "This order number is already used by another blade."
+msgstr ""
+
+msgid "Blades"
 msgstr ""
 
 msgid "Sealing"
@@ -141,9 +147,6 @@ msgstr ""
 msgid "Blade"
 msgstr ""
 
-msgid "Blades"
-msgstr ""
-
 msgid "Text"
 msgstr ""
 
@@ -191,9 +194,6 @@ msgid "Add a new blade"
 msgstr ""
 
 msgid "Add a new signage"
-msgstr ""
-
-msgid "Edit"
 msgstr ""
 
 msgid "Add"

--- a/geotrek/signage/locale/es/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: 2025-10-22 09:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish <https://weblate.makina-corpus.net/projects/geotrek-admin/signage/es/>\n"
@@ -52,6 +52,12 @@ msgid "Lines"
 msgstr ""
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
+msgstr ""
+
+msgid "This order number is already used by another blade."
+msgstr ""
+
+msgid "Blades"
 msgstr ""
 
 msgid "Sealing"
@@ -141,9 +147,6 @@ msgstr ""
 msgid "Blade"
 msgstr ""
 
-msgid "Blades"
-msgstr ""
-
 msgid "Text"
 msgstr ""
 
@@ -191,9 +194,6 @@ msgid "Add a new blade"
 msgstr ""
 
 msgid "Add a new signage"
-msgstr ""
-
-msgid "Edit"
 msgstr ""
 
 msgid "Add"

--- a/geotrek/signage/locale/fr/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: 2025-10-22 09:00+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://weblate.makina-corpus.net/projects/geotrek-admin/signage/fr/>\n"
@@ -53,6 +53,12 @@ msgstr "Lignes"
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
 msgstr "Position de la lame sur la signalétique (haut = 1). Si vous attribuez une position déjà utilisée, cela déplacera les positions des autres lames"
+
+msgid "This order number is already used by another blade."
+msgstr "Ce numéro d'ordre est déjà utilisé par une autre lame."
+
+msgid "Blades"
+msgstr "Lames"
 
 msgid "Sealing"
 msgstr "Scellement"
@@ -141,9 +147,6 @@ msgstr "Commune"
 msgid "Blade"
 msgstr "Lame"
 
-msgid "Blades"
-msgstr "Lames"
-
 msgid "Text"
 msgstr "Texte"
 
@@ -192,9 +195,6 @@ msgstr "Ajouter une lame"
 
 msgid "Add a new signage"
 msgstr "Ajouter une signalétique"
-
-msgid "Edit"
-msgstr "Modifier"
 
 msgid "Add"
 msgstr "Ajouter"

--- a/geotrek/signage/locale/it/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: 2025-10-22 09:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://weblate.makina-corpus.net/projects/geotrek-admin/signage/it/>\n"
@@ -52,6 +52,12 @@ msgid "Lines"
 msgstr ""
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
+msgstr ""
+
+msgid "This order number is already used by another blade."
+msgstr ""
+
+msgid "Blades"
 msgstr ""
 
 msgid "Sealing"
@@ -141,9 +147,6 @@ msgstr ""
 msgid "Blade"
 msgstr ""
 
-msgid "Blades"
-msgstr ""
-
 msgid "Text"
 msgstr ""
 
@@ -191,9 +194,6 @@ msgid "Add a new blade"
 msgstr ""
 
 msgid "Add a new signage"
-msgstr ""
-
-msgid "Edit"
 msgstr ""
 
 msgid "Add"

--- a/geotrek/signage/locale/nl/LC_MESSAGES/django.po
+++ b/geotrek/signage/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 13:27+0000\n"
+"POT-Creation-Date: 2026-08-14 08:17+0000\n"
 "PO-Revision-Date: 2025-10-22 09:01+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Dutch <https://weblate.makina-corpus.net/projects/geotrek-admin/signage/nl/>\n"
@@ -52,6 +52,12 @@ msgid "Lines"
 msgstr ""
 
 msgid "Position of the blade on the signage (top=1). Assigning a position that has already been used will shift the positions of the other blades"
+msgstr ""
+
+msgid "This order number is already used by another blade."
+msgstr ""
+
+msgid "Blades"
 msgstr ""
 
 msgid "Sealing"
@@ -141,9 +147,6 @@ msgstr ""
 msgid "Blade"
 msgstr ""
 
-msgid "Blades"
-msgstr ""
-
 msgid "Text"
 msgstr ""
 
@@ -191,9 +194,6 @@ msgid "Add a new blade"
 msgstr ""
 
 msgid "Add a new signage"
-msgstr ""
-
-msgid "Edit"
 msgstr ""
 
 msgid "Add"

--- a/geotrek/signage/templates/signage/signage_form.html
+++ b/geotrek/signage/templates/signage/signage_form.html
@@ -7,13 +7,12 @@
     {% crispy form %}
 
     <fieldset class="formset">
+        {{ blade_formset.non_form_errors }}
         {{ blade_formset.management_form }}
         {% for blade_form in blade_formset.forms %}
-            <div class="form-row inline controls controls-row {{ blade_from.prefix }}">
+            <div class="form-row inline controls controls-row {{ blade_form.prefix }}">
+                {% if blade_form.instance.pk %}{{ blade_form.DELETE }}{% endif %}
                 {% crispy blade_form %}
-                {% if blade_form.instance.pk %}
-                    <a href="{% url 'signage:blade_edit' pk=blade_form.instance.pk %}">{% trans "Edit" %}</a>
-                {% endif %}
             </div>
         {% endfor %}
     </fieldset>

--- a/geotrek/signage/tests/test_views.py
+++ b/geotrek/signage/tests/test_views.py
@@ -1154,6 +1154,7 @@ class SignageViewsTest(CommonTest):
         }
 
     def get_good_data(self):
+        blade = BladeFactory.create()
         good_data = {
             "name_fr": "test",
             "name_en": "test_en",
@@ -1161,6 +1162,18 @@ class SignageViewsTest(CommonTest):
             "publication_date": "2020-03-17",
             "type": SignageTypeFactory.create().pk,
             "conditions": SignageConditionFactory.create().pk,
+            "blades-TOTAL_FORMS": "1",
+            "blades-INITIAL_FORMS": "1",
+            "blades-MIN_NUM_FORMS": "0",
+            "blades-MAX_NUM_FORMS": "1000",
+            "blades-0-id": blade.pk,
+            "blades-0-number": "1",
+            "blades-0-direction": blade.direction.pk,
+            "blades-0-type": blade.type.pk,
+            "blades-0-color": blade.color.pk,
+            "blades-0-conditions": ",".join(
+                [str(condition.pk) for condition in blade.conditions.all()]
+            ),
         }
         if settings.TREKKING_TOPOLOGY_ENABLED:
             path = PathFactory.create()
@@ -1194,6 +1207,23 @@ class SignageViewsTest(CommonTest):
         form = response.context["form"]
         type = form.fields["type"]
         self.assertTrue((signagetype.pk, str(signagetype)) in type.choices)
+
+    def test_creating_blades_with_same_number(self):
+        data = self.get_good_data()
+
+        # add a blade with the same number
+        data["blades-TOTAL_FORMS"] = "2"
+        data["blades-1-id"] = ""
+        data["blades-1-number"] = "1"
+        data["blades-1-direction"] = BladeDirectionFactory.create().pk
+        data["blades-1-type"] = BladeTypeFactory.create().pk
+        data["blades-1-color"] = BladeColorFactory.create().pk
+
+        response = self.client.post(self._get_add_url(), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "This order number is already used by another blade."
+        )
 
 
 class SignageMultiActionsViewTest(

--- a/geotrek/signage/views.py
+++ b/geotrek/signage/views.py
@@ -33,7 +33,7 @@ from geotrek.common.viewsets import GeotrekMapentityViewSet
 from geotrek.core.models import AltimetryMixin
 
 from .filters import BladeFilterSet, SignageFilterSet
-from .forms import BladeForm, LineFormset, SignageForm
+from .forms import BladeForm, BladeFormset, LineFormset, SignageForm
 from .models import (
     Blade,
     Line,
@@ -62,6 +62,11 @@ logger = logging.getLogger(__name__)
 class LineMixin(FormsetMixin):
     context_name = "line_formset"
     formset_class = LineFormset
+
+
+class BladeMixin(FormsetMixin):
+    context_name = "blade_formset"
+    formset_class = BladeFormset
 
 
 class SignageList(CustomColumnsMixin, MapEntityList):
@@ -117,12 +122,12 @@ class SignageDocument(MapEntityDocument):
     model = Signage
 
 
-class SignageCreate(MapEntityCreate):
+class SignageCreate(BladeMixin, MapEntityCreate):
     model = Signage
     form_class = SignageForm
 
 
-class SignageUpdate(MapEntityUpdate):
+class SignageUpdate(BladeMixin, MapEntityUpdate):
     queryset = Signage.objects.existing()
     form_class = SignageForm
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a form set in the 'Signage' form to add and edit all the blades of a sign at the same time. As before, lines can be added or edited from the blade form.

## Related Issue

[Ajout d'un formset des lames dans le formulaire signalétique #5511](https://github.com/GeotrekCE/Geotrek-admin/issues/5511)

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated

### AI requirements

*Skip the checkboxes below 👇 If you didn't use AI for your contribution*

* [ ] I used AI assistance to produce part or all of this contribution
* [ ] I have read, reviewed, understood and can explain the code I am submitting
* [ ] I can explain and discuss my work to a maintainer
* [ ] I pasted the prompt used and mentioned the model used below

<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
