### PR TITLE
Fix site duplication so that the clone ID is used as the tree ID if the original site doesn't have a parent

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ CHANGELOG
 **Bug fixes**
 
 * Fix intervention duplication to also duplicate its target when linked to its own topology instead of another object (e.g. signage, etc) (refs #3845)
+* Fix site duplication so that the clone ID is used as the tree ID if the original site doesn't have a parent (refs #5461)
 
 
 2.126.1         (2026-08-14)

--- a/geotrek/common/tests/__init__.py
+++ b/geotrek/common/tests/__init__.py
@@ -174,8 +174,11 @@ class CommonTest(AuthentFixturesTest, MapEntityTest):
             "date_update",
             "name",
             "name_en",
+            # intervention
             "target_id",
             "target",
+            # site
+            "tree_id",
         ]
         for field in self.model._meta.get_fields():
             if not field.related_model and field.name not in fields_name_different:

--- a/geotrek/outdoor/models.py
+++ b/geotrek/outdoor/models.py
@@ -499,6 +499,17 @@ class Site(
     def tourism_sites(cls, tourism_obj, queryset=None):
         return intersecting(queryset_or_model(queryset, cls), obj=tourism_obj)
 
+    def duplicate(self, **kwargs):
+        """
+        Duplicate the site and ensure that a duplicated root site gets its own tree ID.
+        https://github.com/GeotrekCE/Geotrek-admin/issues/5461
+        """
+        clone = super().duplicate(**kwargs)
+        if clone.parent is None:
+            clone.tree_id = clone.id
+            clone.save(update_fields=["tree_id"])
+        return clone
+
 
 Path.add_property("sites", lambda self: intersecting(Site, self), _("Sites"))
 Topology.add_property("sites", Site.topology_sites, _("Sites"))

--- a/geotrek/outdoor/tests/test_models.py
+++ b/geotrek/outdoor/tests/test_models.py
@@ -111,6 +111,20 @@ class SiteTest(TestCase):
         # Means that only the parent_site is duplicated and not his child
         self.assertEqual(Site.objects.count(), 3)
 
+    def test_duplicate_root_site_doesnt_duplicate_tree_id(self):
+        self.site_1 = SiteFactory.create(name="parent_site")
+        self.site_2 = SiteFactory.create(name="child_site", parent=self.site_1)
+        clone = self.site_1.duplicate()
+        self.assertNotEqual(clone.tree_id, self.site_1.tree_id)
+        self.assertEqual(list(self.site_2.get_ancestors()), [self.site_1])
+
+    def test_duplicate_child_site_duplicate_tree_id(self):
+        self.site_1 = SiteFactory.create(name="parent_site")
+        self.site_2 = SiteFactory.create(name="child_site", parent=self.site_1)
+        clone = self.site_2.duplicate()
+        self.assertEqual(clone.tree_id, self.site_2.tree_id)
+        self.assertEqual(list(self.site_2.get_ancestors()), [self.site_1])
+
 
 class SiteSuperTest(TestCase):
     @classmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the duplicate site does not have a parent, set its tree ID to its ID. Otherwise, the children of the initial site will be unable to retrieve the root of the hierarchy because there are multiple roots (the root of a hierarchy is defined by the tree ID).

## Related Issue

* https://github.com/GeotrekCE/Geotrek-admin/issues/5461

## Checklist

- [ ] I have followed the guidelines in our [Contributing document](https://geotrek.readthedocs.io/en/latest/contribute/contributing.html)
- [ ] My code respects the Definition of done available in the [Development section of the documentation](https://geotrek.readthedocs.io/en/latest/contribute/development.html#definition-of-done-for-new-model-fields)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes
- [ ] I added an entry in the changelog file
- [ ] My commits are all using prefix convention (emoji + tag name) and references associated issues
- [ ] I added a label to the PR corresponding to the perimeter of my contribution
- [ ] The title of my PR mentionned the issue associated

### AI requirements

*Skip the checkboxes below 👇 If you didn't use AI for your contribution*

* [ ] I used AI assistance to produce part or all of this contribution
* [ ] I have read, reviewed, understood and can explain the code I am submitting
* [ ] I can explain and discuss my work to a maintainer
* [ ] I pasted the prompt used and mentioned the model used below

<!-- ⚠️ IMPORTANT : All new lines of code should be tested -->
<!-- ⚠️ PR are always reviewed by at least one person before being merged -->
<!-- Usually pull requests target the `master` branch on this repository -->
