### PR TITLE
Fixes the bug related to the geometries of duplicated interventions (fixes #3845)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ CHANGELOG
 2.126.1+dev     (XXXX-XX-XX)
 ----------------------------
 
+**Bug fixes**
+
+* Fix geometry of duplicated intervention
+
 
 2.126.1         (2026-08-14)
 ----------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ CHANGELOG
 
 **Bug fixes**
 
-* Fix geometry of duplicated intervention
+* Fix intervention duplication to also duplicate its target when linked to its own topology instead of another object (e.g. signage, etc) (refs #3845)
 
 
 2.126.1         (2026-08-14)

--- a/geotrek/common/tests/__init__.py
+++ b/geotrek/common/tests/__init__.py
@@ -175,6 +175,8 @@ class CommonTest(AuthentFixturesTest, MapEntityTest):
                 "date_update",
                 "name",
                 "name_en",
+                "target_id",
+                "target"
             ]
             if not field.related_model and field.name not in fields_name_different:
                 self.assertEqual(

--- a/geotrek/common/tests/__init__.py
+++ b/geotrek/common/tests/__init__.py
@@ -176,7 +176,7 @@ class CommonTest(AuthentFixturesTest, MapEntityTest):
                 "name",
                 "name_en",
                 "target_id",
-                "target"
+                "target",
             ]
             if not field.related_model and field.name not in fields_name_different:
                 self.assertEqual(

--- a/geotrek/common/tests/__init__.py
+++ b/geotrek/common/tests/__init__.py
@@ -167,17 +167,17 @@ class CommonTest(AuthentFixturesTest, MapEntityTest):
                 self.model.objects.filter(name__endswith="(copy)").count(), 1
             )
         self.assertEqual(self.model.objects.filter(structure=structure).count(), 1)
+        fields_name_different = [
+            "id",
+            "uuid",
+            "date_insert",
+            "date_update",
+            "name",
+            "name_en",
+            "target_id",
+            "target",
+        ]
         for field in self.model._meta.get_fields():
-            fields_name_different = [
-                "id",
-                "uuid",
-                "date_insert",
-                "date_update",
-                "name",
-                "name_en",
-                "target_id",
-                "target",
-            ]
             if not field.related_model and field.name not in fields_name_different:
                 self.assertEqual(
                     str(getattr(obj_1, field.name)),

--- a/geotrek/maintenance/models.py
+++ b/geotrek/maintenance/models.py
@@ -1,5 +1,4 @@
 import os
-import uuid
 from datetime import datetime
 
 from django.conf import settings

--- a/geotrek/maintenance/models.py
+++ b/geotrek/maintenance/models.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from datetime import datetime
 
 from django.conf import settings
@@ -419,6 +420,18 @@ class Intervention(
     @property
     def jobs_display(self):
         return ", ".join([str(job) for job in self.jobs.all()])
+
+    def duplicate(self, **kwargs):
+        clone = super().duplicate(**kwargs)
+        if clone.target_type == ContentType.objects.get_for_model(Topology):
+            # if the target is a topology create a new one with the same information
+            topology = self.target
+            new_topology = Topology.objects.create(kind="INTERVENTION")
+            new_topology.mutate(topology)
+
+            clone.target = new_topology
+            clone.save(update_fields=["target_id"])
+        return clone
 
 
 Path.add_property(

--- a/geotrek/maintenance/models.py
+++ b/geotrek/maintenance/models.py
@@ -423,7 +423,7 @@ class Intervention(
     def duplicate(self, **kwargs):
         clone = super().duplicate(**kwargs)
         if clone.target_type == ContentType.objects.get_for_model(Topology):
-            # if the target is a topology create a new one with the same information
+            # if the target is a topology instead of another object (e.g. signage, etc), create a new one with the same information
             topology = self.target
             new_topology = Topology.objects.create(kind="INTERVENTION")
             new_topology.mutate(topology)

--- a/geotrek/maintenance/tests/test_models.py
+++ b/geotrek/maintenance/tests/test_models.py
@@ -29,6 +29,7 @@ from geotrek.maintenance.tests.factories import (
     SignageInterventionFactory,
 )
 from geotrek.outdoor.tests.factories import CourseFactory, SiteFactory
+from geotrek.signage.models import Signage
 from geotrek.signage.tests.factories import BladeFactory, SignageFactory
 
 
@@ -342,6 +343,10 @@ class InterventionTest(TestCase):
         self.assertIn("-", interv.target_csv_display)
 
     def test_duplication_with_topology_target(self):
+        """
+        Test that duplicating an intervention with a topology target creates an independent topology copy.
+        https://github.com/GeotrekCE/Geotrek-admin/issues/3845
+        """
         topology = TopologyFactory.create()
         intervention = InterventionFactory.create(
             target=topology,
@@ -350,15 +355,32 @@ class InterventionTest(TestCase):
             name="intervention test",
         )
         self.assertEqual(Intervention.objects.count(), 1)
-        Intervention.duplicate(intervention)
+        intervention_copy = Intervention.duplicate(intervention)
         self.assertEqual(Intervention.objects.count(), 2)
-        intervention_copy = Intervention.objects.get(name="intervention test (copy)")
         self.assertEqual(intervention_copy.target_type, intervention.target_type)
         self.assertNotEqual(intervention_copy.target_id, intervention.target_id)
         topology_copy = intervention_copy.target
+        self.assertNotEqual(topology_copy.pk, topology.pk)
         self.assertEqual(topology_copy.geom, topology.geom)
         self.assertEqual(topology_copy.offset, topology.offset)
         self.assertEqual(topology_copy.kind, "INTERVENTION")
+
+    def test_duplication_without_topology_target(self):
+        """
+        Test that duplicating an intervention without topology target duplicate the target id.
+        """
+        signage = SignageFactory.create()
+        intervention = InterventionFactory.create(
+            target=signage,
+            target_id=signage.pk,
+            target_type=ContentType.objects.get_for_model(Signage),
+            name="intervention test",
+        )
+        self.assertEqual(Intervention.objects.count(), 1)
+        intervention_copy = Intervention.duplicate(intervention)
+        self.assertEqual(Intervention.objects.count(), 2)
+        self.assertEqual(intervention_copy.target_type, intervention.target_type)
+        self.assertEqual(intervention_copy.target_id, intervention.target_id)
 
 
 @skipIf(not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only")

--- a/geotrek/maintenance/tests/test_models.py
+++ b/geotrek/maintenance/tests/test_models.py
@@ -344,7 +344,10 @@ class InterventionTest(TestCase):
     def test_duplication_with_topology_target(self):
         topology = TopologyFactory.create()
         intervention = InterventionFactory.create(
-            target=topology, target_id=topology.pk, target_type=ContentType.objects.get_for_model(Topology), name="intervention test"
+            target=topology,
+            target_id=topology.pk,
+            target_type=ContentType.objects.get_for_model(Topology),
+            name="intervention test",
         )
         self.assertEqual(Intervention.objects.count(), 1)
         Intervention.duplicate(intervention)
@@ -355,7 +358,8 @@ class InterventionTest(TestCase):
         topology_copy = intervention_copy.target
         self.assertEqual(topology_copy.geom, topology.geom)
         self.assertEqual(topology_copy.offset, topology.offset)
-        self.assertEqual(topology_copy.kind, 'INTERVENTION')
+        self.assertEqual(topology_copy.kind, "INTERVENTION")
+
 
 @skipIf(not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only")
 class ProjectModelTest(TestCase):

--- a/geotrek/maintenance/tests/test_models.py
+++ b/geotrek/maintenance/tests/test_models.py
@@ -360,7 +360,6 @@ class InterventionTest(TestCase):
         self.assertEqual(intervention_copy.target_type, intervention.target_type)
         self.assertNotEqual(intervention_copy.target_id, intervention.target_id)
         topology_copy = intervention_copy.target
-        self.assertNotEqual(topology_copy.pk, topology.pk)
         self.assertEqual(topology_copy.geom, topology.geom)
         self.assertEqual(topology_copy.offset, topology.offset)
         self.assertEqual(topology_copy.kind, "INTERVENTION")

--- a/geotrek/maintenance/tests/test_models.py
+++ b/geotrek/maintenance/tests/test_models.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import LineString, Point
 from django.test import TestCase
 
+from geotrek.core.models import Topology
 from geotrek.core.tests.factories import (
     PathFactory,
     StakeFactory,
@@ -340,6 +341,21 @@ class InterventionTest(TestCase):
         interv = InterventionFactory.create(target=None)
         self.assertIn("-", interv.target_csv_display)
 
+    def test_duplication_with_topology_target(self):
+        topology = TopologyFactory.create()
+        intervention = InterventionFactory.create(
+            target=topology, target_id=topology.pk, target_type=ContentType.objects.get_for_model(Topology), name="intervention test"
+        )
+        self.assertEqual(Intervention.objects.count(), 1)
+        Intervention.duplicate(intervention)
+        self.assertEqual(Intervention.objects.count(), 2)
+        intervention_copy = Intervention.objects.get(name="intervention test (copy)")
+        self.assertEqual(intervention_copy.target_type, intervention.target_type)
+        self.assertNotEqual(intervention_copy.target_id, intervention.target_id)
+        topology_copy = intervention_copy.target
+        self.assertEqual(topology_copy.geom, topology.geom)
+        self.assertEqual(topology_copy.offset, topology.offset)
+        self.assertEqual(topology_copy.kind, 'INTERVENTION')
 
 @skipIf(not settings.TREKKING_TOPOLOGY_ENABLED, "Test with dynamic segmentation only")
 class ProjectModelTest(TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When duplicating an intervention based on a path, the topology representing the geometry was not duplicated. As a result, both interventions shared the same geometry. 

## Related Issue

* https://github.com/GeotrekCE/Geotrek-admin/issues/3845

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated

### AI requirements

*Skip the checkboxes below 👇 If you didn't use AI for your contribution*

* [ ] I used AI assistance to produce part or all of this contribution
* [ ] I have read, reviewed, understood and can explain the code I am submitting
* [ ] I can explain and discuss my work to a maintainer
* [ ] I pasted the prompt used and mentioned the model used below

<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
